### PR TITLE
Take over enummapset, which is now fixed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -261,7 +261,7 @@ packages:
         - probability
         - sample-frame
         - sample-frame-np
-        - set-cover
+        - set-cover < 0
         - sox
         - soxlib
         - spreadsheet

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -137,11 +137,12 @@ packages:
 
     "Mikolaj Konarski <mikolaj.konarski@funktory.com> @Mikolaj":
         - sdl2-ttf
+        - enummapset
         - assert-failure
         - minimorph
         - miniutter
-        - LambdaHack < 0
-        - Allure < 0
+        - LambdaHack
+        - Allure
 
     "Jürgen Keck <jhyphenkeck@gmail.com> @j-keck":
         - wreq-stringless < 0
@@ -260,7 +261,7 @@ packages:
         - probability
         - sample-frame
         - sample-frame-np
-        - set-cover < 0
+        - set-cover
         - sox
         - soxlib
         - spreadsheet
@@ -3825,7 +3826,6 @@ packages:
     "Build failure with GHC 8.6":
         # out of bounds
         - SCalendar < 0
-        - enummapset < 0
         - haskell-tools-builtin-refactorings < 0
         - hpqtypes < 0
         - lrucache < 0


### PR DESCRIPTION
and enable my two packages that depend on it. I know at least one more package on Stackage, set-cover, was broken by enummapset and may now also run fine, so let me optimistically enable it and see what CI says.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
