### PR TITLE
build-constraints.yaml: cabal2nix build is fixed in version 2.10.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2205,7 +2205,7 @@ packages:
         - nagios-check
 
     "Peter Simons <simons@cryp.to> @peti":
-        - cabal2nix < 0 # build failure via hpack-0.29 NixOS/cabal2nix#359
+        - cabal2nix
         - cabal2spec
         - distribution-nixpkgs
         - flexible-defaults


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
