### PR TITLE
Re-add esqueleto

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2136,6 +2136,7 @@ packages:
         - smtp-mail
         - liboath-hs < 0 # GHC 8.4 via inline-c
         - servant-quickcheck < 0
+        - esqueleto
 
     "Matthew Pickering <matthewtpickering@gmail.com> @mpickering":
         - refact


### PR DESCRIPTION
I've been added as a maintainer to the Esqueleto package :smile:

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I've done the last step, but I get a Haddock failure (cf [esqueleto#110](https://github.com/bitemyapp/esqueleto/issues/110)). Not sure the best way to proceed here, as it seems to be unrelated to any of the Haddocks in the package itself.
