### PR TITLE
Added haskell-names package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1220,6 +1220,7 @@ packages:
         - hformat
         - simple-log
         - text-region
+        - haskell-names
 
     "Aleksey Kliger <aleksey@lambdageek.org> @lambdageek":
         - unbound-generics


### PR DESCRIPTION
`haskell-names` now builds with `lts-12.5` and `nightly`