### PR TITLE
Remove < 0.4.0 constraint for tomland

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3388,7 +3388,7 @@ packages:
 
     "Stevan Andjelkovic <stevan.andjelkovic@here.com> @stevana":
         - quickcheck-state-machine
-        
+
     "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
         - hdevtools
         - servant-exceptions
@@ -3568,7 +3568,7 @@ packages:
 
     "Wanja Chresta <wanja.hs@chrummibei.ch> @wchresta":
         - matrix-static
-    
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056
@@ -3673,9 +3673,6 @@ packages:
         - gloss < 1.13
         - gloss-raster < 1.13
         - gloss-rendering < 1.13
-
-        # https://github.com/commercialhaskell/stackage/issues/3924
-        - tomland < 0.4
 
         # https://github.com/commercialhaskell/stackage/issues/3926
         - vinyl < 0.10


### PR DESCRIPTION
Resolves #3924

`summoner-1.1.0` has been released with bumped up `tomland` version.

* https://hackage.haskell.org/package/summoner-1.1.0