### PR TITLE
Remove HaTeX from ``defaultExpectedFailures``

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -149,8 +149,6 @@ defaultExpectedFailures ghcVer = execWriter $ do
     -- issues with pthread
     mapM_ add $ words "hlibgit2 gitlib-s3 gitlib-libgit2"
 
-    -- https://github.com/Daniel-Diaz/HaTeX/issues/30
-    add "HaTeX"
   where
     add = tell . singleton . PackageName
 


### PR DESCRIPTION
Test suites failures are no longer expected in package HaTeX, since last version of the library has been pushed to Hackage.
