### PR TITLE
Unconstrain base-compat

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3635,9 +3635,6 @@ packages:
         - hspec < 2.5.3
         - hspec-discover <  2.5.3
 
-        # https://github.com/haskell-compat/base-compat/issues/56
-        - base-compat < 0.10.2
-
         # https://github.com/commercialhaskell/stackage/issues/3796
         - trifecta < 2
 


### PR DESCRIPTION
haskell-compat/base-compat#56 has been fixed in `base-compat-0.10.4`.
