### PR TITLE
Reenable text-show and text-show-instances

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2118,8 +2118,8 @@ packages:
         - monad-par-extras
         - mtl-compat
         - proxied
-        - text-show < 0
-        - text-show-instances < 0
+        - text-show
+        - text-show-instances
         - th-abstraction
         - thread-local-storage
 


### PR DESCRIPTION
For some reason, I wasn't notified that these were held back, so this PR reenables them.