### PR TITLE
add hvega and ihaskell-hvega

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3292,6 +3292,8 @@ packages:
 
     "Douglas Burke <dburke.gw@gmail.com> @DougBurke":
         - swish
+        - hvega
+        - ihaskell-hvega
 
     "Adam Flott <adam@adamflott.com> @adamflott":
         - milena


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I had to remove `--haddock` with `--resolver nightly` as this fell over when building one of the dependencies: `haskell-src-exts-1.20.2`. It worked with `--bench` when using ghc 8.2 (i.e. `--resolver lts-11`).