### PR TITLE
Restore cuckoo-filter

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3612,7 +3612,7 @@ packages:
 
     "Chris Coffey <chris@foldl.io> @ChrisCoffey":
         - servant-tracing
-        - cuckoo-filter < 0 # adinapoli/cuckoofilter#1
+        - cuckoo-filter
         - confcrypt
 
     "Rick Owens <rick@owensmurray.com> @owensmurray":


### PR DESCRIPTION
Added `cuckoo-filter` back after the tests were fixed for 8.6.1.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
