### PR TITLE
Reown xlsx package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1914,7 +1914,6 @@ packages:
         - streaming-bytestring
         - string-class
         - string-combinators
-        - xlsx
 
     "Rob O'Callahan ropoctl@gmail.com @rcallahan":
         - pipes-fastx
@@ -2010,7 +2009,7 @@ packages:
         - thread-local-storage
 
     "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
-        - xlsx < 0 # build failure with GHC 8.4 https://github.com/qrilka/xlsx/issues/116
+        - xlsx
 
     "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
         - monad-logger-prefix


### PR DESCRIPTION
Taken ownership of `xlsx` back from Kostiantyn

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
