### PR TITLE
Restore algebraic-graphs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3158,7 +3158,7 @@ packages:
         - wai-middleware-rollbar < 0 # aeson
 
     "Andrey Mokhov <andrey.mokhov@gmail.com> @snowleopard":
-        - algebraic-graphs < 0 # via base-compat-0.10.1
+        - algebraic-graphs
 
     "Albert Krewinkel <albert+stackage@zeitkraut.de> @tarleb":
         - hslua


### PR DESCRIPTION
Restoring `algebraic-graphs` after resolving the `base-compat` issue #3493. 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
