### PR TITLE
Reenable magicbane (0.3.0) and dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -444,8 +444,6 @@ packages:
         - http-client
         - http-conduit
 
-        - rio-orphans
-
     "Omari Norman <omari@smileystation.com> @massysett":
         - rainbow
         - rainbox

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -444,6 +444,8 @@ packages:
         - http-client
         - http-conduit
 
+        - rio-orphans
+
     "Omari Norman <omari@smileystation.com> @massysett":
         - rainbow
         - rainbox
@@ -1334,7 +1336,7 @@ packages:
         - microformats2-parser
         - hspec-expectations-pretty-diff
         - wai-cli
-        # - magicbane # https://github.com/myfreeweb/magicbane/issues/9
+        - magicbane
 
     "Francesco Mazzoli <f@mazzo.li> @bitonic":
         - language-c-quote
@@ -2034,7 +2036,7 @@ packages:
 
     "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
         - monad-logger-prefix
-        - monad-metrics < 0 # via exceptions-0.10.0
+        - monad-metrics
         # - ekg-cloudwatch # http-conduit 2.3 via amazonka
         - smtp-mail
         - liboath-hs < 0 # GHC 8.4 via inline-c


### PR DESCRIPTION
I'm actually really confused about `rio` itself in stackage?? It's visible [on the website](https://www.stackage.org/nightly-2018-07-06/package/rio-0.1.3.0) "Stackage Nightly 2018-07-06: 0.1.3.0" but I can't find it in this file?? Wanted to add `rio-orphans` next to `rio` but there's no `rio` somehow... /cc @snoyberg 

monad-metrics had its `exception` bounds updated: https://github.com/parsonsmatt/monad-metrics/issues/11