### PR TITLE
Add proto-lens-runtime and proto-lens-setup.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3163,6 +3163,8 @@ packages:
         - proto-lens-combinators
         - proto-lens-protobuf-types
         - proto-lens-protoc
+        - proto-lens-runtime
+        - proto-lens-setup
         - proto-lens
         - proto-lens-arbitrary
         - proto-lens-optparse


### PR DESCRIPTION
They were released earlier today on Hackage.

FYI, they are prerequisites for upgrading the `proto-lens-*` suite to their
latest versions.  In particular, they are required by
`proto-lens-protobuf-types-0.4.0.0` and `proto-lens-combinators-0.4.0.0`.

Tested by `stack unpack`-ing the packages and using the following `stack.yaml`:
```
resolver: nightly-2018-09-03

packages:
- '.'

extra-deps:
- lens-labels-0.3.0.0
- proto-lens-0.4.0.0
- proto-lens-protoc-0.4.0.0
```