### PR TITLE
Add more packages, the ones supported by Neil Mitchell

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -247,7 +247,7 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
     addRange "FP Complete <michael@fpcomplete.com>" "kure" "<= 2.4.10"
 
     mapM_ (add "Neil Mitchell") $ words
-        "hlint hoogle shake derive"
+        "hlint hoogle shake derive tagsoup cmdargs safe uniplate nsis"
 
     mapM_ (add "Alan Zimmerman") $ words
         "hjsmin language-javascript"


### PR DESCRIPTION
Add some additional packages. I think uniplate, safe and cmdargs were already dependencies of packages that are included, so that's just making the ownership explicit. tagsoup and nsis are new packages to add to the list.
