### PR TITLE
Remove version constraints on threepenny-gui

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3532,9 +3532,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/3728
         - aeson < 1.4
-
-        # https://github.com/commercialhaskell/stackage/issues/3729
-        - threepenny-gui < 0.8.2.4
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
threepenny-gui is compatible with the latest `websockets-0.12.5.1`.

This reverts commit b0b8b758c0ce9bdf5ac1efbffafc4b1812e1fe56.

Closes #3729.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
