### PR TITLE
backprop and hmatrix-backprop enabled

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1802,10 +1802,10 @@ packages:
 
     "Justin Le <justin@jle.im> @mstksg":
         - auto
-        - backprop < 0 # GHC 8.4 via type-combinators
+        - backprop
         - configurator-export
         - hamilton
-        - hmatrix-backprop < 0 # GHC 8.4 via ghc-typelits-knownnat
+        - hmatrix-backprop
         - hmatrix-vector-sized
         - one-liner-instances
         - prompt


### PR DESCRIPTION
Their dependencies on type-combinators have been removed, so they work on ghc 8.4 now :)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
