### PR TITLE
Add dbaynard packages (ucam-webauth*)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3731,6 +3731,11 @@ packages:
     "Josef Thorne <joseft.168@gmail.com> @Grendel-Grendel-Grendel":
         - focuslist
 
+    "David Baynard <haskell@baynard.me> @dbaynard":
+        - time-qq # see christian-marie/time-qq#3
+        - ucam-webauth
+        - ucam-webauth-types
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
- ucam-webauth-types (new to hackage)
- ucam-webauth (new to hackage)
- time-qq (dependency, with permission of maintainer christian-marie/time-qq#3 )

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

    - [x] ucam-webauth-types-0.1.0.0
    - [x] time-qq-0.0.1.0
    - [x] ucam-webauth-0.1.0.0

    This last package needed the above two packages adding as extra-deps