### PR TITLE
euler-tour-tree is now compatible with GHC 8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1932,7 +1932,7 @@ packages:
         - atom-conduit
         - conduit-parse
         - dublincore-xml-conduit
-        - euler-tour-tree < 0 # GHC 8.4 via base-4.11.0.0
+        - euler-tour-tree
         - opml-conduit
         - rss-conduit
         - timerep


### PR DESCRIPTION
Last release of `euler-tour-tree` (0.1.1.0) is compatible with GHC 8.6 .

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
