### PR TITLE
Add Dan Burton's packages

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -172,6 +172,11 @@ defaultStablePackages = unPackageMap $ execWriter $ do
     mapM_ (add "Ryan Newton <ryan.newton@alum.mit.edu>") $ words
         "accelerate"
 
+    mapM_ (add "Dan Burton <danburton.email@gmail.com>") $ words =<<
+        [ "basic-prelude composition io-memoize numbers rev-state runmemo"
+        , "tardis"
+        ]
+
     -- https://github.com/fpco/stackage/issues/46
     addRange "Michael Snoyman" "QuickCheck" "< 2.6"
 


### PR DESCRIPTION
The addition of my packages successfully passed the `select` and `check` phases (by adding `addRange "temp" "stm-chans" "< 2.1"`, which is an orthagonal issue). I am having other issues building all of Stackage on my machine, but I did test a fresh `cabal install` of all of the packages I added, and can reasonably expect that they will not interfere with anyone else's stuff.
