### PR TITLE
Re-enabled range library. Build issues against free >= 5 are fixed.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1977,8 +1977,7 @@ packages:
         - hsass
 
     "Robert Massaioli <robertmassaioli@gmail.com> @robertmassaioli":
-        []
-        # - range # build failure w/ free 5
+        - range
 
     "Vladislav Zavialov <vlad.z.4096@gmail.com> @int-index":
         - transformers-lift


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
