### PR TITLE
add HaskellNet-SSL back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1351,7 +1351,7 @@ packages:
 
     "Leza M. Lutonda <lemol-c@hotmail.com> @lemol":
         - HaskellNet
-        - HaskellNet-SSL < 0
+        - HaskellNet-SSL
 
     "Jens Petersen <juhpetersen@gmail.com> @juhp":
         - cabal-rpm


### PR DESCRIPTION
HaskellNet-SSL 0.3.4.1 should compile fine with network-2.7.0.0

Attempt to fix https://github.com/dpwright/HaskellNet-SSL/issues/22

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
