### PR TITLE
Add some of Chris Done's packages

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -283,6 +283,7 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
         , "Chart Chart-diagrams histogram-fill random-source"
         , "webdriver"
         , "foreign-store"
+        , "statistics-linreg"
         -- https://github.com/Soostone/retry/issues/18
         -- , "retry"
         ]
@@ -337,8 +338,11 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
         , "tls-debug vhd language-java"
         ]
 
-    mapM_ (add "Chris Done") $ words
-        "statistics-linreg"
+    mapM_ (add "Chris Done") $ words =<<
+        [ "ace check-email freenect frisby gd haskell-docs "
+        , "hostname-validate ini lucid osdkeys pdfinfo present "
+        , "pure-io scrobble sourcemap" ]
+    -- TODO: Add hindent and structured-haskell-mode once they've been ported to HSE 1.16.
     -- https://github.com/isomorphism/these/issues/11
     -- when (ghcVer >= GhcMajorVersion 7 8) $ add "Chris Done" "shell-conduit"
 


### PR DESCRIPTION
I'm expecting these packages to build with the latest package set. I bumped a couple of them. Some might pull in some dependencies that don't build. We'll see.

I have to do a bit of work to port `structured-haskell-mode` to HSE 1.16, and @gibiansky submitted a pull request I need to go through that ports hindent to 1.16.
