### PR TITLE
Fixed louispan packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2999,12 +2999,13 @@ packages:
         - arrow-extras
         - data-diverse
         - data-diverse-lens
-        - disposable < 0 # GHC 8.4 via ghcjs-base-stub
-        - ghcjs-base-stub < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        - ghcjs-base-stub
         - glaze
         - glazier
-        - glazier-pipes
-        - javascript-extras < 0 # GHC 8.4 via ghcjs-base-stub
+        - glazier-react
+        - glazier-react-widget
+        - javascript-extras
+        - lens-misc
         - l10n
         - pipes-category
         - pipes-fluid
@@ -4064,7 +4065,6 @@ expected-test-failures:
     - ghc-exactprint # https://github.com/alanz/ghc-exactprint/issues/47
     - llvm-hs-pretty # https://github.com/llvm-hs/llvm-hs-pretty/issues/48
     - nettle # https://github.com/stbuehler/haskell-nettle/issues/8
-    - pipes-misc # https://github.com/louispan/pipes-misc/issues/1
     - pixelated-avatar-generator # 0.1.3 https://github.com/ExcaliburZero/pixelated-avatar-generator/issues/19
     - servant-elm # https://github.com/mattjbray/servant-elm/issues/38
     - shikensu # https://github.com/icidasset/shikensu/issues/5

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3002,9 +3002,9 @@ packages:
         - ghcjs-base-stub
         - glaze
         - glazier
-        - glazier-react
-        - glazier-react-widget
-        - javascript-extras
+        - glazier-react < 0 # waiting for glazier 1.0
+        - glazier-react-widget < 0 # waiting for glazier 1.0
+        - javascript-extras < 0  # waiting for ghcjs-base-stub 0.2
         - lens-misc
         - l10n
         - pipes-category


### PR DESCRIPTION
* Deprecated disposable, glazier-pipes.
* Added lens-misc.
* Fixed pipes-misc assertion failure.
* Temporarily disabled javascript-extras (waiting on ghcjs-base-stub-0.2.0.0)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
