### PR TITLE
Add parseargs to package list

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -75,6 +75,9 @@ defaultStablePackages = execWriter $ do
 
     mapM_ (add "Edward Kmett") $ words
         "lens"
+
+    mapM_ (add "Bart Massey <bart.massey+stackage@gmail.com>") $ words
+        "parseargs"
   where
     add maintainer package = addRange maintainer package "-any"
     addRange maintainer package range =


### PR DESCRIPTION
My parseargs argument parsing library has been stable for some time, and I use it in a lot of projects; I believe some other folks are using it also. I'd like to have it included in stackage.
