### PR TITLE
Added rope utf16 splay with permission

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3837,6 +3837,9 @@ packages:
     "Felix Paulusma <felix.paulusma@gmail.com> @Vlix":
         - safe-json
 
+    "Olle Fredriksson <fredriksson.olle@gmail.com> @ollef":
+        - rope-utf16-splay
+
     "Grandfathered dependencies":
         - Boolean
         - ChasingBottoms


### PR DESCRIPTION
Added under ollef's name with permission https://github.com/ollef/rope-utf16-splay/issues/1
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
