### PR TITLE
Remove hs-zstd

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3370,7 +3370,6 @@ packages:
 
     "Luis Pedro Coelho <luis@luispedro.org> @luispedro":
         - safeio
-        - hs-zstd
         - conduit-algorithms
         - conduit-zstd
 
@@ -5229,7 +5228,6 @@ expected-test-failures:
     - rattletrap # OOM? https://github.com/fpco/stackage/issues/2232
     - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
-    - zstd # ghc 8.2.2 bug? https://github.com/fpco/stackage/issues/3219
 
     # Linting failures (these may break every time HLint gets updated so keep them disabled)
     # https://www.snoyman.com/blog/2017/11/future-proofing-test-suites
@@ -5468,7 +5466,6 @@ skipped-benchmarks:
     - xmlgen
     - yi-rope
     - zippers
-    - zstd
 
     # Transitive outdated dependencies
     # These packages


### PR DESCRIPTION
This package (hs-zstd) only present briefly and now zstd contains the relevant bugfixes.

Sorry for the noise, but it was my previous upload of hs-zstd that made people point me in the right direction of how to just take over `zstd` maintenance.
