### PR TITLE
Re-enabling haskell-tools packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3162,15 +3162,15 @@ packages:
         - instance-control
         - references
         - classyplate
-        - haskell-tools-ast < 0
-        - haskell-tools-backend-ghc < 0
-        - haskell-tools-prettyprint < 0
-        - haskell-tools-refactor < 0
-        - haskell-tools-rewrite < 0
-        - haskell-tools-demo < 0
-        - haskell-tools-cli < 0
-        - haskell-tools-daemon < 0
-        - haskell-tools-debug < 0
+        - haskell-tools-ast
+        - haskell-tools-backend-ghc
+        - haskell-tools-prettyprint
+        - haskell-tools-refactor
+        - haskell-tools-rewrite
+        - haskell-tools-demo
+        - haskell-tools-cli
+        - haskell-tools-daemon
+        - haskell-tools-debug
 
     "David Fisher <ddf1991@gmail.com> @ddfisher":
         - socket-activation


### PR DESCRIPTION
Haskell tools 1.1.1 versions are compatible with GHC 8.6

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage

I could not try out the packages separately, because of dependencies between the packages.

