### PR TITLE
Add haskeline.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3189,6 +3189,7 @@ packages:
         - tensorflow-test
         - pier-core
         - pier
+        - haskeline
 
     "Christof Schramm <christof.schramm@campus.lmu.de>":
         - mnist-idx


### PR DESCRIPTION
It builds fine with ghc-8.6.1, and it was in previous LTS's with no issues, and
so i'm not sure why it was removed in the ghc-8.6 nightlies.   Might be
something to do with being distributed with GHC, but not being a core package
from Stackage's perspective.  In either case, adding it explicitly seems like
the right thing to do long-term.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
