### PR TITLE
Fixed issues with registry

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4446,7 +4446,6 @@ expected-test-failures:
     - perf # https://github.com/fpco/stackage/pull/2859
     - picosat # https://github.com/fpco/stackage/pull/2382
     - pkcs10 # https://github.com/fcomb/pkcs10-hs/issues/2
-    - registry # https://github.com/commercialhaskell/stackage/pull/4160
     - sourcemap # https://github.com/chrisdone/sourcemap/issues/3
     - squeal-postgresql # https://github.com/fpco/stackage/issues/3180
     - text-icu # https://github.com/bos/text-icu/issues/32


### PR DESCRIPTION
Please re-enable registry in the next LTS.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
