### PR TITLE
Unblock megaparsec

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2015,9 +2015,9 @@ packages:
     "Stack Builders stackage@stackbuilders.com @stackbuilders":
         - atomic-write
         - dbcleaner
-        - dotenv < 0.6.0.1 # https://github.com/commercialhaskell/stackage/issues/3955
+        - dotenv
         - hapistrano
-        - inflections < 0.4.0.4 # https://github.com/commercialhaskell/stackage/issues/3955
+        - inflections
         - stache
         - scalendar
 
@@ -3300,7 +3300,7 @@ packages:
         - first-class-patterns
         - relude
         - summoner
-        - tomland
+        - tomland < 0 # megaparsec 7
 
     "Lorenz Moesenlechner <moesenle@gmail.com> @moesenle":
         - servant-websockets
@@ -3818,7 +3818,6 @@ packages:
         - cryptocompare < 0
         - cryptonite-openssl < 0
         - csg < 0
-        - cue-sheet < 0
         - curl-runnings < 0
         - cyclotomic < 0
         - czipwith < 0
@@ -3829,10 +3828,7 @@ packages:
         - deferred-folds < 0
         - dejafu < 0
         - derulo < 0
-        - dhall < 0
         - dhall-bash < 0
-        - dhall-json < 0
-        - dhall-text < 0
         - dhall-to-cabal < 0
         - diagrams-solve < 0
         - discrimination < 0
@@ -3952,7 +3948,6 @@ packages:
         - hslua < 0
         - hslua-aeson < 0
         - hslua-module-text < 0
-        - hspec-megaparsec < 0
         - hspec-need-env < 0
         - hspec-wai-json < 0
         - hsx-jmacro < 0
@@ -4168,7 +4163,6 @@ packages:
         - sparkle < 0
         - speculation < 0
         - squeal-postgresql < 0
-        - stache < 0
         - stack < 0
         - statestack < 0
         - static-text < 0
@@ -4304,15 +4298,6 @@ packages:
         - hspec-core < 2.5.6
         - hspec-discover < 2.5.6
         - hspec-meta < 2.5.6
-
-        # https://github.com/commercialhaskell/stackage/issues/3955
-        - megaparsec < 7.0.0
-        - hspec-megaparsec
-        - modern-uri
-        - cue-sheet
-        - stache
-        - neat-interpolation < 0.3.2.3
-        - language-docker < 8.0.0
 
         # https://github.com/commercialhaskell/stackage/issues/4053
         - yaml < 0.11


### PR DESCRIPTION
see #3955

This PR blocks `tomland` in order to unblock a number of other packages that were waiting on `megaparsec` to be unconstrained.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

^ I have tested `dhall` only, the other packages I have not tested.