### PR TITLE
QuickCheck 2.12, Servant 0.15, http-api-data-0.4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3544,9 +3544,6 @@ packages:
         - servant-auth-swagger
         - servant-auth-docs
         - servant-elm
-        - servant-streaming
-        - servant-streaming-client
-        - servant-streaming-server
         - streaming-wai
         - systemd
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3834,38 +3834,11 @@ packages:
         - Win32 == 2.6.1.0
 
     "Stackage upper bounds":
-        # https://github.com/commercialhaskell/stackage/issues/3949
-        - QuickCheck < 2.12
-        - hspec < 2.5.6
-        - hspec-core < 2.5.6
-        - hspec-discover < 2.5.6
-        - hspec-meta < 2.5.6
-        - hspec-contrib < 0.5.1
-        - cassava-conduit < 0.5.1 # https://github.com/commercialhaskell/stackage/pull/4139#issuecomment-443035843
-
-        # https://github.com/commercialhaskell/stackage/issues/4053
-        - yaml < 0.11
-
         # https://github.com/commercialhaskell/stackage/issues/4056
         - postgresql-simple < 0.6
 
         # https://github.com/commercialhaskell/stackage/issues/4073
         - pretty-show < 1.9
-
-        # https://github.com/commercialhaskell/stackage/issues/4130
-        - servant < 0.15
-        - servant-client < 0.15
-        - servant-client-core < 0.15
-        - servant-foreign < 0.15
-        - servant-server < 0.15
-        - servant-docs < 0.11.3
-        - servant-js < 0.9.4
-        - servant-mock < 0.8.5
-        - servant-swagger < 1.1.7
-        - servant-yaml < 0.1.0.1
-
-        # https://github.com/commercialhaskell/stackage/issues/4131
-        - http-api-data < 0.4
 
         # https://github.com/commercialhaskell/stackage/issues/4156
         - base-unicode-symbols < 0.2.3


### PR DESCRIPTION
Wanted to see where we're at with https://github.com/commercialhaskell/stackage/issues/3949 after two months.

QuickCheck-2.12.6.1 is out of bounds for:
- [x] fused-effects-0.1.2.0 (>=2.7 && < 2.12). Rob Rix <robrix@github.com> @robrix. @robrix. Used by: test-suite
- [ ] hw-balancedparens-0.2.0.2 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-bits-0.7.0.5 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-excess-0.2.0.2 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-prim-0.6.2.22 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-rankselect-0.12.0.4 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-rankselect-base-0.3.2.1 (>=2.10 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] psqueues-0.2.7.0 (>=2.7 && < 2.12). Jasper Van der Jeugt @jaspervdj. @jaspervdj. Used by: test-suite
- [ ] pure-zlib-0.6.4 (>=2.7 && < 2.12). John Ky newhoggy@gmail.com @newhoggy. @GaloisInc. Used by: test-suite

hspec-2.6.0 (Simon Hengel <sol@typeful.net> @sol) is out of bounds for:
- [ ] antiope-s3-6.1.5 (>=2.4 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @arbor. Used by: test-suite
- [ ] cayley-client-0.4.7 (>=2.1.10 && < 2.6). Michel Boucey <michel.boucey@gmail.com> @MichelBoucey. @MichelBoucey. Used by: test-suite
- [ ] clay-0.13.1 (>=2.2.0 && < 2.6). Sebastiaan Visser <haskell@fvisser.nl> @sebastiaanvisser. @sebastiaanvisser. Used by: test-suite
- [ ] codec-rpm-0.2.2 (>=2.4.4 && < 2.6). Jens Petersen <juhpetersen@gmail.com> @juhp. @weldr. Used by: test-suite
- [ ] hw-balancedparens-0.2.0.2 (>=2.2 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-excess-0.2.0.2 (>=2.3 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-hspec-hedgehog-0.1.0.5 (>=2.4 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: library, test-suite
- [ ] hw-json-0.9.0.1 (==2.5.*). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-prim-0.6.2.22 (>=2.4 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-rankselect-0.12.0.4 (>=2.4 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-rankselect-base-0.3.2.1 (>=2.2 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite
- [ ] hw-streams-0.0.0.8 (>=2.4 && < 2.6). John Ky newhoggy@gmail.com @newhoggy. @haskell-works. Used by: test-suite

hspec-discover-2.6.0 is out of bounds for:
- [ ] clay-0.13.1 (>=2.2.0 && < 2.6). Sebastiaan Visser <haskell@fvisser.nl> @sebastiaanvisser. @sebastiaanvisser. Used by: test-suite

http-api-data-0.4 (Nickolay Kudasov <nickolay.kudasov@gmail.com> @fizruk) is out of bounds for:
- [ ] language-puppet-1.4.1 (>=0.2 && < 0.4). Simon Marechal <bartavelle@gmail.com> @bartavelle. @bartavelle. Used by: library

servant-0.15 (Haskell Servant <jkarni@gmail.com>) is out of bounds for:
- [ ] language-puppet-1.4.1 (>=0.9 && < 0.15). Simon Marechal <bartavelle@gmail.com> @bartavelle. @bartavelle. Used by: library

servant-client-0.15 (Haskell Servant <jkarni@gmail.com>) is out of bounds for:
- [ ] language-puppet-1.4.1 (>=0.9 && < 0.15). Simon Marechal <bartavelle@gmail.com> @bartavelle. @bartavelle. Used by: library

servant-foreign-0.15 (Haskell Servant <jkarni@gmail.com>) is out of bounds for:
- [x] servant-ruby-0.8.0.2 (>=0.9 && < 0.12). Hardy Jones <jones3.hardy@gmail.com> @joneshf. @joneshf. Used by: library

yaml-0.11.0.0 (Michael Snoyman michael@snoyman.com @snoyberg) is out of bounds for:
- [ ] language-puppet-1.4.1 (>=0.8.31 && < 0.11). Simon Marechal <bartavelle@gmail.com> @bartavelle. @bartavelle. Used by: library, executable
- [ ] yesod-bin-1.6.0.3 (>=0.8 && < 0.11). Michael Snoyman michael@snoyman.com @snoyberg. @snoyberg. Used by: executable
