### PR TITLE
re-enable postgresql-typed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3172,7 +3172,7 @@ packages:
         - viewprof < 0 # brick-0.38 commercialhaskell/stackage#3839 vty-5.22 commercialhaskell/stackage#3840
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
-        - postgresql-typed < 0
+        - postgresql-typed
         - invertible
         - ztail
         - zip-stream


### PR DESCRIPTION
current version (0.5.3.0) builds fine on lts-13.1 and nightly-2018-12-31

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
