### PR TITLE
Add uuid & byteorder

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -71,6 +71,10 @@ stablePackages = execWriter $ do
     add "blaze-html"
     add "blaze-markup"
     add "stylish-haskell"
+
+    -- Antoine Latter
+    add "uuid"
+    add "byteorder"
   where
     add = flip addRange "-any"
     addRange package range =


### PR DESCRIPTION
There are quit a few test failures, but they don't seem related to these two packages.

I also added-on 'byteorder' because it was already being pulled in as a dependency.

Details of test failures:
- missing executable 'hspec-discover' (many)
- Missing QuickCheck == 2.4.\* (many)
- missing test-framework == 0.6.*
- GLUT failed to build the test-suite for some reason
- HTTP failed in configure
- haskell-src-exts - gave odd message failing to run tests
- hspec-expectations - failed to configure
- optparse-applicative - failed to build test-suite
- Failed to register the inplace version of the package - it is shadowed by the already installed proper version:
  - setenv
  - text
- Failed test-cases:
  - hjsmin - failed to open some file
  - markdown - failed to find a required directory
  - statistics
  - unix-time
