### PR TITLE
xlsx-tabular dependency no longer has problem

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2684,7 +2684,7 @@ packages:
         - free-vl
 
     "Kazuo Koga <obiwanko@me.com> @kkazuo":
-        - xlsx-tabular < 0 # DependencyFailed (PackageName "xlsx")
+        - xlsx-tabular
 
     "Mikhail Glushenkov <mikhail.glushenkov@gmail.com> @23Skidoo":
         - Cabal


### PR DESCRIPTION
I am able to build xlsx-tabular using nightly-2018-12-12. The dependency xlsx is already in nightly so I assume the problem has been resolved.


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
