### PR TITLE
Allow clay again now that it compiles with 8.4.x.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -823,7 +823,7 @@ packages:
         - type-operators
 
     "Sebastiaan Visser <haskell@fvisser.nl> @sebastiaanvisser":
-        - clay < 0 # build failure with GHC 8.4 https://github.com/sebastiaanvisser/clay/issues/171
+        - clay
         - fclabels
 
     "Robert Klotzner <robert.klotzner@gmx.at> @eskimor":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
