### PR TITLE
add port-utils to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3013,6 +3013,7 @@ packages:
         - pg-transact
         - hspec-pg-transact
         - postgresql-simple-queue
+        - port-utils
 
     "Mahdi Dibaiee <mdibaiee@aol.com> @mdibaiee":
         - picedit < 0 # DependencyFailed (PackageName "cli")


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
