### PR TITLE
Build uri-bytestring again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4205,7 +4205,6 @@ packages:
         - tz < 0
         - tzdata < 0
         - union < 0
-        - uri-bytestring < 0
         - uri-templater < 0
         - urlpath < 0
         - users < 0
@@ -5118,7 +5117,6 @@ skipped-benchmarks:
     - type-of-html
     - ua-parser
     - unbound-generics
-    - uri-bytestring
     - vec
     - vinyl
     - websockets


### PR DESCRIPTION
As of v0.3.2.1, this seems to compile on nightly (benchmarks too). I'm attempting to get
yesod-auth-oauth2 back in Stackage, which requires hoauth2 (which I've fixed), which
requires uri-bytestring-aeson (which I'm fixing now), which requires uri-bytestring.

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
