### PR TITLE
Add base-noprelude

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3233,8 +3233,7 @@ packages:
         - universum
 
     "Kowainik <xrom.xkov@gmail.com> @ChShersh":
-        # Requires Cabal file format 2.2
-        # - base-noprelude == 4.11.1.0
+        - base-noprelude == 4.11.1.0
         - first-class-patterns
         - relude
         - summoner


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands:

      stack unpack base-noprelude-4.11.1.0
      cd base-noprelude-4.11.1.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Looks like Stackage now supports Cabal 2.2.