### PR TITLE
restore the slack-web package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4275,7 +4275,6 @@ packages:
         - shake-language-c < 0
         - shikensu < 0
         - simplest-sqlite < 0
-        - slack-web < 0
         - slave-thread < 0
         - smtp-mail < 0
         - snap-blaze < 0


### PR DESCRIPTION
slack-web is now ok with ghc-8.6, restoring it.

Checklist:
- [x ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x ] At least 30 minutes have passed since uploading to Hackage
- [x ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

