### PR TITLE
add back in hamilton, hmatrix-backprop, hmatrix-vector-sized

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1836,6 +1836,9 @@ packages:
         - backprop
         - configurator-export
         - emd
+        - hamilton
+        - hmatrix-backprop
+        - hmatrix-vector-sized
         - one-liner-instances
         - prompt
         - tagged-binary


### PR DESCRIPTION
Hi!  Sorry, it seems like my multiple-PR jockeying (submitting two PR's at once that both forked from master in different ways) has caused some unfortunate consequences and lead to 26f129c15cc37e02e02e5599cbbb7333b8ac084d inadvertently removing some of my packages from *build-constraints.yaml* (hamilton, hmatrix-backprop, hmatrix-vector-sized).  Hopefully this PR can undo my mess :)

Thanks again!

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
