### PR TITLE
Added prettyclass, pretty-class is depricated

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -651,6 +651,9 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
 
     mapM_ (add "Alexander Thiemann <mail@athiemann.net>") $ words
        "graph-core reroute Spock"
+       
+    mapM_ (add "Joey Eremondi <joey@eremondi.com>") $ words
+       "prettyclass"
 
     -- https://github.com/fpco/stackage/issues/217
     addRange "Michael Snoyman" "transformers" "< 0.4"


### PR DESCRIPTION
I'm not the maintainer for this, but there isn't contact information for PrettyClass on the hackage page. It seems pretty minimal, and it would be good to have, since pretty-class, which is included, is deprecated.
