### PR TITLE
Add FontyFruity & Rasterific to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -322,6 +322,9 @@ packages:
     "Vincent Berthoux <vincent.berthoux@gmail.com>":
         # https://github.com/fpco/stackage/issues/354
         - JuicyPixels < 3.2
+        - FontyFruity
+        # Restricted to version 0.3 due to limit on JuicyPixels
+        - Rasterific
 
     "Patrick Brisbin":
         - gravatar


### PR DESCRIPTION
Will enable diagrams-rasterific to be added in the future.
