### PR TITLE
Add password and password-instances packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2283,6 +2283,8 @@ packages:
         - hailgun-simple < 0 # via hailgun
         - natural-transformation
         # - opaleye-trans # product-profunctors 0.9
+        - password
+        - password-instances
         - pretty-simple
         - read-env-var
         - servant-checked-exceptions < 0 # https://github.com/cdepillabout/servant-checked-exceptions/issues/29


### PR DESCRIPTION
This PR adds the `password` and `password-instances` packages to
`build-constraints.yaml`.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
