### PR TITLE
Reinstate palette

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1420,7 +1420,7 @@ packages:
         - bcrypt
 
     "Jeffrey Rosenbluth <jeffrey.rosenbluth@gmail.com> @jeffreyrosenbluth":
-        - palette < 0
+        - palette
         - diagrams-canvas
         - svg-builder
 


### PR DESCRIPTION
Reinstate the palette package, which has been updated since it was last removed.  Closes diagrams/palette#8 .

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
