### PR TITLE
Fully remove llvm-hs from 8.6 build failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4462,7 +4462,6 @@ packages:
         - jni < 0
         - large-hashable < 0
         - libmpd < 0
-        - llvm-hs
         - llvm-hs-pretty < 0
         - matrix-static < 0
         - med-module < 0


### PR DESCRIPTION
Previously, I accidentally only removed the < 0 constraint instead of
the full line.