### PR TITLE
Added 'binary-list' package.

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -375,7 +375,7 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
         ]
 
     mapM_ (add "Daniel Díaz <dhelta.diaz@gmail.com>") $ words
-        "HaTeX matrix"
+        "HaTeX matrix binary-list"
 
     mapM_ (add "Gabriel Gonzalez <Gabriel439@gmail.com>")
         ["pipes", "pipes-parse", "pipes-concurrency"]


### PR DESCRIPTION
I couldn't test that stackage builds correctly. I get stuck at `./dist/build/stackage/stackage build` with `Building of alex-3.1.3 failed, please see build-tools.log`. In any case, there should be no problem with this package. It has very few dependencies.
