### PR TITLE
Remove ghci-hexcalc from expected test failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5174,9 +5174,6 @@ expected-test-failures:
     # https://github.com/blamario/monoid-subclasses/issues/18
     - monoid-subclasses
 
-    # https://github.com/takenobu-hs/ghci-hexcalc/issues/1
-    - ghci-hexcalc
-
     # https://github.com/Bodigrim/exp-pairs/issues/16
     - exp-pairs
 


### PR DESCRIPTION
The issue was fixed and Hackage has a new release with the fix

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
