### PR TITLE
Remove build constraints related to proto-lens.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3680,9 +3680,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/3926
         - vinyl < 0.10
 
-        # https://github.com/commercialhaskell/stackage/issues/3931
-        - proto-lens-protobuf-types < 0.3.0.2
-
         # https://github.com/commercialhaskell/stackage/issues/3945
         - dhall < 1.17
 
@@ -3929,7 +3926,6 @@ skipped-tests:
     # the relevant stackage upper bound is lifted.
 
     # Compilation failures
-    - proto-lens-combinators # https://github.com/google/proto-lens/issues/119
     - snappy # https://github.com/bos/snappy/issues/1
 
     # Runtime issues


### PR DESCRIPTION
Now that fpco/stackage-curator#64 has been merged, there is no longer
a conflict between the `protobuf-simple` package and `proto-lens`-related
packages.  Packages that use `proto-lens` to generate Haskell source files
should work now.  (I'm not sure whether we need to wait for a release of
`stackage-curator` before merging this.)

Changes:
- Allow `proto-lens-protobuf-types-0.3.0.2`; previously only older versions
  were allowed (#3931)
- Run tests for `proto-lens-combinators_test`; previously they were disabled
  (google/proto-lens#119)

I tested this change by running `stackage-curator` manually on the latest LTS,
(with `proto-lens-protobuf-types-0.3.0.1`) then rerunning the same commands
manually for `0.3.0.2` (ncluding recreating the PATH that `stackage-curator`
used).  But let me know if there are any other commands I can run to help
validate this.