### PR TITLE
Add Elm and related libraries

### DIFF
--- a/Stackage/Config.hs
+++ b/Stackage/Config.hs
@@ -652,9 +652,10 @@ defaultStablePackages ghcVer requireHP = unPackageMap $ execWriter $ do
     mapM_ (add "Alexander Thiemann <mail@athiemann.net>") $ words
        "graph-core reroute Spock"
        
-    mapM_ (add "Joey Eremondi <joey@eremondi.com>") $ 
-       words "prettyclass language-glsl union-find aeson-pretty QuasiText" ++
-       words "digest zip-archive elm-compiler elm-package elm-core-sources elm-build-lib" 
+    mapM_ (add "Joey Eremondi <joey@eremondi.com>") $ words =<<
+        [ "prettyclass language-glsl union-find aeson-pretty QuasiText"
+        , "digest zip-archive elm-compiler elm-package elm-core-sources elm-build-lib"
+        ]
 
     -- https://github.com/fpco/stackage/issues/217
     addRange "Michael Snoyman" "transformers" "< 0.4"


### PR DESCRIPTION
Haskelm isn't quite ready, but the other Elm libraries and their dependencies are.
I've got this combo compiling on the FP centre, so it should work here.
Hopefully I'll have Haskelm ready before January.
