### PR TITLE
Add bounds on hspec packages because of QuickCheck bounds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4498,6 +4498,9 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4444
         - QuickCheck < 2.13
         - quickcheck-instances < 0.3.20
+        - hspec-core < 2.7.1
+        - hspec < 2.7.1
+        - hspec-discover < 2.7.1
 
         # https://github.com/commercialhaskell/stackage/issues/4446
         - dependent-sum < 0.5


### PR DESCRIPTION
Caught this bounds failure on new Stackage build server
