### PR TITLE
Revert "Re-enable `shikensu`"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3226,7 +3226,7 @@ packages:
         # - alerta # servant-client 0.12
 
     "Steven Vandevelde <icid.asset@gmail.com> @icidasset":
-        - shikensu
+        - shikensu < 0 # GHC 8.4 via flow
 
     "George Pollard <porges@porg.es> @Porges":
         - email-validate


### PR DESCRIPTION
Reverts commercialhaskell/stackage#3975

@icidasset this PR failed with the following error:

```
tasty-1.1.0.3 (Roman Cheplyaka <roma@ro-che.info> @feuerbach) is out of bounds for:
- [ ] shikensu-0.3.8 (>=0.11 && < 1.1). Steven Vandevelde <icid.asset@gmail.com> @icidasset. @icidasset. Used by: test-suite
```