### PR TITLE
Add unbeliever package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2347,6 +2347,7 @@ packages:
         - http-common
         - http-streams
         - locators
+        - unbeliever
 
     "Sean Hunt <scshunt@csclub.uwaterloo.ca @scshunt":
         - cheapskate


### PR DESCRIPTION
A library that helps building command-line programs, both tools and longer-running daemons.

Tested with current `lts` and with `nightly` (I had to do a cabal revision on Hackage to bump the upper bound of **hspec** for `nightly`).

- [x] Meaningful commit message
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine:

      stack unpack unbeliever-0.9.3.2
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
