### PR TITLE
Bring 'fmt' back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2091,7 +2091,7 @@ packages:
         - charsetdetect-ae
         - ilist
         # - text-all # text-1.2.3.0
-        - fmt < 0 # DependencyFailed (PackageName "text-format")
+        - fmt
 
     "Takano Akio tak@anoak.io @takano-akio":
         - fast-builder < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
Not sure why it was dropped from Stackage, since version 0.6 doesn't even depend on `text-format`.

Note: I ran the command from the checklist, but it failed at Haddock stage for `haskell-src-exts` with `ErrorFailure (-11)`. Without `--haddock`, it succeeds.

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
