### PR TITLE
Remove hpc-coveralls flag setting for scotty

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3997,9 +3997,6 @@ package-flags:
     safe-money:
         serialise: false
 
-    scotty:
-        hpc-coveralls: false
-
     # https://github.com/fpco/stackage/issues/3619
     transformers-compat:
         five-three: true


### PR DESCRIPTION
`scotty-0.11.3` no longer depends on `hpc-coveralls` and has removed the `-fhpc-coveralls` flag as a result.