### PR TITLE
Adding hquantlib-time for building hquantlib

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2912,7 +2912,8 @@ packages:
         - leapseconds-announced
 
     "Pavel Ryzhov <paul@paulrz.cz> @paulrzcz":
-        - hquantlib < 0
+        - hquantlib-time
+        - hquantlib
         - HSvm
 
     "Henri Verroken <henriverroken@gmail.com> @hverr":


### PR DESCRIPTION
After package split I forgot to add hquantlib-time to Stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
