### PR TITLE
Add hpack-dhall

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -59,6 +59,7 @@ packages:
     "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
         - siggy-chardust
         - detour-via-sci
+        - hpack-dhall
 
     "Matthew Ahrens <matt.p.ahrens@gmail.com> @mpahrens":
         - forkable-monad


### PR DESCRIPTION
Adds `hpack-dhall` to stackage nightly.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

When I did the above check I had to make the following substitution, see https://github.com/BlockScope/hpack-dhall/issues/26 for more detail on why this was necessary:

```
-- $ rm -f stack.yaml && stack init --resolver nightly --solver
++ $ rm -f stack.yaml && stack init --resolver nightly --solver --ignore-subdirs
```
