### PR TITLE
Update build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -264,7 +264,7 @@ packages:
         - probability
         - sample-frame
         - sample-frame-np
-        - set-cover < 0
+        - set-cover
         - sox
         - soxlib
         - spreadsheet


### PR DESCRIPTION
re-enable set-cover, should work now since enummapset is adapted to GHC-8.6.3

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
