### PR TITLE
simple-log-0.9.8 builds with ghc-8.6.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4311,7 +4311,6 @@ packages:
         - shake < 0
         - shake-language-c < 0
         - shikensu < 0
-        - simple-log < 0
         - simplest-sqlite < 0
         - slack-web < 0
         - slave-thread < 0


### PR DESCRIPTION
a bit offtop: `haskell-names-0.9.3` is also compatible with `ghc-8.6.1`, but it's disabled under `@phischu` maintainer. Is it ok to have two maintainers for one package? Should I just enabled it there?