### PR TITLE
Re-enable logging-effect-extra-*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2527,9 +2527,9 @@ packages:
         - binary-search
 
     "Jason Shipman <jasonpshipman@gmail.com> @jship":
-        - logging-effect-extra < 0 # GHC 8.4 via base-4.11.0.0
-        - logging-effect-extra-file < 0 # GHC 8.4 via base-4.11.0.0
-        - logging-effect-extra-handler < 0 # GHC 8.4 via base-4.11.0.0
+        - logging-effect-extra
+        - logging-effect-extra-file
+        - logging-effect-extra-handler
         - overhang
         - tao
         - tao-example


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

`logging-effect-extra` won't build using the steps above because it depends on `logging-effect-extra-file` and `logging-effect-extra-handler`, but it should build fine once the other 2 are available.  I went ahead and included `logging-effect-extra` in this PR but let me know if I need to drop it until the other 2 go through.