### PR TITLE
Re-enable apecs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2170,7 +2170,7 @@ packages:
         - GPipe < 0 # GHC 8.4 via base-4.11.0.0
 
     "Jonas Carpay <jonascarpay@gmail.com> @jonascarpay":
-        - apecs < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
+        - apecs
 
     "Spencer Janssen <spencerjanssen@gmail.com> @spencerjanssen":
         - Xauth


### PR DESCRIPTION
I cannot reproduce the issue on os x or linux, and the date (2018-04-13) does not match an apecs update. I am not sure what might have caused this, but I think it has been fixed?
