### PR TITLE
Adding async-pool to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3491,6 +3491,9 @@ packages:
 
     "Owen Lynch <root@owenlynch.org> @olynch":
         - natural-sort
+        
+    "John Biesnecker <jbiesnecker@gmail.com> @biesnecker":
+        - async-pool
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Chatted with @jwiegley already (https://github.com/jwiegley/async-pool/issues/11) and I'm going to maintain this package in stackage.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
