### PR TITLE
Re-enable cmark

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2541,7 +2541,7 @@ packages:
 
     "John MacFarlane <jgm@berkeley.edu> @jgm":
         - hsb2hs < 0 # build failure with GHC 8.4
-        - cmark < 0 # DependencyFailed (PackageName "markdown")
+        - cmark
         - texmath
         - highlighting-kate
         - skylighting


### PR DESCRIPTION
I didn't have any trouble adding it as an extra dependency alongside other LTS 12.0 packages. I couldn't find out why it was disabled in the first place.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
