### PR TITLE
Re-add squeal-postgresql

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3295,6 +3295,9 @@ packages:
     "Phil Ruffwind <rf@rufflewind.com> @Rufflewind":
         - blas-hs
 
+    "Eitan Chatav <eitan@gmail.com> @echatav":
+        - squeal-postgresql
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
Re-add squeal-postgresql. Fixed issue morphismtech/squeal#30 in pull request morphismtech/squeal#33.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
