### PR TITLE
Re-enable cabal-file-th

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1712,7 +1712,7 @@ packages:
         - text-manipulate
 
     "Nick Partridge <nkpart@gmail.com> @nkpart":
-        - cabal-file-th < 0 # build failure with GHC 8.4
+        - cabal-file-th
 
     "Gershom Bazerman <gershomb@gmail.com> @gbaz":
         - jmacro < 0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Because this project has a cabal file in the test folder, `stack init --resolver nightly` picks up `test` as a package. It isn't, the cabal file is just test data. When I manually remove `test` from the list of packages in the generated stack yaml the project builds and tests successfully.