### PR TITLE
Reenable servant-kotlin for GHC 8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4134,7 +4134,6 @@ packages:
         - servant-elm < 0
         - servant-exceptions < 0
         - servant-github-webhook < 0
-        - servant-kotlin < 0
         - servant-pandoc < 0
         - servant-quickcheck < 0
         - servant-rawm < 0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
