### PR TITLE
restore slack-web

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2352,7 +2352,7 @@ packages:
     "Emmanuel Touzery <etouzery@gmail.com> @emmanueltouzery":
         - app-settings
         - hsexif
-        # - slack-web # https://github.com/jpvillaisaza/slack-web/issues/67
+        - slack-web
 
     "Nickolay Kudasov <nickolay.kudasov@gmail.com> @fizruk":
         - http-api-data


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

A new version of slack-web was published with fixes, it can be enabled again now.