### PR TITLE
re-enable apecs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4407,7 +4407,6 @@ packages:
         - ClustalParser < 0
         - Fin < 0
         - HPDF < 0
-        - apecs < 0
         - broadcast-chan < 0
         - df1 < 0
         - di-handle < 0


### PR DESCRIPTION
Builds with 8.6 now