### PR TITLE
Remove version constraint, fixes libraft-0.2.1 compilation failure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4377,9 +4377,6 @@ packages:
         - ansi-terminal < 0.9
         - tasty < 1.2.1
 
-        # https://github.com/commercialhaskell/stackage/issues/4337
-        - libraft < 0.2.0.0 # compilation failure
-
         # https://github.com/commercialhaskell/stackage/issues/4344
         - pandoc < 2.6
         - pandoc-citeproc < 0.16


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
