### PR TITLE
Unblock matrix-static

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4424,7 +4424,6 @@ packages:
         - large-hashable < 0
         - libmpd < 0
         - llvm-hs-pretty < 0
-        - matrix-static < 0
         - med-module < 0
         - monad-recorder < 0
         - multistate < 0


### PR DESCRIPTION
matrix-static build failure on GHC 8.6 is fixed with 0.2

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
