### PR TITLE
Add the hailgun package back to stackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2099,7 +2099,7 @@ packages:
         - emailaddress < 0  # opaleye
         - envelope
         - from-sum
-        - hailgun < 0 # via exceptions-0.10.0
+        - hailgun
         - hailgun-simple < 0 # via hailgun
         - natural-transformation
         # - opaleye-trans # product-profunctors 0.9


### PR DESCRIPTION
The hailgun package was removed because of the block on exceptions-0.10.0.

This has been fixed in hailgun-0.4.1.8.


------------------------------------------------------------

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
