### PR TITLE
Add `lawful` and `gdp` packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3151,6 +3151,8 @@ packages:
     "Matt Noonan <matt.noonan@gmail.com> @matt-noonan":
         - justified-containers
         - roles >= 0.2
+        - lawful
+        - gdp
 
     "Levent Erkok <erkokl@gmail.com> @LeventErkok":
         - sbv < 0 # DependencyFailed (PackageName "crackNum")


### PR DESCRIPTION
`gdp` depends on `lawful`, so I had to do `stack init --resolver nightly --solver` below.

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
