### PR TITLE
Stackage builds with new curator/Stack/Nix

### DIFF
--- a/automated/nix-build/README.md
+++ b/automated/nix-build/README.md
@@ -1,0 +1,5 @@
+# Building Stackage with Nix
+
+The script `build.sh` is supposed to be run in a directory where `curator unpack`
+was run - it assumes existence of `unpack-dir` directory with a Stackage
+snapshot `stack.yaml` and unpacked packages in it.

--- a/automated/nix-build/build.sh
+++ b/automated/nix-build/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu +x
+
+NIX_VERSION="2.0.4"
+curl https://nixos.org/releases/nix/nix-$NIX_VERSION/install | sh
+
+# no code to install stack2nix yet
+
+stack2nix --cabal2nix-args="--no-hpack" unpack-dir > snapshot.nix
+
+nix build -f snapshot-fixed.nix

--- a/automated/nix-build/fetch-nixpkgs.nix
+++ b/automated/nix-build/fetch-nixpkgs.nix
@@ -1,0 +1,23 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+  src = import <nix/fetchurl.nix> {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    inherit (spec) sha256;
+  };
+  nixcfg = import <nix/config.nix>;
+in builtins.derivation {
+  system = builtins.currentSystem;
+  name = "${src.name}-unpacked";
+  builder = builtins.storePath nixcfg.shell;
+  inherit src;
+  args = [
+    (builtins.toFile "builder" ''
+      $coreutils/mkdir $out
+      cd $out
+      $gzip -d < $src | $tar -x --strip-components=1
+    '')
+  ];
+  coreutils = builtins.storePath nixcfg.coreutils;
+  tar = builtins.storePath nixcfg.tar;
+  gzip = builtins.storePath nixcfg.gzip;
+}

--- a/automated/nix-build/nixpkgs-src.json
+++ b/automated/nix-build/nixpkgs-src.json
@@ -1,0 +1,6 @@
+{
+    "owner":  "NixOS",
+    "repo":   "nixpkgs",
+    "rev":    "c2950341d038995bf46a7b72db961bb3d3e9ac12",
+    "sha256": "0ghirjm6xvsihci3fladrn4nrnh2yr529v7c406hmw0yp25kv0i4"
+}

--- a/automated/nix-build/snapshot-fixed.nix
+++ b/automated/nix-build/snapshot-fixed.nix
@@ -1,0 +1,41 @@
+{ pkgs ? import (import ./fetch-nixpkgs.nix) {}
+, compiler ? pkgs.haskell.packages.ghc863
+}:
+let
+  snapshot = import ./snapshot.nix { pkgs = pkgs; compiler = compiler; };
+in
+  snapshot.override (with pkgs.haskell.lib; {
+    overrides = self: super: {
+      # disabling packages from non-hackage-packages.nix
+      futhark = null;
+      multi-ghc-travis = null;
+      vaultenv = null;
+      # native deps
+      check-email = super.check-email.override { resolv = null; };
+      flac = super.flac.override { FLAC = pkgs.flac; };
+      freenect = super.freenect.override { freenect_sync = null; libfreenect = null; };
+      haskell-gi = super.haskell-gi.override { gobject-introspection = pkgs.gnome3.gobjectIntrospection; };
+      HDBC-mysql = super.HDBC-mysql.override { mysqlclient = pkgs.mysql;};
+      libffi = super.libffi.override { ffi = null; };
+      # fixes
+      blas-ffi = overrideCabal super.blas-ffi (
+        old: { libraryPkgconfigDepends = old.libraryPkgconfigDepends ++ [ pkgs.openblasCompat ]; }
+      );
+      odbc = overrideCabal super.odbc (
+        old: { librarySystemDepends = old.librarySystemDepends ++ [ pkgs.freetds ]; }
+      );
+      html-entities = null; # https://github.com/nikita-volkov/html-entities/issues/8
+      category = null; # conflict in Prelude.hs
+      constraint = null; # because of category
+      lame = null; # fails with 'Total ticks: 451489'
+      proto-lens-protobuf-types = overrideCabal super.proto-lens-protobuf-types (
+      old: { libraryToolDepends = old.libraryToolDepends ++ [ pkgs.protobuf ]; }
+      );
+      # libraft = null; # xxx/postgres/entries.sql: openFile: does not exist (No such file or directory) in libraft-0.2.0.0
+      xmlbf-xeno = null; # because of html-entities
+      xmonad = null; # xmonad requires extra patches for Nix
+      xmonad-contrib = null;
+      xmonad-extras = null;
+      hlibgit2 = disableHardening super.hlibgit2 [ "format" ];
+    };
+  })

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5058,6 +5058,48 @@ expected-test-failures:
     # https://github.com/commercialhaskell/stackage/issues/4294
     - asif
 
+    # to get fixed in version after 0.3.2 https://github.com/snoyberg/tar-conduit/issues/28
+    - tar-conduit
+
+    # https://github.com/aristidb/http-types/pull/91
+    - http-types
+
+    # https://github.com/cchalmers/pcg-random/pull/7
+    - pcg-random
+
+    # https://github.com/snoyberg/conduit/issues/385
+    - conduit-extra
+
+    # Stack builds test and benchmarks in one pass so benchmark could prevent tests from getting built
+    - cryptohash
+
+    # https://github.com/basvandijk/threads/issues/10
+    - threads
+
+    # https://github.com/alphaHeavy/lzma-conduit/issues/19
+    - lzma-conduit
+
+    # https://github.com/blamario/monoid-subclasses/issues/18
+    - monoid-subclasses
+
+    # doctests for the following packages fail because of ambiguous module
+    # names, to be fixed in https://github.com/sol/doctest/pull/218
+    - blaze-colonnade
+    - co-log-core
+    - colonnade
+    - control-dsl
+    - dhall
+    - greskell-core
+    - jose-jwt
+    - jwt
+    - language-nix
+    - lens-regex
+    - pcre-heavy
+    - servant-checked-exceptions-core
+    - servant-rawm
+    - vinyl
+    - world-peace
+
 # end of expected-test-failures
 
 # Benchmarks which are known not to build. Note that, currently we do not run

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -899,7 +899,7 @@ packages:
         - grouped-list < 0 # GHC 8.4 via base-4.11.1.0
         - haskintex < 0
         - HaTeX < 0
-        - include-file < 0 # https://github.com/Daniel-Diaz/include-file/pull/3
+        - include-file
         - matrix
         - pcre-light
         - phantom-state

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4804,8 +4804,6 @@ skipped-tests:
     - js-flot
     - js-jquery
 
-    - relapse # because of include-file
-
     # Requires filesystem access
     - json-autotype # https://github.com/commercialhaskell/stackage/issues/4185
 # end of skipped-tests

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -899,7 +899,7 @@ packages:
         - grouped-list < 0 # GHC 8.4 via base-4.11.1.0
         - haskintex < 0
         - HaTeX < 0
-        - include-file
+        - include-file < 0 # https://github.com/Daniel-Diaz/include-file/pull/3
         - matrix
         - pcre-light
         - phantom-state
@@ -4789,6 +4789,23 @@ skipped-tests:
     # Uses Cabal's "library internal" stanza feature
     - s3-signer
 
+    # Due to cycles, which are actually just limitations in Stack right now.
+    - call-stack
+    - HUnit
+    - criterion
+    - hspec
+    - foundation
+    - attoparsec
+    - case-insensitive
+    - nanospec
+    - scientific
+    - vector-binary-instances
+    - clock
+    - js-flot
+    - js-jquery
+
+    - relapse # because of include-file
+
     # Requires filesystem access
     - json-autotype # https://github.com/commercialhaskell/stackage/issues/4185
 # end of skipped-tests
@@ -5324,6 +5341,16 @@ skipped-benchmarks:
     # Benchmark dependencies with multiple libraries per package
     # See: https://github.com/fpco/stackage-curator/issues/68
     - tomland
+
+    # Due to cycles, which are actually just limitations in Stack right now.
+    - criterion
+    - foundation
+    - hspec
+    - attoparsec
+    - case-insensitive
+    - nanospec
+    - scientific
+    - vector-binary-instances
 
 # end of skipped-benchmarks
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5082,6 +5082,9 @@ expected-test-failures:
     # https://github.com/blamario/monoid-subclasses/issues/18
     - monoid-subclasses
 
+    # https://github.com/takenobu-hs/ghci-hexcalc/issues/1
+    - ghci-hexcalc
+
     # doctests for the following packages fail because of ambiguous module
     # names, to be fixed in https://github.com/sol/doctest/pull/218
     - blaze-colonnade

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5059,9 +5059,6 @@ expected-test-failures:
     # to get fixed in version after 0.3.2 https://github.com/snoyberg/tar-conduit/issues/28
     - tar-conduit
 
-    # https://github.com/aristidb/http-types/pull/91
-    - http-types
-
     # https://github.com/cchalmers/pcg-random/pull/7
     - pcg-random
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5080,6 +5080,9 @@ expected-test-failures:
     # https://github.com/takenobu-hs/ghci-hexcalc/issues/1
     - ghci-hexcalc
 
+    # https://github.com/Bodigrim/exp-pairs/issues/16
+    - exp-pairs
+
     # doctests for the following packages fail because of ambiguous module
     # names, to be fixed in https://github.com/sol/doctest/pull/218
     - blaze-colonnade


### PR DESCRIPTION
Stackage builds will basically work with `curator build` (after snapshot was generated and check with curator) - I will need to add helper scripts doing that.
The PR to Stack repo with curator updates will follow and as Stackage builds are still running expect some additional updates of `build-constraints.yaml`