### PR TITLE
(Re-)added Frames, hpp, and ffmpeg-light

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2453,8 +2453,9 @@ packages:
         - LibZip >= 1.0
 
     "Anthony Cowley <acowley@gmail.com> @acowley":
-        - Frames < 0 # GHC 8.4 via base-4.11.0.0
-        - hpp < 0 # build failure with GHC 8.4 via bytestring-trie
+        - Frames
+        - hpp
+        - ffmpeg-light
 
     "Takayuki Muranushi <muranushi@gmail.com> @nushio3":
         - binary-search


### PR DESCRIPTION
- New version of `Frames` with a relaxed `base` constraint.
- New version of `hpp` that I believe builds with current versions of dependencies
- Adding `ffmpeg-light` as its CI situation has recently been improved to offer more confidence that it can be expected to build.

CI for all three is green.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
