### PR TITLE
Use more correct pruning done in commercialhaskell/stack/pull/4547

### DIFF
--- a/automated/build-next.sh
+++ b/automated/build-next.sh
@@ -61,7 +61,7 @@ BINDIR=$(cd $ROOT/bin ; pwd)
 (
 cd $BINDIR
 rm -f stackage-curator stackage-curator-2*.bz2
-CURATOR2=stackage-curator-2-401883a889b06e0a2ac772fac7abcc743d5a00e2
+CURATOR2=stackage-curator-2-7e65b644121812d9a3a8b24d7130bb8865485f8f
 wget "https://download.fpcomplete.com/stackage-curator-2/$CURATOR2.bz2"
 bunzip2 "$CURATOR2.bz2"
 chmod +x $CURATOR2
@@ -90,7 +90,7 @@ fi
 (
 cd $BINDIR
 rm -f stack stack-*.bz2
-STACK=stack-401883a889b06e0a2ac772fac7abcc743d5a00e2
+STACK=stack-7e65b644121812d9a3a8b24d7130bb8865485f8f
 wget "https://download.fpcomplete.com/stackage-curator-2/$STACK.bz2"
 bunzip2 "$STACK.bz2"
 chmod +x $STACK

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -11,7 +11,7 @@ export PATH=$HOME/.local/bin:$PATH
 curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 # Get new Stackage curator
-CURATOR2=stackage-curator-2-6ec4ac4ee5016e2ecd86af2abfa722b94d2a56c3
+CURATOR2=stackage-curator-2-7e65b644121812d9a3a8b24d7130bb8865485f8f
 wget "https://download.fpcomplete.com/stackage-curator-2/$CURATOR2.bz2"
 bunzip2 "$CURATOR2.bz2"
 chmod +x $CURATOR2

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -6,8 +6,8 @@ mkdir -p ~/.local/bin
 export PATH=$HOME/.local/bin:$PATH
 
 # Get new Stackage curator
-CURATOR2=stackage-curator-2-90cf65bfddea4e8abb5bc68fe83d59a7f8766757
-wget  "https://s3.amazonaws.com/www.snoyman.com/stackage-curator-2/$CURATOR2.bz2"
+CURATOR2=stackage-curator-2-6ec4ac4ee5016e2ecd86af2abfa722b94d2a56c3
+wget "https://download.fpcomplete.com/stackage-curator-2/$CURATOR2.bz2"
 bunzip2 "$CURATOR2.bz2"
 chmod +x $CURATOR2
 mv $CURATOR2 ~/.local/bin/stackage-curator-2

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -20,9 +20,12 @@ mv $CURATOR2 ~/.local/bin/stackage-curator-2
 # Install GHC
 stack setup $GHCVER
 
+# curator's constraint command has target as a required parameter
+# because of a different constraints handling in minor LTS version bumps
+NIGHTLY="nightly-$(date +%Y-%m-%d)"
 # New curator check
 stackage-curator-2 update &&
-  stackage-curator-2 constraints &&
-  stackage-curator-2 snapshotincomplete &&
+  stackage-curator-2 constraints --target=$NIGHTLY &&
+  stackage-curator-2 snapshot-incomplete &&
   stackage-curator-2 snapshot &&
-  stack --resolver ghc-$GHCVER exec stackage-curator-2 checksnapshot
+  stack --resolver ghc-$GHCVER exec stackage-curator-2 check-snapshot

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -2,7 +2,8 @@
 
 set -euxo pipefail
 
-export GHCVER=8.6.3
+ETC=$(cd $(dirname $0) ; pwd)
+export GHCVER=$(sed -n "s/^ghc-version: \"\(.*\)\"/\1/p" "$ETC/../build-constraints.yaml")
 
 # Download and unpack the stack executable
 mkdir -p ~/.local/bin

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -4,8 +4,10 @@ set -euxo pipefail
 
 export GHCVER=8.6.3
 
+# Download and unpack the stack executable
 mkdir -p ~/.local/bin
 export PATH=$HOME/.local/bin:$PATH
+curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 # Get new Stackage curator
 CURATOR2=stackage-curator-2-6ec4ac4ee5016e2ecd86af2abfa722b94d2a56c3

--- a/etc/curator-2-check.sh
+++ b/etc/curator-2-check.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+export GHCVER=8.6.3
+
 mkdir -p ~/.local/bin
 export PATH=$HOME/.local/bin:$PATH
 
@@ -12,9 +14,12 @@ bunzip2 "$CURATOR2.bz2"
 chmod +x $CURATOR2
 mv $CURATOR2 ~/.local/bin/stackage-curator-2
 
+# Install GHC
+stack setup $GHCVER
+
 # New curator check
 stackage-curator-2 update &&
   stackage-curator-2 constraints &&
   stackage-curator-2 snapshotincomplete &&
   stackage-curator-2 snapshot &&
-  stackage-curator-2 checksnapshot
+  stack --resolver ghc-$GHCVER exec stackage-curator-2 checksnapshot


### PR DESCRIPTION
Previous (intermediate) curator version didn't deal 100% properly with boot libraries versions, some details could be seen in https://github.com/commercialhaskell/stack/pull/4547