### PR TITLE
IPv6Addr-1.1.1 package is OK for GHC 8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3697,7 +3697,6 @@ packages:
         - HandsomeSoup < 0
         - HaskellNet < 0
         - HaskellNet-SSL < 0
-        - IPv6Addr < 0
         - IPv6DB < 0
         - JuicyPixels-extra < 0
         - JuicyPixels-scale-dct < 0


### PR DESCRIPTION
Checklist:
- [X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ X] At least 30 minutes have passed since uploading to Hackage
- [ X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
