### PR TITLE
Re-enable eventstore package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2374,7 +2374,7 @@ packages:
         - pusher-http-haskell < 0 # GHC 8.4 via base-4.11.0.0
 
     "Yorick Laupa yo.eight@gmail.com @YoEight":
-        - eventstore < 0 # GHC 8.4 via text-format
+        - eventstore
         - dotnet-timespan
         - eventsource-api < 0 # GHC 8.4 build failure
         - eventsource-geteventstore-store < 0 # GHC 8.4 via protolude


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I can't run *exactly* the commands above as my library require a package that isn't on stackage. However, my package compiles if I add, `protobuf-0.2.1.2` in this case, as an extra-dep.
