### PR TITLE
hledger now has easytest upper bound

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4491,9 +4491,6 @@ packages:
         - hunit-dejafu < 2.0.0.0
         - tasty-dejafu < 2.0.0.0
 
-        # https://github.com/simonmichael/hledger/issues/983
-        - easytest < 0.3
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
Removing the workaround for https://github.com/simonmichael/hledger/issues/983
now that hledger-lib-1.14.1 and hledger-1.14.2 are released.