### PR TITLE
Re-enable yesod-auth-hashdb

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1102,7 +1102,7 @@ packages:
         - mysql-simple
         - sphinx
         - xmlhtml < 0 # GHC 8.4 via hspec-2.5.0
-        - yesod-auth-hashdb < 0
+        - yesod-auth-hashdb
 
     "Toralf Wittner <tw@dtex.org> @twittner":
         - bytestring-conversion


### PR DESCRIPTION
Version 1.7.1 just released

[ Checklist OK with nightly-2018-11-19 ]
