### PR TITLE
Bump cabal-format-version to 2.4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3,7 +3,7 @@ ghc-major-version: "8.6"
 # This affects which version of the Cabal file format we allow. We
 # should ensure that this is always no greater than the version
 # supported by the most recent cabal-install and Stack releases.
-cabal-format-version: "2.2"
+cabal-format-version: "2.4"
 
 # Constraints for brand new builds
 packages:


### PR DESCRIPTION
Assuming that `stack` can handle Cabal 2.4 packages.

stackage-curator can, as of https://github.com/fpco/stackage-curator/commit/543672f908e1df94b700d00b8ed02c7efdd1e79b