### PR TITLE
Add reanimate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3849,6 +3849,7 @@ packages:
         
     "David Himmelstrup <lemmih@gmail.com> @lemmih":
         - reanimate-svg
+        - reanimate
 
     "Grandfathered dependencies":
         - Boolean


### PR DESCRIPTION
0.1.4.1 should fix the dependency issue.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
