### PR TITLE
Unblock `ihaskell` and `ghc-parser`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3556,8 +3556,8 @@ packages:
         - servant-exceptions < 0 # https://github.com/ch1bo/servant-exceptions/issues/9
 
     "Vaibhav Sagar <vaibhavsagar@gmail.com> @vaibhavsagar":
-        - ihaskell < 0
-        - ghc-parser < 0
+        - ihaskell
+        - ghc-parser
 
     "Alexis Williams <alexis@typedr.at> @typedrat":
         - stb-image-redux


### PR DESCRIPTION
I've just released new versions to Hackage that are compatible with
LTS-13.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
