### PR TITLE
Add detour-via-sci

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -13,6 +13,7 @@ packages:
 
     "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
         - siggy-chardust
+        - detour-via-sci
 
     "Matthew Ahrens <matt.p.ahrens@gmail.com> @mpahrens":
         - forkable-monad


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

```
stack unpack detour-via-sci-1.0.0
cd detour-via-sci-1.0.0
stack init --resolver nightly
```

```
stack build --resolver nightly
Selected resolver: nightly-2018-06-29
detour-via-sci-1.0.0: configure (lib)
Configuring detour-via-sci-1.0.0...
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
detour-via-sci-1.0.0: build (lib)
Preprocessing library for detour-via-sci-1.0.0..
Building library for detour-via-sci-1.0.0..
[1 of 2] Compiling Data.Via.Scientific ( library/Data/Via/Scientific.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Data/Via/Scientific.o )
[2 of 2] Compiling Paths_detour_via_sci ( .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/autogen/Paths_detour_via_sci.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Paths_detour_via_sci.o )
ignoring (possibly broken) abi-depends field for packages
detour-via-sci-1.0.0: copy/register
Installing library in /.../detour-via-sci-1.0.0/.stack-work/install/x86_64-osx/nightly-2018-06-29/8.4.3/lib/x86_64-osx-ghc-8.4.3/detour-via-sci-1.0.0-HZFvkPgCXtLFcu3J5M3kLe
Registering library for detour-via-sci-1.0.0..
```

```
stack build --resolver nightly --test
Selected resolver: nightly-2018-06-29
detour-via-sci-1.0.0: unregistering (missing dependencies: hlint)
haskell-src-exts-1.20.2: configure
haskell-src-exts-1.20.2: build
haskell-src-exts-1.20.2: copy/register
haskell-src-exts-util-0.2.3: configure
haskell-src-exts-util-0.2.3: build
haskell-src-exts-util-0.2.3: copy/register
hlint-2.1.6: configure
hlint-2.1.6: build
hlint-2.1.6: copy/register
detour-via-sci-1.0.0: configure (lib + test)
Configuring detour-via-sci-1.0.0...
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
detour-via-sci-1.0.0: build (lib + test)
Preprocessing library for detour-via-sci-1.0.0..
Building library for detour-via-sci-1.0.0..
[1 of 2] Compiling Data.Via.Scientific ( library/Data/Via/Scientific.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Data/Via/Scientific.o )
[2 of 2] Compiling Paths_detour_via_sci ( .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/autogen/Paths_detour_via_sci.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Paths_detour_via_sci.o )
ignoring (possibly broken) abi-depends field for packages
Preprocessing test suite 'hlint' for detour-via-sci-1.0.0..
Building test suite 'hlint' for detour-via-sci-1.0.0..
[1 of 3] Compiling Data.Via.Scientific ( library/Data/Via/Scientific.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/hlint/hlint-tmp/Data/Via/Scientific.o )
[2 of 3] Compiling Main             ( test-suite-hlint/HLint.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/hlint/hlint-tmp/Main.o )
[3 of 3] Compiling Paths_detour_via_sci ( .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/hlint/autogen/Paths_detour_via_sci.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/hlint/hlint-tmp/Paths_detour_via_sci.o )
Linking .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/hlint/hlint ...
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
Preprocessing test suite 'doctest' for detour-via-sci-1.0.0..
Building test suite 'doctest' for detour-via-sci-1.0.0..
[1 of 3] Compiling Data.Via.Scientific ( library/Data/Via/Scientific.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/doctest/doctest-tmp/Data/Via/Scientific.o )
[2 of 3] Compiling Main             ( test-suite-doctest/DocTest.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/doctest/doctest-tmp/Main.o )
[3 of 3] Compiling Paths_detour_via_sci ( .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/doctest/autogen/Paths_detour_via_sci.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/doctest/doctest-tmp/Paths_detour_via_sci.o )
Linking .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/doctest/doctest ...
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
detour-via-sci-1.0.0: copy/register
Installing library in /.../detour-via-sci-1.0.0/.stack-work/install/x86_64-osx/nightly-2018-06-29/8.4.3/lib/x86_64-osx-ghc-8.4.3/detour-via-sci-1.0.0-KZ1xMNzxCydE03YtYjV6Nt
Registering library for detour-via-sci-1.0.0..
detour-via-sci-1.0.0: test (suite: doctest)

Examples: 44  Tried: 44  Errors: 0  Failures: 0 Tried: 0  Errors: 0  Failures: 0

detour-via-sci-1.0.0: Test suite doctest passed
detour-via-sci-1.0.0: test (suite: hlint)

No hints

detour-via-sci-1.0.0: Test suite hlint passed
Completed 5 action(s).
```

```
stack build --resolver nightly --haddock
Selected resolver: nightly-2018-06-29
detour-via-sci-1.0.0: unregistering
detour-via-sci-1.0.0: configure (lib)
Configuring detour-via-sci-1.0.0...
clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
detour-via-sci-1.0.0: build (lib)
Preprocessing library for detour-via-sci-1.0.0..
Building library for detour-via-sci-1.0.0..
[1 of 2] Compiling Data.Via.Scientific ( library/Data/Via/Scientific.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Data/Via/Scientific.o )
[2 of 2] Compiling Paths_detour_via_sci ( .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/autogen/Paths_detour_via_sci.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Paths_detour_via_sci.o )
ignoring (possibly broken) abi-depends field for packages
detour-via-sci-1.0.0: haddock
Preprocessing library for detour-via-sci-1.0.0..
Running Haddock on library for detour-via-sci-1.0.0..
Haddock coverage:
 100% ( 16 / 16) in 'Data.Via.Scientific'
Documentation created:
.stack-work/dist/x86_64-osx/Cabal-2.2.0.1/doc/html/detour-via-sci/index.html,
.stack-work/dist/x86_64-osx/Cabal-2.2.0.1/doc/html/detour-via-sci/detour-via-sci.txt
detour-via-sci-1.0.0: copy/register
Installing library in /.../detour-via-sci-1.0.0/.stack-work/install/x86_64-osx/nightly-2018-06-29/8.4.3/lib/x86_64-osx-ghc-8.4.3/detour-via-sci-1.0.0-HZFvkPgCXtLFcu3J5M3kLe
Registering library for detour-via-sci-1.0.0..
Updating Haddock index for local packages in
/Users/pdejoux/dev/src/blockscope/detour-via-sci-1.0.0/.stack-work/install/x86_64-osx/nightly-2018-06-29/8.4.3/doc/index.html
Updating Haddock index for local packages and dependencies in
/.../detour-via-sci-1.0.0/.stack-work/install/x86_64-osx/nightly-2018-06-29/8.4.3/doc/all/index.html
Updating Haddock index for snapshot packages in
/.../.stack/snapshots/x86_64-osx/nightly-2018-06-29/8.4.3/doc/index.html
```
