### PR TITLE
Add persistent-typed-db, restore other packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2176,13 +2176,14 @@ packages:
         - xlsx
 
     "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
-        - monad-logger-prefix < 0 # trasnformers https://github.com/commercialhaskell/stackage/issues/4408
-        - monad-metrics < 0
+        - monad-logger-prefix
+        - monad-metrics
         # - ekg-cloudwatch # http-conduit 2.3 via amazonka
         - smtp-mail
-        - liboath-hs < 0 # GHC 8.4 via inline-c
+        - liboath-hs
         - servant-quickcheck < 0
-        - esqueleto < 0 # https://github.com/bitemyapp/esqueleto/issues/115
+        - esqueleto
+        - persistent-typed-db
 
     "Matthew Pickering <matthewtpickering@gmail.com> @mpickering":
         - refact


### PR DESCRIPTION
esqueleto, monad-logger-prefix, liboath-hs, and monad-metrics have all been updated to be compliant with stackage nightly.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

(I have done the above commands on all relevant packages)