### PR TITLE
Add rhine-gloss

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -35,6 +35,7 @@ packages:
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
         - dunai
         - rhine
+        - rhine-gloss
 
     "Paul Johnson <paul@cogito.org.uk> @PaulJohnson":
         - geodetics


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message - please not `Update build-constraints.yml`
- [X] At least 30 minutes have passed since Hackage upload
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


The build failed by requiring external libraries to build `OpenGLRaw`, this can be fixed by adding the following to `stack.yaml`:

```
nix:
  enable: true
  packages: [libGL libGLU]
```
I don't know what the standard way around this is in stackage, but it seems to be no fault of `rhine-gloss`.