### PR TITLE
dimensional-1.3 on hackage builds on GHC-8.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4695,7 +4695,6 @@ skipped-benchmarks:
     - data-has
     - data-msgpack
     - dbus
-    - dimensional
     - discrimination
     - do-list
     - edit-distance


### PR DESCRIPTION
dimensional-1.3 builds against GHC-8.6.3.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
