### PR TITLE
Add zeromq4-haskell.

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -486,6 +486,8 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
     mapM_ (add "Paul Rouse <pgr@doynton.org>") $ words
         "yesod-auth-hashdb"
 
+    add "Toralf Wittner <tw@dtex.org>" "zeromq4-haskell"
+
     -- https://github.com/fpco/stackage/issues/216
     -- QuickCheck constraint
     -- when (ghcVer == GhcMajorVersion 7 6) $


### PR DESCRIPTION
In twittner/zeromq-haskell#58 I have been asked to consider adding
zeromq4-haskell to stackage. The package builds with recent versions of
its dependencies from hackage, but I did not test against stackage.

Please note that this package depends on zeromq >= 4.0.
