### PR TITLE
Re-enables wave (et al.) for 8.6.2 nightlies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2351,10 +2351,10 @@ packages:
         - req
         - req-conduit
         - cue-sheet
-        - wave < 0 # mrkkrp/wave#9
-        - flac < 0 # depends on wave
-        - flac-picture < 0 # depends on flac
-        - lame < 0 # depends on wave
+        - wave
+        - flac
+        - flac-picture
+        - lame
         - path
         - forma
         - stache


### PR DESCRIPTION
Previously this was failing due to a critical bug in GHC 8.6.1 (cf. mrkkrp/wave#9).

Now that the nightlies are on GHC 8.6.2 it should be good to re-add.