### PR TITLE
Add lzma-clib package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3810,6 +3810,7 @@ configure-args:
 # Used for packages that cannot be built on Linux
 skipped-builds:
     - hfsevents
+    - lzma-clib
     - Win32
     - Win32-notify
 


### PR DESCRIPTION
The `lzma` package is added but it's not buildable on Windows if `lzma-clib` package is not available. Since `lzma-clib` is not part of snaphot, `lzma` cannot be built on Windows.

I am unable to pinpoint where exactly `lzma` package is added. Its only occurence whithin the `build-constraints.yaml` file is under `skipped-tests`, but I don't really know the meaning of that section. Could someone please review whether my change is enough to add `lzma-clib` package to the snapshot, or should I add as a package under my name to the `packages` section?


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks