### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7,6 +7,8 @@ cabal-format-version: "2.0"
 
 # Constraints for brand new builds
 packages:
+    "Matthew Ahrens <matt.p.ahrens@gmail.com> @mpahrens":
+        - forkable-monad
     "Iris Ward <aditu.venyhandottir@gmail.com> @AdituV":
         - typenums
 


### PR DESCRIPTION
"forkable-monad maintainer - adding myself to list so forkable-monad can be added to stackage.

> - [ X] Meaningful commit message: 
forkable monad maintainer

> - [X ] At least 30 minutes have passed since Hackage upload
> - [X ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):
> 
>       stack unpack $package-$version
>       cd $package-$version
>       stack init --resolver nightly
>       stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
> 

These worked for me!

forkable monad is on hackage maintained by my account there, mpahrens, same as my personal github account.
Source is uploaded and actively maintained under my organization github: system-indystress 
I don't know if that is a problem.
