### PR TITLE
Fix name: Change cmotoche to CristhianMotoche

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5432,7 +5432,7 @@ github-users:
         - jsl
         - sestrella
         - juanpaucar
-        - cmotoche
+        - CristhianMotoche
     scotty-web:
         - RyanGlScott
         - xich


### PR DESCRIPTION
I'm sorry. I was confused with the names and I place the initial part of my org email. :palm-face: @CristhianMotoche is the correct GitHub user name.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
