### PR TITLE
Re-enable stack

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4342,7 +4342,6 @@ packages:
         - hledger-ui < 0
         - hledger-web < 0
         - hpack-dhall < 0
-        - stack < 0
         - stack2nix < 0
 
     "GHC upper bounds":


### PR DESCRIPTION
Was blocked by `interpolate` (via `hpack`).  Both of those now re-enabed, so `stack` can be re-enabled too.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
