### PR TITLE
Re-add amazonka-s3-streaming

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3055,8 +3055,7 @@ packages:
         - vector-mmap
 
     "Alex Mason <alex.mason@data61.csiro.au> @Axman6":
-        []
-        # - amazonka-s3-streaming # https://github.com/axman6/amazonka-s3-streaming/issues/9
+        - amazonka-s3-streaming
 
     "Ondrej Palkovsky <palkovsky.ondrej@gmail.com> @ondrap":
         - json-stream < 0 # GHC 8.4 via base-4.11.0.0


### PR DESCRIPTION
v1.0.0.2 has been released which should work with current snapshots again. Currently doesn't build with nightly because amazonka-* doesn't but once it does thing should be fine - v1.0.0.2 allows http-client < 0.7, which appears to be what's breaking amazonka.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks