### PR TITLE
Adds sendfile to the build-constraints and re-enables happstack-server

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2376,7 +2376,7 @@ packages:
         - boomerang < 0 # GHC 8.4 via template-haskell-2.13.0.0
         # - happstack-hsp # haskell-src-exts via hsx2hs
         - happstack-jmacro < 0 # GHC 8.4 via happstack-server
-        - happstack-server < 0 # GHC 8.4 via template-haskell-2.13.0.0
+        - happstack-server
         - happstack-server-tls < 0 # GHC 8.4 via happstack-server
         - hsx-jmacro
         - ixset < 0 # GHC 8.4 via syb-with-class
@@ -3382,9 +3382,12 @@ packages:
 
     "Alexander Krupenkin <mail@akru.me> @akru":
         - web3 < 0 # via exceptions-0.10.0
-        
+
     "Georg Rudoy <0xd34df00d@gmail.com> @0xd34df00d":
         - enum-subset-generate
+
+    "Trevis Elser <trevis@silencedpoet.com> @telser":
+        - sendfile
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
This adds the `sendfile` package to the build-constraints and re-enables `happstack-server`. I am not sure if it is generally acceptable to re-enable someone else's package or not though. With that said I will gladly, re-submit with just `sendfile`, take "ownership" of `happstack-server`, or some other solution as well. Adding both of these as extra-deps on top of nightly has caused no issue for me locally, but I only did the checklist set of commands for `sendfile` since `happstack-server` depends on it.

@stepcut I'm including you here since you're the maintainer of `happstack-server` that I re-enabled here.  No intention of stepping on your toes, just looking to get things back into the upstream resolver. 

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
