### PR TITLE
Add missing dependency true-name

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4203,6 +4203,7 @@ packages:
         - token-bucket
         - tonatona
         - transformers-base
+        - true-name
         - tuple-th
         - type-fun
         - type-hint


### PR DESCRIPTION
Caught this when testing new Stackage build server, it had appeared in Travis checks already - 
https://travis-ci.org/commercialhaskell/stackage/jobs/509510736