### PR TITLE
Fixed louispan glazier packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3139,15 +3139,14 @@ packages:
         - arrow-extras
         - data-diverse
         - data-diverse-lens
-        - disposable
         - ghcjs-base-stub
         - glaze
         - glazier
-        - glazier-pipes
-        # - glazier-react # https://github.com/louispan/glazier-react/issues/7
-        # - glazier-react-widget # https://github.com/louispan/glazier-react/issues/7
+        - glazier-react
+        - glazier-react-widget
         - javascript-extras
         - l10n
+        - lens-misc
         - pipes-category
         - pipes-fluid
         - pipes-misc


### PR DESCRIPTION
* Re-enabled glazier-react and glazier-react-widget. 
* Removed deprecated glazier-pipes, disposable.
* Added lens-misc.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
