### PR TITLE
lib flag is no longer required for cabal-install

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4460,7 +4460,6 @@ package-flags:
         servant-client-core: false
 
     cabal-install:
-        lib: true
         # https://github.com/haskell/cabal/issues/4883
         native-dns: false
 


### PR DESCRIPTION
It was required for Cabal-2.2 but as we have Cabal-2.4 for quite some time it makes sense to remove this flag and e.g. current Stack master complains seeing it

Resolves https://github.com/fpco/stackage-curator/issues/60