### PR TITLE
re-add gym-http-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3256,8 +3256,7 @@ packages:
         - hedgehog-corpus
 
     "Sam Stites <sam@stites.io> @stites":
-        []
-        # - gym-http-api # https://github.com/fpco/stackage/issues/3354
+        - gym-http-api
 
     "Tom Sydney Kerckhove <syd.kerckhove@gmail.com> @NorfairKing":
         - genvalidity


### PR DESCRIPTION
Fixes #3354 

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload (Hackage build matrix is complete: https://matrix.hackage.haskell.org/package/gym-http-api)
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
