### PR TITLE
Re-enable hw-json package on nightlies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2645,7 +2645,7 @@ packages:
         - hw-ip
         - hw-fingertree < 0 # build failure with GHC 8.4
         - hw-fingertree-strict
-        - hw-json < 0 # via hw-rankselect-0.12.0.3
+        - hw-json
         - hw-parser
         - hw-prim
         - hw-rankselect


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [ ] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
