### PR TITLE
Re-enable singletons tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5006,7 +5006,6 @@ expected-test-failures:
     - serialport # "The tests need two serial ports as command line arguments" https://github.com/jputcu/serialport/issues/30
     - serversession-backend-redis # redis
     - shake # Needs ghc on $PATH with some installed haskell packages
-    - singletons # Needs ghc on $PATH with som installed haskell packages
     - stack # https://github.com/fpco/stackage/issues/3707
     - stripe-http-streams # https://github.com/fpco/stackage/issues/2945, needs Stripe account
     - users-persistent # sqlite


### PR DESCRIPTION
`singletons-2.5` features a significantly revamped test suite that makes fewer assumptions about what is on one's `PATH`, so Stackage should be able to run the tests with no issues now.