### PR TITLE
fixed: yesod-form-bootstrap4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3038,7 +3038,7 @@ packages:
         # - haskell-import-graph # fgl via graphviz
         - string-transform
         - uniq-deep
-        - yesod-form-bootstrap4 < 0 # https://github.com/ncaq/yesod-form-bootstrap4/issues/2
+        - yesod-form-bootstrap4
         - yesod-recaptcha2
 
     "Andrei Barbu <andrei@0xab.com> @abarbu":


### PR DESCRIPTION
by [deleted: addClass closed #2 · ncaq/yesod-form-bootstrap4@7315a49](https://github.com/ncaq/yesod-form-bootstrap4/commit/7315a49e952c6ab46fa7a20d896ac21c5c8a8637)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

haskell-src-exts will be a build error.
However, trying with yesod-form does not seem to be a problem with my package because it will be the same thing.
It may depend on the environment so I would like others to try it.

~~~
% stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
Selected resolver: nightly-2018-07-09
yesod-core-1.6.6: configure
yesod-core-1.6.6: build
haskell-src-exts-1.20.2: configure
haskell-src-exts-1.20.2: build
yesod-core-1.6.6: haddock
yesod-core-1.6.6: copy/register
haskell-src-exts-1.20.2: haddock     
Progress 2/8                         

--  While building custom Setup.hs for package haskell-src-exts-1.20.2 using:
      /home/ncaq/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_2.2.0.1_ghc-8.4.3 --builddir=.stack-work/dist/x86_64-linux/Cabal-2.2.0.1 haddock --html --hoogle --html-location=../$pkg-$version/ --haddock-option=--hyperlinked-source
    Process exited with code: ExitFailure (-11)
    Logs have been written to: /home/ncaq/Desktop/stackage/yesod-form-bootstrap4-1.0.1/.stack-work/logs/haskell-src-exts-1.20.2.log

    Configuring haskell-src-exts-1.20.2...
    Preprocessing library for haskell-src-exts-1.20.2..
    Building library for haskell-src-exts-1.20.2..
    [ 1 of 17] Compiling Language.Haskell.Exts.Extension ( src/Language/Haskell/Exts/Extension.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Extension.o )
    [ 2 of 17] Compiling Language.Haskell.Exts.ExtScheme ( src/Language/Haskell/Exts/ExtScheme.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/ExtScheme.o )
    [ 3 of 17] Compiling Language.Haskell.Exts.SrcLoc ( src/Language/Haskell/Exts/SrcLoc.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/SrcLoc.o )
    [ 4 of 17] Compiling Language.Haskell.Exts.Syntax ( src/Language/Haskell/Exts/Syntax.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Syntax.o )
    [ 5 of 17] Compiling Language.Haskell.Exts.ParseSyntax ( src/Language/Haskell/Exts/ParseSyntax.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/ParseSyntax.o )
    [ 6 of 17] Compiling Language.Haskell.Exts.Pretty ( src/Language/Haskell/Exts/Pretty.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Pretty.o )
    [ 7 of 17] Compiling Language.Haskell.Exts.Fixity ( src/Language/Haskell/Exts/Fixity.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Fixity.o )
    [ 8 of 17] Compiling Language.Haskell.Exts.Comments ( src/Language/Haskell/Exts/Comments.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Comments.o )
    [ 9 of 17] Compiling Language.Haskell.Exts.ParseMonad ( src/Language/Haskell/Exts/ParseMonad.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/ParseMonad.o )
    [10 of 17] Compiling Language.Haskell.Exts.ParseUtils ( src/Language/Haskell/Exts/ParseUtils.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/ParseUtils.o )
    [11 of 17] Compiling Language.Haskell.Exts.InternalLexer ( src/Language/Haskell/Exts/InternalLexer.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/InternalLexer.o )
    [12 of 17] Compiling Language.Haskell.Exts.Lexer ( src/Language/Haskell/Exts/Lexer.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Lexer.o )
    [13 of 17] Compiling Language.Haskell.Exts.InternalParser ( .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/InternalParser.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/InternalParser.o )
    [14 of 17] Compiling Language.Haskell.Exts.Parser ( src/Language/Haskell/Exts/Parser.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Parser.o )
    [15 of 17] Compiling Language.Haskell.Exts.ExactPrint ( src/Language/Haskell/Exts/ExactPrint.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/ExactPrint.o )
    [16 of 17] Compiling Language.Haskell.Exts.Build ( src/Language/Haskell/Exts/Build.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts/Build.o )
    [17 of 17] Compiling Language.Haskell.Exts ( src/Language/Haskell/Exts.hs, .stack-work/dist/x86_64-linux/Cabal-2.2.0.1/build/Language/Haskell/Exts.o )
    ignoring (possibly broken) abi-depends field for packages
    Preprocessing library for haskell-src-exts-1.20.2..
    Running Haddock on library for haskell-src-exts-1.20.2..
~~~