### PR TITLE
Add shake-language-c to build constraints

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -601,6 +601,9 @@ packages:
         - opaleye
         - product-profunctors
 
+    "Samplecount stefan@samplecount.com @kaoskorobase":
+        - shake-language-c
+
     "Stackage upper bounds":
         # cabal-install is buggy still.
         - network < 2.6


### PR DESCRIPTION
I'd like to add a package of ours, shake-language-c, to Stackage. I've followed the instructions in https://github.com/fpco/stackage#get-your-package-included, if there's any problem with this PR, please let me know!
