### PR TITLE
Update docker image to LLVM 7.0 and reenable llvm-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4462,7 +4462,7 @@ packages:
         - jni < 0
         - large-hashable < 0
         - libmpd < 0
-        - llvm-hs < 0
+        - llvm-hs
         - llvm-hs-pretty < 0
         - matrix-static < 0
         - med-module < 0

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -174,11 +174,11 @@ wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update \
     && apt-get install -y llvm-5.0
 
-# llvm-6.0 for llvm-hs (separate since it needs wget)
+# llvm-7.0 for llvm-hs (separate since it needs wget)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-    && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" \
+    && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" \
     && apt-get update \
-    && apt-get install -y llvm-6.0
+    && apt-get install -y llvm-7
 
 # Buggy versions of ld.bfd fail to link some Haskell packages:
 # https://sourceware.org/bugzilla/show_bug.cgi?id=17689. Gold is


### PR DESCRIPTION
I’ve tested that the new docker image can be built correctly and that within that docker image `llvm-hs` passes all tests using the current nightly resolver.
