### PR TITLE
Add `kind-generics-th` to Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1144,6 +1144,7 @@ packages:
         - generics-mrsop
         - kind-apply
         - kind-generics
+        - kind-generics-th
 
     "Matvey Aksenov <matvey.aksenov@gmail.com> @supki":
         - terminal-size


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

  This requires the nightly repo to update the `kind-apply` and `kind-generics` packages to the latest version too. Otherwise the package will not build. I was not sure about how to handle this case.