### PR TITLE
Re-enable ersatz's test suite

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5261,7 +5261,6 @@ expected-test-failures:
     - yeshql-hdbc # https://github.com/tdammers/yeshql/issues/6
     - yesod-gitrev # https://github.com/DanBurton/yesod-gitrev/issues/5
     - record-dot-preprocessor # https://github.com/commercialhaskell/stackage/issues/4449
-    - ersatz # https://github.com/commercialhaskell/stackage/issues/4571
 
     # Recursive deps https://github.com/fpco/stackage/issues/1818
     - options


### PR DESCRIPTION
`erstaz-0.4.7` has a working test suite again, per https://github.com/commercialhaskell/stackage/issues/4571#issuecomment-497970551.

Fixes #4571.