### PR TITLE
Re-enable lrucache

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3828,7 +3828,6 @@ packages:
         - SCalendar < 0
         - haskell-tools-builtin-refactorings < 0
         - hpqtypes < 0
-        - lrucache < 0
         - primitive-extras < 0
         - ref-fd < 0
         - stm-hamt < 0


### PR DESCRIPTION
I am not the owner of this package, but I want to use it. Problems with containers-0.6.1 have been fixed in lrucache-1.2.0.1.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
