### PR TITLE
Remove Earley from expected test failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5055,7 +5055,6 @@ expected-test-failures:
     - hpack-dhall # https://github.com/BlockScope/hpack-dhall/issues/25
 
     # Compilation failures
-    - Earley # https://github.com/commercialhaskell/stackage/issues/4193
     - ListLike # No issue tracker, e-mail sent to maintainer
     - amazonka-core # https://github.com/brendanhay/amazonka/issues/397
     - async-timer # https://github.com/mtesseract/async-timer/issues/8


### PR DESCRIPTION
It was fixed in https://github.com/ollef/Earley/pull/43
Fixes #4193

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
