### PR TITLE
add lens-typelevel to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1874,6 +1874,7 @@ packages:
         - hamilton
         - hmatrix-backprop
         - hmatrix-vector-sized
+        - lens-typelevel
         - one-liner-instances
         - prompt
         - tagged-binary


### PR DESCRIPTION
Adding *lens-typelevel* to stackage.  Thanks in advance! :)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
