### PR TITLE
Enable `dhall-bash`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -881,7 +881,7 @@ packages:
         - morte < 0
         - bench
         - dhall
-        - dhall-bash < 0
+        - dhall-bash
         - dhall-json
         # - dhall-nix # deriving-compat via hnix
         - dhall-text


### PR DESCRIPTION
`dhall-bash-1.17.0` now supports the latest version of `containers`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
