### PR TITLE
Adding back in one-liner

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1836,7 +1836,7 @@ packages:
         - hamilton < 0 # via vector-sized
         - hmatrix-backprop < 0 # via vector-sized
         - hmatrix-vector-sized < 0 # via vector-sized
-        - one-liner-instances < 0 # via one-liner
+        - one-liner-instances
         - prompt
         - tagged-binary
         # - type-combinators-singletons # GHC 8.4 via type-combinators
@@ -3562,8 +3562,6 @@ packages:
     # be removed from this list if they are fixed.
     "Unmaintained packages with compilation failures":
         - stackage-types < 0
-        - one-liner < 0 # via contravariant-1.5
-        - unfoldable < 0 # via one-liner
 
      # If you want to make sure a package is removed from stackage,
      # place it here with a `< 0` constraint and send a pull


### PR DESCRIPTION
*one-liner-1.0* has been compatible with the nightlies since a hackage revision was made, so this PR takes it back off of the blocked packages list :)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
