### PR TITLE
Fix quickcheck-state-machine

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3375,9 +3375,9 @@ packages:
     "Henry Laxen <nadine.and.henry@pobox.com> @HenryLaxen":
         - bbdb
 
-    "Stevan Andjelkovic <stevan@advancedtelematic.com> @stevana":
-        - quickcheck-state-machine < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-
+    "Stevan Andjelkovic <stevan.andjelkovic@here.com> @stevana":
+        - quickcheck-state-machine
+        
     "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
         - hdevtools < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - servant-exceptions


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
