### PR TITLE
Allow groundhog-th to build with LTS 13

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -981,11 +981,11 @@ packages:
 
     "Boris Lykah <lykahb@gmail.com> @lykahb":
         - groundhog
-        - groundhog-inspector < 0 # via groundhog-th
+        - groundhog-inspector < 0 # was blocked by groundhog-th but not tested since
         - groundhog-mysql
         - groundhog-postgresql
         - groundhog-sqlite
-        - groundhog-th < 0 # https://github.com/lykahb/groundhog/issues/84
+        - groundhog-th
 
     "Janne Hellsten <jjhellst@gmail.com> @nurpax":
         - sqlite-simple


### PR DESCRIPTION
groundhog-th-0.10.2 now uses yaml version 0.11 - https://hackage.haskell.org/package/groundhog-th-0.10.2 - which was the reason for it being removed from LTS 13 - https://github.com/lykahb/groundhog/issues/84

I don't need groundhog-inspector so have not tried to see if this can also be added back.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
