### PR TITLE
dimensional-1.3 now builds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4328,7 +4328,6 @@ packages:
         - broadcast-chan < 0
         - df1 < 0
         - di-handle < 0
-        - dimensional < 0
         - exinst < 0
         - extensible < 0
         - gtk2hs-buildtools < 0
@@ -5236,6 +5235,7 @@ skipped-benchmarks:
     - binary-parsers # criterion 1.5
     - buffer-builder # ghc 8.4 via json-builder build failure
     - cryptohash-sha512 # criterion 1.5
+    - dimensional # base < 4.7, https://github.com/bjornbm/dimensional/issues/207
     - ed25519 # Criterion
     - hw-balancedparens # criterion 1.5, https://github.com/commercialhaskell/stackage/issues/3880
     - hw-rankselect-base # criterion 1.5, https://github.com/commercialhaskell/stackage/issues/3880


### PR DESCRIPTION
Apparently, my previous pull request (#4275) wasn't quite right. This is a second try. Here benchmarks are disabled due to a hackage metadata edit (https://github.com/bjornbm/dimensional/issues/207).

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
