### PR TITLE
Reenable higher-leveldb tests on 8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4753,7 +4753,6 @@ skipped-tests:
     - github-types
     - graph-core
     - hexml-lens
-    - higher-leveldb
     - hspec-core
     - inflections
     - inline-r


### PR DESCRIPTION
Tests compile and pass on 8.6 from `0.5.0.2`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
