### PR TITLE
Re-enable my (Mark Karpov's) packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3739,7 +3739,6 @@ packages:
         - HaskellNet < 0
         - HaskellNet-SSL < 0
         - IPv6DB < 0
-        - JuicyPixels-extra < 0
         - JuicyPixels-scale-dct < 0
         - LambdaHack < 0
         - Network-NineP < 0
@@ -3871,8 +3870,6 @@ packages:
         - file-modules < 0
         - filecache < 0
         - find-clumpiness < 0
-        - flac < 0
-        - flac-picture < 0
         - flow < 0
         - fold-debounce-conduit < 0
         - friday < 0
@@ -3883,7 +3880,6 @@ packages:
         - generic-xmlpickler < 0
         - generics-eot < 0
         - ghc-parser < 0
-        - ghc-syntax-highlighter < 0
         - ghcjs-base-stub < 0
         - gi-gtk-hs < 0
         - gio < 0
@@ -3966,7 +3962,6 @@ packages:
         - hxt-pickle-utils < 0
         - hyperloglog < 0
         - hyraxAbif < 0
-        - identicon < 0
         - ihaskell < 0
         - ihaskell-hvega < 0
         - incremental-parser < 0
@@ -4003,7 +3998,6 @@ packages:
         - lackey < 0
         - lambdabot-core < 0
         - lambdabot-irc-plugins < 0
-        - lame < 0
         - language-c-quote < 0
         - language-puppet < 0
         - learn-physics < 0
@@ -4029,10 +4023,6 @@ packages:
         - mime-mail-ses < 0
         - minio-hs < 0
         - miso < 0
-        - mmark < 0
-        - mmark-cli < 0
-        - mmark-ext < 0
-        - modern-uri < 0
         - moesocks < 0
         - monad-metrics < 0
         - mongoDB < 0
@@ -4107,8 +4097,6 @@ packages:
         - rebase < 0
         - ref-fd < 0
         - registry < 0
-        - req < 0
-        - req-conduit < 0
         - req-url-extra < 0
         - require < 0
         - rerebase < 0
@@ -4216,7 +4204,6 @@ packages:
         - wai-slack-middleware < 0
         - wai-transformers < 0
         - warp-tls-uid < 0
-        - wave < 0
         - web-plugins < 0
         - webdriver < 0
         - webex-teams-api < 0
@@ -4991,7 +4978,6 @@ skipped-benchmarks:
     - binary-tagged
     - Earley
     - IntervalMap
-    - JuicyPixels-extra
     - ad
     - attoparsec
     - backprop


### PR DESCRIPTION
All the packages should work with GHC 8.6.2 now, let's try to re-enable them.
