### PR TITLE
Re-enable hakyll

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -564,7 +564,7 @@ packages:
         - psqueues
         - websockets
         - websockets-snap
-        # - hakyll # containers-0.6
+        - hakyll
 
     "Sibi Prabakaran <sibi@psibi.in> @psibi":
         - download


### PR DESCRIPTION
hakyll 4.12.5.0 fixed the problem.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
