### PR TITLE
Reenable dunai

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4243,7 +4243,6 @@ packages:
         - df1 < 0
         - di-handle < 0
         - dimensional < 0
-        - dunai < 0
         - exinst < 0
         - extensible < 0
         - fgl < 0


### PR DESCRIPTION
Dunai has released version 0.5.1 which is compatible with current stackage.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
