### PR TITLE
added: debug-trace-var

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2988,6 +2988,7 @@ packages:
         - minio-hs
 
     "ncaq <ncaq@ncaq.net> @ncaq":
+        - debug-trace-var
         # - haskell-import-graph # fgl via graphviz
         - string-transform
         - uniq-deep


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I can't stack build by `No setup information found for ghc-8.4.3 on your platform.`