### PR TITLE
DAV is buildable within nightly EXCEPT for xml-hamlet

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3696,7 +3696,6 @@ packages:
         # out of bounds
         - Agda < 0
         - Allure < 0
-        - DAV < 0
         - DRBG < 0
         - HTF < 0
         - HaTeX < 0


### PR DESCRIPTION
xml-hamlet is buildable within nightly and should be pulled in without issue