### PR TITLE
add terminal-progress-bar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -10,6 +10,9 @@ cabal-format-version: "2.4"
 # Constraints for brand new builds
 packages:
 
+    "Roel van Dijk <roel@lambdacube.nl> @roelvandijk":
+        - terminal-progress-bar
+
     "Marek Fajkus <marek.faj@gmail.com> @turboMaCk":
         - wai-enforce-https
 


### PR DESCRIPTION
As requested by https://github.com/roelvandijk/terminal-progress-bar/issues/26
Seems to build fine with multiple GHC versions: https://matrix.hackage.haskell.org/#/package/terminal-progress-bar

I have no problems with supporting this package now and in the future.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
