### PR TITLE
Re-enable clang-pure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2787,7 +2787,7 @@ packages:
     "Patrick Chilton <chpatrick@gmail.com> @chpatrick":
         - webrtc-vad
         - servant-generic
-        # - clang-pure
+        - clang-pure
         - codec
 
     "Michal Konecny <mikkonecny@gmail.com> @michalkonecny":


### PR DESCRIPTION
Dependencies must be installed like this: https://github.com/chpatrick/clang-pure/blob/master/.travis.yml#L155

Could you add them to the build environment please?

Checklist:
- [ ] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
