### PR TITLE
Revert "Add ‘megaparsec-tests’ and ‘parser-combinators-tests’"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2381,35 +2381,33 @@ packages:
         - tar-conduit
 
     "Mark Karpov <markkarpov92@gmail.com> @mrkkrp":
-        - JuicyPixels-extra
-        - cue-sheet
-        - flac
-        - flac-picture
-        - forma
-        - ghc-syntax-highlighter
-        - hspec-megaparsec
-        - htaglib
-        - html-entity-map
-        - identicon
-        - lame
         - megaparsec
-        - megaparsec-tests
-        - mmark
-        - mmark-cli
-        - mmark-ext
-        - modern-uri
-        - pagination
-        - parser-combinators
-        - parser-combinators-tests
-        - path
+        - htaglib
         - path-io
+        - hspec-megaparsec
+        - zip
+        - JuicyPixels-extra
+        - identicon
+        - pagination
+        - text-metrics
+        - tagged-identity
         - req
         - req-conduit
-        - stache
-        - tagged-identity
-        - text-metrics
+        - cue-sheet
         - wave
-        - zip
+        - flac
+        - flac-picture
+        - lame
+        - path
+        - forma
+        - stache
+        - parser-combinators
+        - modern-uri
+        - mmark
+        - mmark-ext
+        - html-entity-map
+        - mmark-cli
+        - ghc-syntax-highlighter
 
     "Emmanuel Touzery <etouzery@gmail.com> @emmanueltouzery":
         - app-settings


### PR DESCRIPTION
Reverts commercialhaskell/stackage#4535

parser-combinators-1.0.3 (Mark Karpov <markkarpov92@gmail.com> @mrkkrp) is out of bounds for:
- [ ] parser-combinators-tests-1.0.3 (==1.0.2). Mark Karpov <markkarpov92@gmail.com> @mrkkrp. @mrkkrp. Used by: test-suite
