### PR TITLE
Add persistent-test missing dependency for persistent-sqlite

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -464,6 +464,7 @@ packages:
         - persistent-postgresql
         - persistent-sqlite
         - persistent-template
+        - persistent-test
         # - stackage-curator # http-conduit 2.3 via amazonka
         - store
         - wai-websockets


### PR DESCRIPTION
Caught this missing dependency on the new build server
