### PR TITLE
Re-enable `persistent-mysql-haskell` with its deps.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8,7 +8,7 @@ cabal-format-version: "2.2"
 # Constraints for brand new builds
 packages:
 
-    "Erik Schnetter <schnetter@gmail.com> @eschnett": 
+    "Erik Schnetter <schnetter@gmail.com> @eschnett":
         - mpi-hs < 0 # https://github.com/commercialhaskell/stackage/issues/4068
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
@@ -4034,7 +4034,6 @@ packages:
         - morte < 0
         - multipart < 0
         - mwc-probability-transition < 0
-        - mysql-haskell < 0
         - mysql-haskell-nem < 0
         - mysql-haskell-openssl < 0
         - named < 0
@@ -4064,7 +4063,6 @@ packages:
         - parallel-io < 0
         - partial-order < 0
         - perf < 0
-        - persistent-mysql-haskell < 0
         - persistent-refs < 0
         - picosat < 0
         - pier < 0
@@ -4180,7 +4178,6 @@ packages:
         - swish < 0
         - tasty-dejafu < 0
         - tasty-stats < 0
-        - tcp-streams < 0
         - tcp-streams-openssl < 0
         - tdigest < 0
         - telegram-bot-simple < 0
@@ -4532,7 +4529,6 @@ skipped-tests:
     - ip # hspec 2.5 https://github.com/andrewthad/haskell-ip/issues/33
     - language-ecmascript # testing-feat 1.1.0.0
     - makefile # GHC 8.2
-    - mysql-haskell # tasty
     - next-ref # hspec 2.3
     - partial-order # HUnit 1.6
     - serialise


### PR DESCRIPTION
Overview:
- `mysql-haskell` and `tcp-streams` are required dependencies.
- latest version of all 3 packages run ok with: `stack build --resolver nightly --haddock --test --bench --no-run-benchmarks`

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks