### PR TITLE
Remove redundant maintainerships from @borsboom

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1234,15 +1234,10 @@ packages:
     "Emanuel Borsboom <manny@fpcomplete.com> @borsboom":
         - BoundedChan
         - broadcast-chan
-        - bytestring-lexing
-        - bytestring-trie < 0 # build failure with GHC 8.4
-        - data-accessor
-        - data-accessor-mtl
         - fuzzcheck
         - here
         - hlibgit2
         # - gitlib-libgit2 # via gitlib: https://github.com/jwiegley/gitlib/issues/72
-        - hostname-validate
         - interpolatedstring-perl6
         - iproute
         - missing-foreign


### PR DESCRIPTION
All the removed packages are also listed under another maintainer, so no changes to what is in Stackage are expected.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [N/A] At least 30 minutes have passed since uploading to Hackage
- [N/A] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
