### PR TITLE
Re-enabling haskell-tools packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2990,9 +2990,9 @@ packages:
         - haskell-tools-refactor
         - haskell-tools-rewrite
         - haskell-tools-demo
-        # - haskell-tools-cli # via tasty-1.1.0.2
-        # - haskell-tools-daemon # via tasty-1.1.0.2
-        - haskell-tools-debug < 0 # via criterion-1.5.0.0
+        - haskell-tools-cli
+        - haskell-tools-daemon
+        - haskell-tools-debug
 
     "David Fisher <ddf1991@gmail.com> @ddfisher":
         - socket-activation


### PR DESCRIPTION
Fixed dependency problems with criterion and tasty.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
