### PR TITLE
Re-enable hoauth2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -792,7 +792,7 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2
+        # - yesod-auth-oauth2 # needs to allow aeson-1.4
         # - yesod-markdown # http-types 0.12 via pandoc
         - yesod-paginator
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -792,7 +792,7 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        # - yesod-auth-oauth2 # via hoauth2
+        - yesod-auth-oauth2
         # - yesod-markdown # http-types 0.12 via pandoc
         - yesod-paginator
 
@@ -2584,8 +2584,7 @@ packages:
         - wai-session-postgresql
 
     "Haisheng Wu <freizl@gmail.com> @freizl":
-        []
-        # - hoauth2 # various deps out of date
+        - hoauth2
 
     "Falko Peters <falko.peters@gmail.com> @informatikr":
         - scrypt
@@ -3103,7 +3102,7 @@ packages:
         # - printcess # lens 4.16
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        # - wai-middleware-auth # via hoauth2
+        - wai-middleware-auth
         # - hip # lens 4.16 via diagrams/chart
         - massiv
         - massiv-io


### PR DESCRIPTION
Fixed in freizl/hoauth2#100, released as v1.8.3.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
