### PR TITLE
Re-enable posix-paths.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2189,7 +2189,7 @@ packages:
         - network-house
         - reinterpret-cast
         - shared-memory
-        - posix-paths < 0 # GHC 8.4 via base-4.11.0.0
+        - posix-paths
         # As dependencies of packages above
         - attoparsec-binary
 


### PR DESCRIPTION
posix-paths-0.2.1.6 is compatible with GHC 8.6.


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks