### PR TITLE
Enable packages dependent on uri-bytestring-aeson

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -768,7 +768,7 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2
+        # - yesod-auth-oauth2 # via hoauth2
         # - yesod-markdown # http-types 0.12 via pandoc
         - yesod-paginator
 
@@ -2547,7 +2547,8 @@ packages:
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":
-        - hoauth2
+        []
+        # - hoauth2 # various deps out of date
 
     "Falko Peters <falko.peters@gmail.com> @informatikr":
         - scrypt
@@ -3058,7 +3059,7 @@ packages:
         # - printcess # lens 4.16
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        - wai-middleware-auth
+        # - wai-middleware-auth # via hoauth2
         # - hip # lens 4.16 via diagrams/chart
         - massiv
         - massiv-io

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -768,7 +768,7 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        # - yesod-auth-oauth2 # via hoauth2
+        - yesod-auth-oauth2
         # - yesod-markdown # http-types 0.12 via pandoc
         - yesod-paginator
 
@@ -2547,8 +2547,7 @@ packages:
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":
-        []
-        # - hoauth2 # various deps out of date
+        - hoauth2
 
     "Falko Peters <falko.peters@gmail.com> @informatikr":
         - scrypt
@@ -3059,7 +3058,7 @@ packages:
         # - printcess # lens 4.16
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        # - wai-middleware-auth # via hoauth2
+        - wai-middleware-auth
         # - hip # lens 4.16 via diagrams/chart
         - massiv
         - massiv-io
@@ -3229,7 +3228,7 @@ packages:
         - conduit-throttle
 
     "Simon Hafner <hafnersimon@gmail.com> @reactormonk":
-        - uri-bytestring-aeson < 0 # GHC 8.4 via base-4.11.0.0
+        - uri-bytestring-aeson
         - katip-scalyr-scribe < 0 # via katip
 
     "Sebastian Witte <woozletoff@gmail.com> @saep":


### PR DESCRIPTION
uri-bytestrying-aeson-0.1.0.7 has been updated to build successfully on
nightly. Resolving this unblocks hoauth2, which in turn unblocks others.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

  I didn't run the above steps exactly for every package enabled in this PR since it is difficult to do faithfully given the chain of dependencies. I did test each package with the nightly resolver separately as I was working through them. I hope it's OK that I let CI here be a final check for me. I apologize if I've missed something and this PR doesn't pass.
