### PR TITLE
Add nonemptymap/hinfo

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7,6 +7,10 @@ cabal-format-version: "2.2"
 
 # Constraints for brand new builds
 packages:
+    "Christopher Davenport <chris@christopherdavenport.tech> @ChristopherDavenport":
+        - nonemptymap
+        - hinfo
+    
     "Edward Wastell <edward@wastell.co.uk> @edwardwas":
         - TotalMap
         - sized-grid


### PR DESCRIPTION
nonemptymap is a library in the containers style for nonempty maps. hinfo allows for quick information about a haskell project, currently optimized for hpack but additional features in the future.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
