### PR TITLE
fix type check failure (Int32 vs Int64)

### DIFF
--- a/Stackage/ServerBundle.hs
+++ b/Stackage/ServerBundle.hs
@@ -24,7 +24,7 @@ import Filesystem (isFile)
 
 -- | Get current time
 epochTime :: IO Tar.EpochTime
-epochTime = (\(CTime t) -> t) <$> PC.epochTime
+epochTime = (\(CTime t) -> fromIntegral t) <$> PC.epochTime
 
 -- | All package/versions in a build plan, including core packages.
 --


### PR DESCRIPTION
Hello,

I am trying to compile stackage on windows, and I get the following compilation error:

```
[11 of 13] Compiling Stackage.ServerBundle ( Stackage\ServerBundle.hs, dist\build\Stackage\ServerBundle.o )

Stackage\ServerBundle.hs:27:28:
    Couldn't match type `Int32' with `Int64'
    Expected type: Tar.EpochTime
      Actual type: Int32
    In the expression: t
    In the first argument of `(<$>)', namely `(\ (CTime t) -> t)'
```

I fixed it with a `fromIntegral`.
