### PR TITLE
Re-enabling haskell-tools packages, added classyplate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2945,15 +2945,16 @@ packages:
     "Boldizsár Németh <nboldi@elte.hu> @nboldi":
         - instance-control
         - references
-        - haskell-tools-ast < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - haskell-tools-backend-ghc < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - haskell-tools-prettyprint < 0 # GHC 8.4 via ghc-8.4.1
-        - haskell-tools-refactor < 0 # GHC 8.4 via template-haskell-2.13.0.0
-        - haskell-tools-rewrite < 0 # GHC 8.4 via ghc-8.4.1
-        # - haskell-tools-demo # Cabal 2 via minisat-solver
-        # - haskell-tools-cli # Cabal 2 via minisat-solver
-        # - haskell-tools-daemon # Cabal 2 via minisat-solver
-        # - haskell-tools-debug # Cabal 2 via minisat-solver
+        - classyplate
+        - haskell-tools-ast
+        - haskell-tools-backend-ghc
+        - haskell-tools-prettyprint
+        - haskell-tools-refactor
+        - haskell-tools-rewrite
+        - haskell-tools-demo
+        - haskell-tools-cli
+        - haskell-tools-daemon
+        - haskell-tools-debug
 
     "David Fisher <ddf1991@gmail.com> @ddfisher":
         - socket-activation


### PR DESCRIPTION
Haskell-tools is now compatible with GHC-8.4.3.

Since there are cross-dependencies the process cannot be done individually. However the project as a whole can be built using `stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

External dependencies:
```
  - fswatch-0.1.0.3
  - knob-0.1.1
  - minisat-solver-0.1
  - portable-lines-0.1
```
