### PR TITLE
Re-enable approximate, compensated, and hyperloglog

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -666,14 +666,14 @@ packages:
         - adjunctions
         - algebra < 0
         - ansi-wl-pprint
-        - approximate < 0
+        - approximate
         - bifunctors
         - bits
         - bound
         - bytes
         - charset
         - comonad
-        - compensated < 0
+        - compensated
         - compressed < 0
         - concurrent-supply
         - constraints
@@ -693,7 +693,7 @@ packages:
         - half
         - heaps
         - hybrid-vectors
-        - hyperloglog < 0
+        - hyperloglog
         - hyphenation
         - integration
         - intern


### PR DESCRIPTION
The dependency that was blocking these packages (`safecopy`) now supports GHC 8.6.