### PR TITLE
hide filemanip instead of Glob in stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4930,7 +4930,7 @@ hide:
 - language-c # conflicts with modules in language-c-quote
 - gl # conflicts with modules in OpenGLRaw
 - svg-tree # conflicts with Graphics.Svg in svg-builder
-- Glob # conflicts with System.FilePath.Glob in filemanip
+- filemanip # conflicts with System.FilePath.Glob in Glob
 - nanospec # conflicts with Test.Hspec in hspec
 - HTF # conflicts with Test.Framework in test-framework
 - courier # conflicts with Network.Transport in network-transport


### PR DESCRIPTION
The [filemanip](http://hackage.haskell.org/package/filemanip) and [Glob](http://hackage.haskell.org/package/Glob) packages both provide the System.FilePath.Glob module, and presumably this is why Glob is marked as a hidden package in build-constraints.yaml. This has required tests to be disabled for several packages, such as multiset, makefile, and [hledger-lib even though it uses PackageImports to explicitly select Glob](https://github.com/commercialhaskell/stackage/issues/4202). 

I suggest filemanip be hidden instead. It's older, unmaintained, and has [60](http://packdeps.haskellers.com/reverse/filemanip) reverse deps, while Glob is actively maintained and has [112](http://packdeps.haskellers.com/reverse/Glob).