### PR TITLE
build-constraints.yaml: add xmonad to list of packages I maintain

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2241,6 +2241,7 @@ packages:
         - SafeSemaphore
         - streamproc
         - titlecase
+        - xmonad
 
     "Mark Fine <mark.fine@gmail.com> @markfine":
         - postgresql-schema


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
