### PR TITLE
Re-enable beam packages after upgrade to beam-0.8.0.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -100,9 +100,10 @@ packages:
         - geodetics
 
     "Travis Athougies <travis@athougies.net> @tathougies":
-        - beam-core < 0
-        - beam-migrate < 0
-        - beam-sqlite < 0
+        - beam-core
+        - beam-migrate
+        - beam-sqlite
+        - beam-postgres
 
     "Fraser Murray <fraser.m.murray@gmail.com @intolerable":
         - stitch < 0 # GHC 8.4 via base-4.11.1.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
