### PR TITLE
Bring back JuicyPixels/FontyFruity/Rasterific in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3685,7 +3685,6 @@ packages:
         - Allure < 0
         - DAV < 0
         - DRBG < 0
-        - FontyFruity < 0
         - HTF < 0
         - HTTP < 0
         - HaTeX < 0
@@ -3694,7 +3693,6 @@ packages:
         - HaskellNet-SSL < 0
         - IPv6Addr < 0
         - IPv6DB < 0
-        - JuicyPixels < 0
         - JuicyPixels-extra < 0
         - JuicyPixels-scale-dct < 0
         - LambdaHack < 0
@@ -3703,7 +3701,6 @@ packages:
         - Network-NineP < 0
         - QuasiText < 0
         - RSA < 0
-        - Rasterific < 0
         - RefSerialize < 0
         - SCalendar < 0
         - ShellCheck < 0


### PR DESCRIPTION
Checklist:
- [ x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x ] At least 30 minutes have passed since uploading to Hackage
- [x ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
