### PR TITLE
Add back language-puppet

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2135,7 +2135,7 @@ packages:
         - strict-base-types
         - withdependencies
         - hruby
-        # - language-puppet # servant 0.13
+        - language-puppet
         - tar-conduit
 
     "Mark Karpov <markkarpov92@gmail.com> @mrkkrp":


### PR DESCRIPTION
Upper bound for servant allows 0.13 in the latest v1.3.17

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
