### PR TITLE
unblock cuda packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ENV HOME /home/stackage
 ENV LANG en_US.UTF-8
 
 # NOTE: also update debian-bootstrap.sh when cuda version changes
-ENV PATH /usr/local/cuda-8.0/bin:/opt/ghc/8.6.1/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV CUDA_PATH /usr/local/cuda-8.0
-ENV LD_LIBRARY_PATH=/usr/local/cuda-8.0/lib64:/usr/local/cuda-8.0/nvvm/lib64
+ENV PATH /usr/local/cuda-10.0/bin:/opt/ghc/8.6.1/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV CUDA_PATH /usr/local/cuda-10.0
+ENV LD_LIBRARY_PATH=/usr/local/cuda-10.0/lib64:/usr/local/cuda-10.0/nvvm/lib64
 
 ADD debian-bootstrap.sh /tmp/debian-bootstrap.sh
 RUN /tmp/debian-bootstrap.sh && rm /tmp/debian-bootstrap.sh

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -803,11 +803,12 @@ packages:
         - colour-accelerate < 0 # GHC 8.4 via base-4.11.0.0
         - lens-accelerate < 0 # GHC 8.4 via base-4.11.0.0
         - mwc-random-accelerate < 0 # GHC 8.4 via accelerate
-        - cuda < 0 # build failure with GHC 8.4
-        - cublas < 0 # build failure with GHC 8.4
-        - cusparse < 0 # build failure with GHC 8.4
-        - cusolver < 0 # build failure with GHC 8.4
-        - nvvm < 0 # build failure with GHC 8.4
+        - cuda
+        - cufft
+        - cublas
+        - cusparse
+        - cusolver
+        - nvvm
         - wide-word
 
     "Dan Burton <danburton.email@gmail.com> @DanBurton":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -268,12 +268,13 @@ cd /tmp \
 # NOTE: also update Dockerfile when cuda version changes
 # Install CUDA toolkit
 # The current version can be found at: https://developer.nvidia.com/cuda-downloads
-CUDA_PKG=8.0.61-1         # update this on new version
-CUDA_VER=${CUDA_PKG:0:3}
-CUDA_APT=${CUDA_VER/./-}
+CUDA_PKG=10.0.130-1
+CUDA_VER=10.0
+CUDA_APT=10-0
 
 pushd /tmp \
     && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_${CUDA_PKG}_amd64.deb \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub \
     && dpkg -i cuda-repo-ubuntu1604_${CUDA_PKG}_amd64.deb \
     && apt-get update -qq \
     && apt-get install -y cuda-drivers cuda-core-${CUDA_APT} cuda-cudart-dev-${CUDA_APT} cuda-cufft-dev-${CUDA_APT} cuda-cublas-dev-${CUDA_APT} cuda-cusparse-dev-${CUDA_APT} cuda-cusolver-dev-${CUDA_APT} \


### PR DESCRIPTION
Unblock cuda packages, and update to CUDA-10.0.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
