### PR TITLE
Re-enable language-puppet

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4397,7 +4397,6 @@ packages:
         - amazonka-core < 0 # via http-client-0.6.1
         - github < 0 # via http-client-0.6.1
         - hailgun < 0 # via http-client-0.6.1
-        - language-puppet < 0 # via http-client-0.6.1
         - mbug < 0 # via http-client-0.6.1
 
         - antiope-athena < 0 # via amazonka


### PR DESCRIPTION
Works again with the latest 1.4.4

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
