### PR TITLE
re-add chart-unit with better deps

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2859,7 +2859,7 @@ packages:
         - numhask-range
         - perf
         - online
-        # - chart-unit # via generic-lens-labels-0.1.0.2, https://github.com/commercialhaskell/stackage/pull/3711
+        - chart-unit
 
     "Iphigenia Df <iphydf@gmail.com> @iphydf":
         - data-msgpack


### PR DESCRIPTION
Removed generic-lens-labels dependency.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
