### PR TITLE
Enable quickcheck-classes + clean up

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1520,9 +1520,6 @@ packages:
         - universe-instances-trans
         - universe-reverse-instances
 
-    "@Bodigrim":
-        - arithmoi
-
     "Abhinav Gupta <mail@abhinavg.net> @abhinav":
         - farmhash
         - pinch < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
@@ -2513,9 +2510,6 @@ packages:
         - ctrie
         - ttrie
 
-    "Andrew Lelechenko <andrew.lelechenko@gmail.com> @Bodigrim":
-        - exp-pairs
-
     "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
         - hsndfile < 0 # build failure with GHC 8.4
         - hsndfile-vector < 0 # build failure with GHC 8.4
@@ -2958,6 +2952,7 @@ packages:
         - chimera
         - quadratic-irrational
         - quickcheck-classes
+        - arithmoi
 
     "Ashley Yakeley <ashley@semantic.org> @AshleyYakeley":
         - countable
@@ -4257,7 +4252,6 @@ packages:
         - fingertree-psqueue < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - cli < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - prim-array < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - quickcheck-classes < 0 # DependencyFailed (PackageName "prim-array")
         - xxhash < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
         - Unique < 0 # GHC 8.4 via base-4.11.0.0
         - ghc-compact < 0 # GHC 8.4 via base-4.11.1.0


### PR DESCRIPTION
It appeared that #4348 was not enough, because `quickcheck-classes` was disabled in "Removed packages" section. 

I also consolidated my packages under a single entry.