### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -275,11 +275,8 @@ packages:
         - fft
         - carray
         - netlib-ffi
-        - netlib-carray
         - blas-ffi
-        - blas-carray
         - lapack-ffi
-        - lapack-carray
         - lapack-ffi-tools
         # Not a maintainer
         - ix-shapable
@@ -3876,9 +3873,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/4241
         - Glob < 0.10
-
-        # https://github.com/commercialhaskell/stackage/issues/4243
-        - blas-ffi < 0.1
 
 # end of packages
 


### PR DESCRIPTION
remove netlib-carray, blas-carray, lapack-carray
I will not maintain them for a while. They turned out to be less useful than thought initially.
Also removed version bound on blas-ffi.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
