### PR TITLE
add greskell, greskell-core and greskell-websocket packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2658,6 +2658,9 @@ packages:
         - wikicfp-scraper
         - wild-bind
         - wild-bind-x11
+        - greskell
+        - greskell-core
+        - greskell-websocket
 
     "Cies Breijs <cies@kde.nl> @cies":
         - htoml


### PR DESCRIPTION
Confirmed with stackage nightly.

Note that greskell-core depends on containers but it doesn't support containers-0.6 yet. I don't think that is a problem with stackage for now, but correct me if I'm wrong.
