### PR TITLE
Remove deprecated packages proto-lens-combinators and lens-labels.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4385,13 +4385,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4347
         - snap-server < 1.1.1.0
 
-        # https://github.com/commercialhaskell/stackage/issues/4353
-        - proto-lens < 0.5.0.0
-        - proto-lens-runtime < 0.5.0.0
-        - proto-lens-protobuf-types < 0.5.0.0
-        - proto-lens-protoc < 0.5.0.0
-        - proto-lens-protobuf-types < 0.5.0.0
-
         # https://github.com/commercialhaskell/stackage/issues/4345
         - req < 2.0.0
         - retry < 0.8.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3313,8 +3313,6 @@ packages:
         - hslua-module-text
 
     "Judah Jacobson <judah.jacobson@gmail.com> @judah":
-        - lens-labels
-        - proto-lens-combinators
         - proto-lens-protobuf-types
         - proto-lens-protoc
         - proto-lens-runtime


### PR DESCRIPTION
They were merged into the latest release of the proto-lens package
(0.5.0.0).

Fixes #4353.