### PR TITLE
Remove upper bound on `rio`. Fix #4479

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4545,9 +4545,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4469
         - cmark-gfm < 0.2.0
 
-        # https://github.com/commercialhaskell/stackage/issues/4479
-        - rio < 0.1.9.0
-
         # https://github.com/commercialhaskell/stackage/issues/4483
         - http-media < 0.8.0.0
 


### PR DESCRIPTION
Now that `rio-0.1.9.2` is on hackage and commercialhaskell/stack#4725 has been merged we can remove upper bound on rio.

CC @snoyberg 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
