### PR TITLE
Re-enable some tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3845,9 +3845,7 @@ skipped-tests:
     - haskell-tools-rewrite # tasty 1.1
     - pandoc # tasty 1.1
     - text-short # tasty 1.1
-    - servant # doctest 0.16
     - servant-auth-docs # doctest 0.16
-    - servant-swagger # doctest 0.16
 
     # Transitive outdated dependencies
     # These can also be checked for updates periodically.
@@ -3916,23 +3914,15 @@ skipped-tests:
     # @phadej
     - edit-distance # QuickCheck 2.10
     - http-api-data # doctest 0.13
-    - tdigest # doctest 0.13
     - time-parsers
-    - servant-mock # hspec-wai https://github.com/fpco/stackage/issues/3014
-    - servant-server # hspec-wai https://github.com/fpco/stackage/issues/3014
     - aeson-compat # tasty, tasty-hunit https://github.com/fpco/stackage/issues/3062, https://github.com/fpco/stackage/issues/2995
     - aeson-extra
     - binary-orphans
-    - insert-ordered-containers
     - integer-logarithms
-    - lattices
     - postgresql-simple-url
     - range-set-list
     - spdx
-    - tdigest
-    - these
     - time-parsers
-    - dlist-nonempty # QuickCheck2.11
     - base64-bytestring-type # https://github.com/commercialhaskell/stackage/issues/3620#issuecomment-395947135
 
     # Uses Cabal's "library internal" stanza feature


### PR DESCRIPTION
I'm quite sure these should allow newest stuff now. Let's see what `stackage-curator` says.