### PR TITLE
Add packages to stable configuration

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -289,6 +289,11 @@ defaultStablePackages ghcVer = unPackageMap $ execWriter $ do
         "hweblib"
 #endif
 
+    mapM_ (add "John Wiegley <johnw@fpcomplete.com>") $ words =<<
+        [ "bindings-dsl github monad-extras numbers these hlibgit2"
+        , "gitlib gitlib-cmdline gitlib-libgit2 gitlib-s3 gitlib-test"
+        ]
+
     -- https://github.com/fpco/stackage/issues/160
     when (ghcVer >= GhcMajorVersion 7 6) $ do
       mapM_ (add "Ketil Malde") $ words =<<


### PR DESCRIPTION
@snoyberg Just wanted to make sure this looks right.  It seemed strange to me that Bindings-DSL wasn't already in the stable package set, when I thought you had mentioned that it was.
