### PR TITLE
Add missing packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -569,6 +569,7 @@ packages:
 
     "Digital Asset <shayne.fletcher@digitalasset.com>":
         - ghc-lib
+        - ghc-lib-parser
 
     "Karl Ostmo <kostmo@gmail.com> @kostmo":
         - perfect-hash-generator
@@ -3995,6 +3996,7 @@ packages:
         - fail
         - fast-logger
         - fast-math
+        - fib
         - file-embed
         - file-embed-lzma
         - filemanip


### PR DESCRIPTION
stackage-curator: Snapshot dependency graph contains errors:

fib (not present) depended on by:
- [x] scheduler-1.1.0 (-any). Alexey Kuleshevich <lehins@yandex.ru> @lehins. @lehins. Used by: benchmark

ghc-lib-parser (not present) depended on by:
- [x] ghc-lib-0.20190402 (==0.20190402). Digital Asset <shayne.fletcher@digitalasset.com>. @digital-asset. Used by: library

Was caught on the new build server. I hope it's correct to assign Digital Asset as a maintainer of ghc-lib-parser
