### PR TITLE
Reenable pkgs depending on writer-cps-transformers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3045,17 +3045,17 @@ packages:
 
     "Daniel Mendler <mail@daniel-mendler.de> @minad":
         - quickcheck-special
-        - writer-cps-mtl < 0 # https://github.com/minad/writer-cps-mtl/issues/3
+        - writer-cps-mtl
         - writer-cps-transformers
         - writer-cps-morph
-        - writer-cps-lens < 0 # writer-cps-mtl
-        - writer-cps-full < 0 # writer-cps-mtl
-        - writer-cps-exceptions < 0 # https://github.com/minad/writer-cps-mtl/issues/3
+        - writer-cps-lens
+        - writer-cps-full
+        - writer-cps-exceptions
         - wl-pprint-annotated
         - wl-pprint-console
         - console-style
         - unlit
-        - intro < 0 # writer-cps-mtl
+        - intro
         - tasty-stats < 0
         - colorful-monoids
         - ihs


### PR DESCRIPTION
Issue is fixed https://github.com/minad/writer-cps-mtl/issues/3

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):