### PR TITLE
Reenable tests of main-tester

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4218,7 +4218,6 @@ expected-test-failures:
     - http-client # https://github.com/snoyberg/http-client/issues/360
     - http-client-tls # https://github.com/snoyberg/http-client/issues/360
     - http-link-header # https://github.com/myfreeweb/http-link-header/issues/7
-    - main-tester # https://github.com/fpco/stackage/pull/3528
     - mmark # https://github.com/commercialhaskell/stackage/issues/3906#issuecomment-413061849
     - servant-swagger # https://github.com/haskell-servant/servant-swagger/issues/89
     - unicode-show # https://github.com/nushio3/unicode-show/issues/2


### PR DESCRIPTION
I disabled doctests by default since v0.2.0.0 with [this commit](https://gitlab.com/igrep/main-tester/commit/ccb1204cc8f10d72d7d0d4557b56f07f6a280c8e).
So now `stack test` without flags would work.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
