### PR TITLE
Update constraints

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3946,7 +3946,7 @@ package-flags:
         containers: true
 
     mintty:
-        win32-2-5: true
+        win32-2-5-3: true
 
     cassava:
         bytestring--lt-0_10_4: false

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3884,9 +3884,6 @@ package-flags:
         simplelocalnet: true
         p2p: true
 
-    logfloat:
-        splitbase: true
-
     curl:
         new-base: true
 
@@ -3906,10 +3903,6 @@ package-flags:
     hxt-relaxng:
         network-uri: true
 
-    pandoc:
-        https: true
-        old-locale: false
-
     text:
         integer-simple: false
 
@@ -3918,12 +3911,6 @@ package-flags:
 
     time-locale-compat:
         old-locale: false
-
-    th-data-compat:
-        template-haskell-210: false
-        template-haskell-212: true
-    th-reify-compat:
-        template-haskell-210: false
 
     HsOpenSSL:
         fast-bignum: false


### PR DESCRIPTION
The default checklist doesn't look to be applicable to this PR (so I've removed it). The main part of this change is about removing no longer existing cabal flags. I'm not sure if we need `mintty` flag - it's enabled by default and the previous version worked the same way and it looks like the only reason we have it now is because it was disabled before f9491d18 - probably it's better to remove it?