### PR TITLE
Drop haskell-src-meta and close #4214

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3905,18 +3905,43 @@ packages:
         - rdf < 0
         - universe < 0
 
+        - haskell-src-meta < 0
+        - stylish-haskell < 0
+        - QuasiText < 0
+        - aeson-qq < 0
+        - codo-notation < 0
+        - here < 0
+        - interpolate < 0
+        - interpolatedstring-perl6 < 0
+        - invertible < 0
+        - language-c-quote < 0
+        - postgresql-typed < 0
+        - qm-interpolated-string < 0
+        - bugsnag-haskell < 0
+        - hspec-wai-json < 0
+        - microformats2-parser < 0
+        - elm2nix < 0
+        - hledger < 0
+        - ucam-webauth < 0
+        - aeson-typescript < 0
+        - eventstore < 0
+        - fmt < 0
+        - generics-eot < 0
+        - hpack < 0
+        - servant-elm < 0
+        - hledger-api < 0
+        - hledger-ui < 0
+        - hledger-web < 0
+        - cabal2nix < 0
+        - hpack-dhall < 0
+        - stack < 0
+        - stack2nix < 0
+
     "GHC upper bounds":
         # Need to always match the version shipped with GHC
         - Win32 == 2.6.1.0
 
     "Stackage upper bounds":
-        # https://github.com/commercialhaskell/stackage/issues/4214
-        # waiting on haskell-src-meta
-        - haskell-src-exts < 1.21
-        - hlint < 2.1.12
-        - hoogle < 5.0.17.4
-        - haskell-names < 0.9.5
-
         # https://github.com/kuribas/cubicbezier/issues/9
         # waiting on cubicbezier
         - matrices < 0.5 # build failure because of cubicbezier


### PR DESCRIPTION
This allows a newer version of haskell-src-exts in

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
