### PR TITLE
add back in fixed typelits-witnesses

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4471,7 +4471,6 @@ packages:
         - o-clock < 0
         - stm-stats < 0
         - teardown < 0
-        - typelits-witnesses < 0
         - typenums < 0
         - typography-geometry < 0
         - universe-instances-extended < 0


### PR DESCRIPTION
Was previously removed because of failure to build with ghc 8.6

----------

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
