### PR TITLE
Re-add `rollbar-hs`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3110,7 +3110,7 @@ packages:
 
     "Hardy Jones <jones3.hardy@gmail.com> @joneshf":
         # - katip-rollbar # async 2.2
-        - rollbar-hs < 0 # aeson
+        - rollbar-hs
         - servant-ruby
         - wai-middleware-rollbar < 0 # aeson
 


### PR DESCRIPTION
Removed in https://github.com/commercialhaskell/stackage/issues/3393.

A new version was released that relaxes the upper bound.

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
