### PR TITLE
Re-enable dejafu, hunit-dejafu, tasty-dejafu

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2188,9 +2188,9 @@ packages:
     "Michael Walker <mike@barrucadu.co.uk> @barrucadu":
         - both
         - concurrency
-        - dejafu < 0
-        - hunit-dejafu < 0
-        - tasty-dejafu < 0
+        - dejafu
+        - hunit-dejafu
+        - tasty-dejafu
         - irc-ctcp
         - irc-conduit
         - irc-client


### PR DESCRIPTION
These now build against nightly.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
