### PR TITLE
Reenable haskell-src-meta, interpolate, fmt

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4530,6 +4530,7 @@ skipped-tests:
     - ed25519 # QuickCheck, hlint and more
     - hackage-security # QuickCheck
     - haddock-library # base-compat-0.10.1, hspec-2.5.1
+    - haskell-src-meta # GHC 8.6, template-haskell
     - http-streams # via snap-server-1.1.0.0
     - indents # tasty 0.12 and tasty-hunit 0.10
     - ip # hspec 2.5 https://github.com/andrewthad/haskell-ip/issues/33

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3857,7 +3857,6 @@ packages:
         - flac < 0
         - flac-picture < 0
         - flow < 0
-        - fmt < 0
         - fold-debounce-conduit < 0
         - friday < 0
         - friday-juicypixels < 0
@@ -3898,7 +3897,6 @@ packages:
         - haskell-lsp < 0
         - haskell-lsp-types < 0
         - haskell-spacegoo < 0
-        - haskell-src-meta < 0
         - haskell-tools-ast < 0
         - haskell-tools-backend-ghc < 0
         - haskell-tools-builtin-refactorings < 0
@@ -3969,7 +3967,6 @@ packages:
         - influxdb < 0
         - inline-java < 0
         - inliterate < 0
-        - interpolate < 0
         - interpolatedstring-perl6 < 0
         - invertible < 0
         - invertible-grammar < 0


### PR DESCRIPTION


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] "On your own machine, in a new directory, you have successfully run the following set of commands" – I did not because `stack init` fails for haskell-src-meta due to its testsuite; in the build-constraints file I have disabled tests for it so it should be okay. Without tests at least haskell-src-meta builds fine.