### PR TITLE
`base-unicode-symbols` and `containers-unicode-symbols`

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -140,6 +140,9 @@ defaultStablePackages = unPackageMap $ execWriter $ do
     mapM_ (add "Felipe Lessa <felipe.lessa@gmail.com>") $ words
         "esqueleto fb fb-persistent yesod-fb yesod-auth-fb"
 
+    mapM_ (add "Alexander Altman <alexanderaltman@me.com>") $ words
+        "base-unicode-symbols containers-unicode-symbols"
+
     -- https://github.com/fpco/stackage/issues/46
     addRange "Michael Snoyman" "QuickCheck" "< 2.6"
     addRange "Michael Snoyman" "syb" "< 0.4"


### PR DESCRIPTION
`base-unicode-symbols` is already effectively present.

Also, Roel van Dijk is the actual maintainer of both packages.

See #58.
