### PR TITLE
Enable minio-hs again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2982,8 +2982,7 @@ packages:
         - sdl2-gfx
 
     "Aditya Manthramurthy <aditya.mmy@gmail.com> @donatello":
-        []
-        # - minio-hs # https://github.com/minio/minio-hs/issues/79
+        - minio-hs
 
     "ncaq <ncaq@ncaq.net> @ncaq":
         # - haskell-import-graph # fgl via graphviz


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


I am hoping this gets minio-hs back on nightly (it is already on LTS-11).