### PR TITLE
fay and fay-base

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -192,6 +192,9 @@ defaultStablePackages ghcVer = unPackageMap $ execWriter $ do
     mapM_ (add "Daniel Díaz <dhelta.diaz@gmail.com>") $ words
         "HaTeX"
 
+    mapM_ (add "Adam Bergmark <adam@edea.se>") $ words
+        "fay fay-base"
+
     -- https://github.com/fpco/stackage/issues/46
     addRange "Michael Snoyman" "QuickCheck" "< 2.6"
 

--- a/allowed.txt
+++ b/allowed.txt
@@ -5437,3 +5437,5 @@ hspec-test-framework SimonHengel
 hspec-test-framework-th SimonHengel
 querystring-pickle BrendanHay
 tuples-homogenous-h98 PetrPudlak
+fay AdamBergmark
+fay-base AdamBergmark


### PR DESCRIPTION
yesod-fay depends on fay, and also on fay-base implicitly, so it should be seamless to add these.

fay 0.16.0.2 is updated to support haskell-src-exts 1.14, so either add a constraint for `fay < 0.16.0.2` or wait for #103 to be resolved, I guess?

I was also wondering, what's your stand on adding fay specific packages to stackage?
