### PR TITLE
Re-enable `shikensu`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3226,7 +3226,7 @@ packages:
         # - alerta # servant-client 0.12
 
     "Steven Vandevelde <icid.asset@gmail.com> @icidasset":
-        - shikensu < 0 # GHC 8.4 via flow
+        - shikensu
 
     "George Pollard <porges@porg.es> @Porges":
         - email-validate


### PR DESCRIPTION
The `flow` package was missing before but has been added in the meantime.
I tested it by using the `nightly-2018-09-16` resolver.
I did need to adjust my test dependency version ranges, but no dependencies of the package itself, so no version bump.
See the last commit on https://github.com/icidasset/shikensu for more info.

Thanks! 🙌 