### PR TITLE
restore hsexif & app-settings, they now support ghc 8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3807,7 +3807,6 @@ packages:
         - antiope-s3 < 0
         - antiope-sns < 0
         - antiope-sqs < 0
-        - app-settings < 0
         - apply-refact < 0
         - approximate < 0
         - arrow-list < 0
@@ -4045,7 +4044,6 @@ packages:
         - hpqtypes < 0
         - hquantlib < 0
         - hsebaysdk < 0
-        - hsexif < 0
         - hslua < 0
         - hslua-aeson < 0
         - hslua-module-text < 0


### PR DESCRIPTION
restore hsexif & app-settings, they now support ghc 8.6

Checklist:
- [ x ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ x ] At least 30 minutes have passed since uploading to Hackage
- [ x ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
