### PR TITLE
Re-enable filecache

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2347,7 +2347,7 @@ packages:
     "Simon Marechal <bartavelle@gmail.com> @bartavelle":
         - compactmap
         - stateWriter < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - filecache < 0
+        - filecache
         - pcre-utils
         - strict-base-types
         - withdependencies < 0


### PR DESCRIPTION
0.4.1 should build alright with ghc-8.6.2

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack filecache-0.4.1
      cd $package-0.4.1
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
