### PR TITLE
Add ‘megaparsec-tests’ and ‘parser-combinators-tests’

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2381,33 +2381,35 @@ packages:
         - tar-conduit
 
     "Mark Karpov <markkarpov92@gmail.com> @mrkkrp":
-        - megaparsec
-        - htaglib
-        - path-io
-        - hspec-megaparsec
-        - zip
         - JuicyPixels-extra
-        - identicon
-        - pagination
-        - text-metrics
-        - tagged-identity
-        - req
-        - req-conduit
         - cue-sheet
-        - wave
         - flac
         - flac-picture
-        - lame
-        - path
         - forma
-        - stache
-        - parser-combinators
-        - modern-uri
-        - mmark
-        - mmark-ext
-        - html-entity-map
-        - mmark-cli
         - ghc-syntax-highlighter
+        - hspec-megaparsec
+        - htaglib
+        - html-entity-map
+        - identicon
+        - lame
+        - megaparsec
+        - megaparsec-tests
+        - mmark
+        - mmark-cli
+        - mmark-ext
+        - modern-uri
+        - pagination
+        - parser-combinators
+        - parser-combinators-tests
+        - path
+        - path-io
+        - req
+        - req-conduit
+        - stache
+        - tagged-identity
+        - text-metrics
+        - wave
+        - zip
 
     "Emmanuel Touzery <etouzery@gmail.com> @emmanueltouzery":
         - app-settings


### PR DESCRIPTION
Test suites of the `megaparsec` and `parser-combinators` were separated into their own packages. In addition, I took the liberty of sorting the list of my packages for clarity.
