### PR TITLE
Add the servant-rawm package back to Hackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2157,7 +2157,7 @@ packages:
         - read-env-var
         - servant-checked-exceptions
         - servant-checked-exceptions-core
-        # - servant-rawm # https://github.com/cdepillabout/servant-rawm/issues/4
+        - servant-rawm
         - servant-static-th
         - termonad
         - world-peace


### PR DESCRIPTION
[servant-rawm-0.3.0.0](http://hackage.haskell.org/package/servant-rawm-0.3.0.0) has been released which gets it compiling with the latest version of servant, as well as on stackage nightly.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
