### PR TITLE
Add invertible-grammar, take over sexp-grammar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3352,8 +3352,11 @@ packages:
         - herms
 
     "Sergey Vinokurov <serg.foo@gmail.com> @sergv":
-        - sexp-grammar
         - tasty-ant-xml
+
+    "Eugene Smolanka <esmolanka@gmail.com> @esmolanka":
+        - sexp-grammar
+        - invertible-grammar
 
     "Maximilian Tagher <feedback.tagher@gmail.com> @MaxGabriel":
         - aeson-iproute


### PR DESCRIPTION
Add `invertible-grammar` and take over `sexp-grammar` in order to get notifications about the package.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
