### PR TITLE
enable lambdabot builds again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2333,8 +2333,8 @@ packages:
         - hsyslog
         - jailbreak-cabal
         - json-autotype
-        - lambdabot-core < 0
-        - lambdabot-irc-plugins < 0
+        - lambdabot-core
+        - lambdabot-irc-plugins
         - language-nix
         - logging-facade-syslog
         - MonadPrompt


### PR DESCRIPTION
Recent versions support network 2.x and 3.x.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
