### PR TITLE
switch maintainership of streaming, streaming-bytestring, and country…

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1957,9 +1957,13 @@ packages:
         - timerep
         - xml-conduit-parse
 
+    "Daniel Cartwright <chessai1996@gmail.com> @chessai":
+        - streaming
+        - streaming-bytestring
+        - country
+
     "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
         - SHA
-        - country
         - currency
         - data-ordlist
         - digits
@@ -1978,8 +1982,6 @@ packages:
         - protocol-buffers
         - protocol-buffers-descriptor
         - regex-pcre
-        - streaming
-        - streaming-bytestring
         - string-class
         - string-combinators
 


### PR DESCRIPTION
… from Kostiantyn Rybnikov to Daniel Cartwright

Checklist:
- [ X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ X ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I did not check the third box because the packages are already on Stackage.

I sent the following email to @k-bx last night (their reply is also attached):

![email-exchange](https://user-images.githubusercontent.com/18648043/47786618-af813400-dce2-11e8-9537-82899d8d1b40.png)

I am also a github maintainer of the `country` package, which I noticed was also on @k-bx's list, and, with his written consent, would like to take stackage maintainership thereof as well.



