### PR TITLE
Reinstate alarmclock and bank-holidays-england

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1177,8 +1177,8 @@ packages:
         - shake-language-c
 
     "David Turner <dave.c.turner@gmail.com> @davecturner":
-        - alarmclock < 0 # GHC 8.4 via base-4.11.0.0
-        - bank-holidays-england < 0 # GHC 8.4 via base-4.11.0.0
+        - alarmclock
+        - bank-holidays-england
 
     "Haskell Servant <jkarni@gmail.com>":
         - servant


### PR DESCRIPTION
The latest versions of these packages have been confirmed working against `nightly-2018-06-18`.