### PR TITLE
Added back in fixed packages and downstream dependencies based on vector-sized, criterion

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4932,6 +4932,12 @@ expected-haddock-failures:
     - classy-prelude-yesod
     - haddock-library # https://github.com/fpco/stackage/issues/3236
 
+    # Modules use compiler plugins
+    # https://github.com/haskell/haddock/issues/900
+    - bins
+    - emd
+    - hmatrix-backprop
+
 # end of expected-haddock-failures
 
 # For packages with haddock issues

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3794,7 +3794,6 @@ packages:
         - bench < 0
         - bhoogle < 0
         - binary-orphans < 0
-        - bins < 0
         - bitcoin-api < 0
         - bitcoin-api-extra < 0
         - bitcoin-block < 0
@@ -3865,7 +3864,6 @@ packages:
         - edit < 0
         - ekg-core < 0
         - ekg-statsd < 0
-        - emd < 0
         - enummapset < 0
         - envy < 0
         - event < 0
@@ -3913,7 +3911,6 @@ packages:
         - gym-http-api < 0
         - hOpenPGP < 0
         - hailgun < 0
-        - hamilton < 0
         - handwriting < 0
         - happstack-server < 0
         - hasbolt < 0
@@ -3952,8 +3949,6 @@ packages:
         - hledger-lib < 0
         - hledger-ui < 0
         - hledger-web < 0
-        - hmatrix-backprop < 0
-        - hmatrix-vector-sized < 0
         - hoopl < 0
         - hopenpgp-tools < 0
         - hpqtypes < 0
@@ -4195,7 +4190,6 @@ packages:
         - users < 0
         - users-postgresql-simple < 0
         - users-test < 0
-        - vector-sized < 0
         - vector-space < 0
         - vectortiles < 0
         - wai-cli < 0
@@ -4986,7 +4980,6 @@ skipped-benchmarks:
     - IntervalMap
     - ad
     - attoparsec
-    - backprop
     - binary-list
     - binary-tagged
     - bit-stream


### PR DESCRIPTION
**Important Caveat**: Due to https://github.com/haskell/haddock/issues/900, some of these packages do not build haddocks on ghc-8.6.  Let me know if it is preferred to leave this packages off of stackage for now, and I'll re-submit a PR excluding them.

Thank you again

Previously waiting on vector-sized
-----------------------

*   bins
*   emd
*   hamilton
*   hmatrix-backprop
*   hmatrix-vector-sized
*   vector-sized (https://github.com/expipiplus1/vector-sized/issues/63)

Previously waiting on criterion
--------------------

*   backprop

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage): **SEE CAVEAT**

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
