### PR TITLE
Re-enable simple-vec3 benchmarks (simple-vec3-0.4.0.8)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4248,7 +4248,6 @@ skipped-benchmarks:
     - identicon # via criterion-1.5.0.0
     - pandoc-types # via criterion-1.5.0.0
     - pipes # optparse-applicative 0.13
-    - simple-vec3 # via criterion-1.5.0.0
     - skylighting-core # via criterion-1.5.0.0
     - snap-server # via criterion-1.5.0.0
     - splitmix # criterion 1.3


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack simple-vec3-0.4.0.8
      cd simple-vec3-0.4.0.8
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
