### PR TITLE
Add gi-vte package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2732,6 +2732,7 @@ packages:
         - gi-gtk-hs
         - gi-gtksource
         - gi-javascriptcore
+        - gi-vte
         # - gi-webkit2 # GHC 8.4
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":


### PR DESCRIPTION
This PR adds the package [gi-vte](https://hackage.haskell.org/package/gi-vte).

This has been added under the github user @garetxe as per the following conversation:

https://github.com/haskell-gi/haskell-gi/issues/177#issuecomment-408793329