### PR TITLE
Re-enable benchpress and pusher-http-haskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2419,8 +2419,8 @@ packages:
         - fuzzyset
 
     "Will Sewell <me@willsewell.com> @willsewell":
-        - benchpress < 0 # GHC 8.4 via base-4.11.0.0
-        - pusher-http-haskell < 0 # GHC 8.4 via base-4.11.0.0
+        - benchpress
+        - pusher-http-haskell
 
     "Yorick Laupa yo.eight@gmail.com @YoEight":
         - eventstore


### PR DESCRIPTION
I'm not sure what the `< 0` syntax means for certain, but these packages are no longer in stackage, so I'm assuming they have been disabled. I have now made sure they are compatible with base-4.11.0.0.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
