### PR TITLE
Allow tests for diagarms-contrib

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4526,7 +4526,6 @@ skipped-tests:
     - cabal-install # tasty 1.1
     - colour # QuickCheck-2.11.3
     - drawille # hspec 2.4
-    - diagrams-contrib # QuickCheck 2.12, containers 0.6
     - ed25519 # QuickCheck, hlint and more
     - exact-pi # QuickCHeck 2.12, tasty-1.2
     - github # hspec-2.6.0, hspec-discover-2.6.0


### PR DESCRIPTION
The upper bounds for `QuickCheck` and `containers` have been bumped via a Hackage revision; I've confirmed that the test suite completes successfully.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
