### PR TITLE
Unblock simple-vec3 benchmarks

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5223,7 +5223,6 @@ skipped-benchmarks:
     - scientific
     - semver
     - sexp-grammar
-    - simple-vec3
     - sorted-list
     - sourcemap
     - stache


### PR DESCRIPTION
simple-vec3-0.4.0.9 supports GHC 8.6 for benchmarks

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
