### PR TITLE
Drop unneeded constraints on LH and Allure (#4475)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4534,10 +4534,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4469
         - cmark-gfm < 0.2.0
 
-        # https://github.com/commercialhaskell/stackage/issues/4475
-        - Allure < 0.9
-        - LambdaHack < 0.9
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
The issue #4475 is reported to be fixed and haddock problems are worked around in the new cabal files (as are the original issue problems, in fact).

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
