### PR TITLE
Uninstall curl before running debian-bootstrap

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -6,11 +6,6 @@
 # Quick start:
 # wget -O - https://raw.github.com/fpco/stackage/master/debian-bootstrap.sh | bash -ex
 
-if which curl > /dev/null; then
-  echo "Uninstalling curl to avoid an issue with cabal-install-1.16"
-  sudo apt-get remove curl
-fi
-
 sudo apt-get update
 sudo apt-get install -y build-essential libncurses-dev git libgmp3c2 libgmp3-dev zlib1g-dev libedit2 libedit-dev freeglut3-dev libglu1-mesa-dev libglib2.0-dev libcairo2-dev libpango1.0-dev libgtk2.0-dev zip libdevil-dev llvm libbz2-dev libjudy-dev libmysqlclient-dev libpq-dev libicu-dev libssl-dev nettle-dev libgsl0-dev libblas-dev liblapack-dev
 wget http://www.haskell.org/ghc/dist/7.4.2/ghc-7.4.2-x86_64-unknown-linux.tar.bz2
@@ -21,9 +16,9 @@ sudo make install
 echo 'export PATH=/opt/ghc-7.4.2/bin:~/.cabal/bin:$PATH' >> ~/.bashrc
 export PATH=/opt/ghc-7.4.2/bin:~/.cabal/bin:$PATH
 cd ..
-wget http://hackage.haskell.org/packages/archive/cabal-install/1.16.0.2/cabal-install-1.16.0.2.tar.gz
-tar zxfv cabal-install-1.16.0.2.tar.gz
-cd cabal-install-1.16.0.2/
+wget http://hackage.haskell.org/packages/archive/cabal-install/1.18.0.5/cabal-install-1.18.0.5.tar.gz
+tar zxfv cabal-install-1.18.0.5.tar.gz
+cd cabal-install-1.18.0.5/
 bash bootstrap.sh
 cd ..
 git clone --recursive https://github.com/fpco/stackage


### PR DESCRIPTION
debian-bootstrap attempts to install cabal-install-1.16, which can either work with curl, wget, or fetch, in that order of preference. Unfortunately the hackage URLs have changed since 1.16, and with the arguments which were used in cabal-install's bootstrap script in 1.16, curl doesn't follow 301 redirects.

The simplest solution is to uninstall curl, so that wget is used instead.
