### PR TITLE
Add sop-core

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1683,6 +1683,7 @@ packages:
     "Andres Löh <andres@well-typed.com> @kosmikus":
         - generics-sop
         - records-sop
+        - sop-core
 
     "Vivian McPhail <haskell.vivian.mcphail@gmail.com> @amcphail":
         - hmatrix-gsl-stats


### PR DESCRIPTION
Note that sop-core-0.4.0.0 is a new dependency of generics-sop-0.4.0.0, which has also been released today.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
