### PR TITLE
Add co-log

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3400,10 +3400,10 @@ packages:
         - o-clock
         - universum
 
-    "Kowainik <xrom.xkov@gmail.com> @ChShersh":
+    "Kowainik <xrom.xkov@gmail.com> @chshersh @vrom911":
         - base-noprelude == 4.12.0.0
         - co-log-core
-        - co-log < 0
+        - co-log
         - first-class-patterns
         - relude
         - shellmet


### PR DESCRIPTION
**Notes**
* Update maintainer information
* `co-log` depends on `co-log-core ^>= 0.2.0.0` and `typerep-map ^>= 0.3.2` which are currently not on Stackage but can be added at the same time

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack co-log-0.3.0.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
