### PR TITLE
Move unix-compat under @jacobstanley

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -186,6 +186,7 @@ packages:
         - hedgehog
         - hedgehog-quickcheck < 0 # via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
         - transformers-bifunctors
+        - unix-compat
 
     "Walter Schulze <awalterschulze@gmail.com> @awalterschulze":
         - katydid < 0 # via transformers-either
@@ -4260,7 +4261,6 @@ packages:
         - universe-instances-extended
         - universe-instances-trans
         - universe-reverse-instances
-        - unix-compat
         - unix-time
         - unordered-containers
         - url


### PR DESCRIPTION
I noticed `unix-compat` was listed under grandfathered dependencies. As the current maintainer, I'm happy to take responsibility for it.