### PR TITLE
Revert "convert diagrams mentions to diagrams/Core team"

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -490,7 +490,7 @@ convertGithubUser x =
     fromMaybe x $ Map.lookup (map toLower x) pairs
   where
     pairs = Map.fromList
-        [ ("diagrams",     "diagrams/Core")
+        [ ("diagrams",     "byorgey")
         , ("yesodweb",     "snoyberg")
         , ("fpco",         "snoyberg")
         , ("faylang",      "bergmark")


### PR DESCRIPTION
It appears this does not actually work; see
https://github.com/fpco/stackage/pull/244#issuecomment-48469406 .

This reverts commit bf61e01909d788146909602b07cf8e30e32cf69e.
