### PR TITLE
convert diagrams mentions to diagrams/Core team

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -468,7 +468,7 @@ convertGithubUser x =
     fromMaybe x $ Map.lookup (map toLower x) pairs
   where
     pairs = Map.fromList
-        [ ("diagrams",     "byorgey")
+        [ ("diagrams",     "diagrams/Core")
         , ("yesodweb",     "snoyberg")
         , ("fpco",         "snoyberg")
         , ("faylang",      "bergmark")


### PR DESCRIPTION
If I understand correctly (see https://github.com/blog/1121-introducing-team-mentions) this should route mentions of packages in the diagrams organization to everyone on the diagrams Core team rather than to just me.
