### PR TITLE
Added `registry` to the list of packages to build

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3601,6 +3601,9 @@ packages:
 
     "asakamirai <asakamirai_hackage@towanowa.net> @asakamirai":
         - kazura-queue
+        
+    "Eric Torreborre <etorreborre@yahoo.com> @etorreborre":
+        - registry
 
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.


### PR DESCRIPTION
Thanks!

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Unfortunately that doesn't work because haddock seems to be hanging when trying to execute for `haskell-src-exts-1.20.2`. Is this a known issue? Is there a workaround?

Thanks.
