### PR TITLE
Remove upper bound on JuicyPixels (related to #270)

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -488,9 +488,6 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
     -- current build status.
     addRange "Andrey Chudnov <oss@chudnov.com>" "language-ecmascript" ">= 0.16.2 && < 1.0"
 
-    -- https://github.com/fpco/stackage/issues/270
-    addRange "Michael Snoyman" "JuicyPixels" "< 3.1.6"
-
     -- https://github.com/fpco/stackage/issues/269
     addRange "Michael Snoyman" "tasty-hunit" "< 0.9"
 


### PR DESCRIPTION
I've updated JuicyPixels to handle transformers > 0.3 and > 0.4, both should work now.
Sorry for the build break.
