### PR TITLE
add wai-enforce-https

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8,6 +8,9 @@ cabal-format-version: "2.4"
 # Constraints for brand new builds
 packages:
 
+    "Marek Fajkus <marek.faj@gmail.com> @turboMaCk":
+        - wai-enforce-https
+
     "Fernando Freire <dogonthehorizon@gmail.com> @dogonthehorizon":
         []
         # - hal # https://github.com/commercialhaskell/stackage/issues/4288


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] * On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

## Notes
I'm NixOS user so I needed to generated [customize stack.yml](https://github.com/commercialhaskell/stack/issues/2130#issuecomment-247032332)

```
nix:
  enable:  true
  packages: [zlib.dev, zlib.out, pkgconfig]
```

Also, I had an issue with `--haddoc` argument:

```
    Warning: 'A' is out of scope.
        If you qualify the identifier, haddock can try to link it
        it anyway.
    Warning: 'haddock: internal error: <stdout>: commitBuffer: invalid argument (invalid character)
```

I have a feeling this might be related to unicode symbols within README.md. Is it a problem for stackage?