### PR TITLE
Re-add hw-hspec-hedgehog

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2817,10 +2817,10 @@ packages:
         - hw-eliasfano
         - hw-excess
         - hw-hedgehog
-        - hw-hspec-hedgehog < 0 # via hspec-2.7.0
+        - hw-hspec-hedgehog
         - hw-int
         - hw-ip
-        - hw-fingertree < 0 # build failure with GHC 8.4
+        - hw-fingertree
         - hw-fingertree-strict
         - hw-json
         - hw-mquery
@@ -4743,13 +4743,6 @@ skipped-tests:
     - servant-swagger # via hspec-2.7.0
     - streaming-cassava # via hspec-2.7.0
     - vinyl # via hspec-2.7.0
-    - arbor-lru-cache # via hw-hspec-hedgehog via hspec-2.7.0
-    - asif # via hw-hspec-hedgehog via hspec-2.7.0
-    - bits-extra # via hw-hspec-hedgehog via hspec-2.7.0
-    - hw-dsv # via hw-hspec-hedgehog via hspec-2.7.0
-    - hw-fingertree-strict # via hw-hspec-hedgehog via hspec-2.7.0
-    - hw-mquery # via hw-hspec-hedgehog via hspec-2.7.0
-    - hw-simd # via hw-hspec-hedgehog via hspec-2.7.0
 
 
     # Blocked due to tests failing to compile for GHC 8.6
@@ -5308,7 +5301,6 @@ skipped-benchmarks:
     - binary-list
     - binary-tagged
     - bit-stream
-    - bits-extra
     - bitset-word8
     - blake2
     - broadcast-chan
@@ -5346,11 +5338,6 @@ skipped-benchmarks:
     - http-link-header
     - http2
     - human-readable-duration
-    - hw-conduit
-    - hw-dsv
-    - hw-prim
-    - hw-rankselect
-    - hw-simd
     - hweblib
     - hxt-regex-xmlschema
     - ilist
@@ -5397,7 +5384,6 @@ skipped-benchmarks:
     - sourcemap
     - stache
     - stm-hamt
-    - sv
     - tar
     - tar-conduit
     - text-builder


### PR DESCRIPTION
unskip tests and benchmarks for hw packages and sv

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

^ I ran those commands for hw-hspec-hedgehog, but lots of things depend on it, so I'm keen to see what Travis CI has to say.