### PR TITLE
Add yesod-auth-hashdb

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -478,6 +478,9 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
             "holy-project"
     when requireHP $ addRange "Yann Esposito <yann.esposito@gmail.com>" "holy-project" "< 0.1.1.1"
 
+    mapM_ (add "Paul Rouse <pgr@doynton.org>") $ words
+        "yesod-auth-hashdb"
+
     -- https://github.com/fpco/stackage/issues/216
     -- QuickCheck constraint
     -- when (ghcVer == GhcMajorVersion 7 6) $


### PR DESCRIPTION
I have not built all of stackage to test this, but I have checked that this module builds against the latest stackage server build (GHC 7.8, 2014-10-02, exclusive).
