### PR TITLE
Unblock the gi-vte package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2732,7 +2732,7 @@ packages:
         - gi-gtk-hs
         - gi-gtksource
         - gi-javascriptcore
-        - gi-vte < 0 # custom setup needed? https://github.com/commercialhaskell/stackage/issues/3867
+        - gi-vte
         # - gi-webkit2 # GHC 8.4
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -119,6 +119,7 @@ apt-get install -y \
     libtre-dev \
     libudev-dev \
     libusb-1.0-0-dev \
+    libvte-2.91-dev \
     libwebkitgtk-3.0-dev \
     libxau-dev \
     libxml2-dev \


### PR DESCRIPTION
The `gi-vte` Haskell package fails to build because the required `libvte-2.91-dev` system package is not installed.

This PR unblocks the `gi-vte` Haskell package, and adds the `libvte-2.91-dev` package to the `debian-bootstrap.sh` file.

This is as recommended by @mihaimaruseac in https://github.com/commercialhaskell/stackage/issues/3867.