### PR TITLE
Renable herms in the build plan

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3416,7 +3416,7 @@ packages:
         - cryptocompare
 
     "Jack Kiefer <jack.c.kiefer@gmail.com> @JackKiefer":
-        - herms < 0 # semigroups 0.18.5
+        - herms
 
     "Sergey Vinokurov <serg.foo@gmail.com> @sergv":
         - tasty-ant-xml


### PR DESCRIPTION
Sorry for being MIA for a bit! `semigroups-0.18.5` is no longer an issue and has been fixed as a dependency in `herms-1.9.0.2`. I've gone through the standard motions and everything seems to be building just fine with the nightlies on my end :)

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
