### PR TITLE
build-constraints.yaml: enable cabal2spec again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2326,7 +2326,7 @@ packages:
 
     "Peter Simons <simons@cryp.to> @peti":
         - cabal2nix
-        # - cabal2spec # https://github.com/peti/cabal2spec/issues/2
+        - cabal2spec
         - cgi
         - distribution-nixpkgs
         - distribution-opensuse


### PR DESCRIPTION
https://github.com/peti/cabal2spec/issues/2 has been fixed.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
