### PR TITLE
Restore rhine

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -34,7 +34,7 @@ packages:
 
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
         - dunai
-        - rhine < 0 # via free-5.1
+        - rhine
 
     "Paul Johnson <paul@cogito.org.uk> @PaulJohnson":
         - geodetics


### PR DESCRIPTION
`rhine-0.4.0.3` works with stackage again. All dependencies have been updated (See #3794).

Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
