### PR TITLE
add MonadRandom to stackage

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -212,6 +212,7 @@ defaultStablePackages ghcVer = unPackageMap $ execWriter $ do
         , "diagrams diagrams-contrib diagrams-core diagrams-lib diagrams-svg"
         , "diagrams-postscript diagrams-builder diagrams-haddock haxr"
         , "BlogLiterately BlogLiterately-diagrams"
+        , "MonadRandom"
         ]
 
     mapM_ (add "Patrick Brisbin") $ words "gravatar"


### PR DESCRIPTION
I have taken over maintainership of the `MonadRandom` package, which is fairly stable and widely used.
