### PR TITLE
Reenable hw-hspec-hedgehog and derivative projects

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2774,7 +2774,7 @@ packages:
         - hw-eliasfano
         - hw-excess
         - hw-hedgehog
-        - hw-hspec-hedgehog < 0 # hspec 2.6
+        - hw-hspec-hedgehog
         - hw-int
         - hw-ip
         - hw-fingertree < 0 # build failure with GHC 8.4
@@ -4097,7 +4097,6 @@ skipped-tests:
     - haddock-library # base-compat-0.10.1, hspec-2.5.1
     - haskell-src-meta # GHC 8.6, template-haskell
     - http-streams # via snap-server-1.1.0.0
-    - hw-mquery # needs hw-hspec-hedgehog which needs hspec<2.6
     - indents # tasty 0.12 and tasty-hunit 0.10
     - ip # hspec 2.5 https://github.com/andrewthad/haskell-ip/issues/33
     - language-ecmascript # testing-feat 1.1.0.0
@@ -4139,19 +4138,6 @@ skipped-tests:
     - hw-rankselect-base # via hspec-2.6.0
     - hw-streams # via hspec-2.6.0
     - clay # via hspec-discover-2.6.0
-    - antiope-s3 # via hw-hspec-hedgehog
-    - arbor-lru-cache # via hw-hspec-hedgehog
-    - asif # via hw-hspec-hedgehog
-    - bits-extra # via hw-hspec-hedgehog
-    - hw-bits # via hw-hspec-hedgehog
-    - hw-dsv # via hw-hspec-hedgehog
-    - hw-fingertree-strict # via hw-hspec-hedgehog
-    - hw-ip # via hw-hspec-hedgehog
-    - hw-prim # via hw-hspec-hedgehog
-    - hw-rankselect # via hw-hspec-hedgehog
-    - hw-rankselect-base # via hw-hspec-hedgehog
-    - hw-simd # via hw-hspec-hedgehog
-    - hw-streams # via hw-hspec-hedgehog
     # another batch per removal of hedgehog
     - axel # via hedgehog
     - bsb-http-chunked # via hedgehog


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Note: I have run those commands to verify that hw-hspec-hedgehog itself works, but not those related projects. I can push more commits to disable them again if CI fails.