### PR TITLE
Drop support for `morte`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -878,7 +878,6 @@ packages:
         - pipes-safe
         - turtle
         - foldl
-        - morte < 0
         - bench
         - dhall
         - dhall-bash < 0


### PR DESCRIPTION
I added `morte` a while ago at user request, but I would like to
drop support for it, given that the `dhall` project has
superseded `morte`.  Also, `morte` has only one
reverse dependency (that I authored, not on Stackage), so
dropping Stackage support for `morte` is non-disruptive.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
