### PR TITLE
Re-enable closed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3628,7 +3628,7 @@ packages:
         - codec-beam
 
     "Chris Parks <christopher.daniel.parks@gmail.com> @cdparks":
-        - closed < 0
+        - closed
 
     "Chris Coffey <chris@foldl.io> @ChrisCoffey":
         - servant-tracing


### PR DESCRIPTION
`closed-0.2.0.1` builds on latest nightly now

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
