### PR TITLE
Package was renamed. Adding `scheduler` instead of `massiv-scheduler`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3205,7 +3205,7 @@ packages:
         # - hip # lens 4.16 via diagrams/chart
         - massiv
         - massiv-io
-        - massiv-scheduler
+        - scheduler
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
         - hledger-iadd


### PR DESCRIPTION
I already deprecated `massiv-scheduler` in favor of `scheduler` on hackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
