### PR TITLE
Added sqlite-simple

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -228,6 +228,9 @@ defaultStablePackages ghcVer = unPackageMap $ execWriter $ do
     mapM_ (add "Boris Lykah <lykahb@gmail.com>") $ words
         "groundhog groundhog-th groundhog-sqlite groundhog-postgresql groundhog-mysql"
 
+    mapM_ (add "Janne Hellsten <jjhellst@gmail.com>") $ words
+        "sqlite-simple"
+
     -- https://github.com/fpco/stackage/issues/46
     addRange "Michael Snoyman" "QuickCheck" "< 2.6"
 


### PR DESCRIPTION
I tried hard to test this addition locally, however both of my attempts to build Stackage failed.  The latter attempt failed on https://github.com/fpco/stackage/issues/129#issuecomment-27125565.  This is not related to sqlite-simple, the error happens regardless of my changes.

As postgresql-simple is already on the ["recommended libraries"](https://www.fpcomplete.com/school/ide-tutorials/recommended-libraries) list, I think it'd make sense to have sqlite-simple and mysql-simple on there too.  This one adds my sqlite-simple.

The test error (https://github.com/IreneKnapp/direct-sqlite/issues/32) that's on "known issues" list in Stackage should also be fixed in direct-sqlite-2.3.7 which was released yesterday.
