### PR TITLE
Added bulletproofs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2769,7 +2769,7 @@ packages:
         - repline
         - picosat < 0
         - aos-signature
-        - bulletproofs < 0 # not published to Hackage yet (11 Nov. 18)
+        - bulletproofs
         - pedersen-commitment
         - merkle-tree
 


### PR DESCRIPTION
Should be able to build the `bulletproofs` package on the latest nightly resolver now. 

http://hackage.haskell.org/package/bulletproofs-0.4.0

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
