### PR TITLE
Add pandoc-pyplot to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8,6 +8,9 @@ cabal-format-version: "2.2"
 # Constraints for brand new builds
 packages:
 
+    "Laurent P. René de Cotret <laurent.decotret@outlook.com> @LaurentRDC":
+        - pandoc-pyplot
+    
     "Andrew Newman <andrewfnewman@gmail.com> @andrewfnewman":
         - geojson
 


### PR DESCRIPTION
pandoc-pyplot is a Pandoc filter that can generate figures from Python code blocks using Matplotlib. It can also be integrated with the static website generator `Hakyll`, which is why it would be great to add `pandoc-pyplot` to stackage.

Version 1.0.0.0 builds correctly using resolver `nightly-2018-10-01`.

Project pages: 
* [Github](https://github.com/LaurentRDC/pandoc-pyplot)
* [Hackage](https://hackage.haskell.org/package/pandoc-pyplot)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
