### PR TITLE
Add taffybar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3899,6 +3899,19 @@ packages:
     "Elben Shira <elben@shira.im> @elben":
         - pencil
 
+    "Ivan Malison <IvanMalison@gmail.com> @IvanMalison":
+        - ConfigFile
+        - dbus-hslogger
+        - gi-cairo-connector
+        - gi-cairo-render
+        - gtk-sni-tray
+        - gtk-strut
+        - rate-limit
+        - status-notifier-item
+        - taffybar
+        - time-units
+        - xml-helpers
+
     "Grandfathered dependencies":
         - Boolean
         - ChasingBottoms < 0 # due to QuickCheck, https://github.com/commercialhaskell/stackage/issues/4444
@@ -4423,7 +4436,6 @@ packages:
         # failed to build
         - Fin < 0
         - HPDF < 0
-        - broadcast-chan < 0
         - df1 < 0
         - di-handle < 0
         - exinst < 0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2909,14 +2909,18 @@ packages:
         - haskell-gi-base
         - gi-atk
         - gi-cairo
-        - gi-glib
+        - gi-dbusmenu
+        - gi-dbusmenugtk3
+        - gi-gdkx11
         - gi-gio
+        - gi-glib
         - gi-gobject
         - gi-gtk
         - gi-gtk-hs
         - gi-gtksource
         - gi-javascriptcore
         - gi-vte
+        - gi-xlib
         # - gi-webkit2 # GHC 8.4
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -42,6 +42,7 @@ apt-get install -y \
     gnupg \
     gradle \
     hscolour \
+    libdbusmenu-gtk3-dev \
     libadns1-dev \
     libaio1 \
     libalut-dev \
@@ -92,8 +93,8 @@ apt-get install -y \
     libmysqlclient-dev \
     libncurses5-dev \
     libnfc-dev \
-    liboath-dev \
     libnotify-dev \
+    liboath-dev \
     libopenal-dev \
     libopenmpi-dev \
     libpango1.0-dev \


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Well, not quite to the above, because I need all of the dependencies that are added as part of this pull request. Here is the stack file that I actually used

https://github.com/taffybar/taffybar/blob/a67568e4bfaf6bf751f500c435a19901baf07d00/stack.yaml#L1

This uses as extra deps only things that are added in this pull request (+ haskell-gi bumped to 0.22.6, but I also checked that 3.2.0 works without this)

Notes about ownership of packages:
- gi-dbusmenu, gi-dbusmenugtk3, gi-gdkx11 and gi-xlib were added for @garetxe which he signed off on here: https://github.com/haskell-gi/haskell-gi/issues/235
- I/taffybar is the direct owner of dbus-hslogger, gi-cairo-connect, gi-cairo-render, gtk-sni-tray, gtk-strut, status-notifier-tiem and taffybar see https://hackage.haskell.org/user/eyevanmalicesun
- I am a maintainer of rate-limit: See https://hackage.haskell.org/user/eyevanmalicesun
- ConfigFile does not seem to have a github repository, I have sent an email but did not get a response
- broadcast-chan issue here https://github.com/merijn/broadcast-chan/issues/9
- Working on time-units, xml-helpers

My main concerns:
- I'm not 100% sure I have gotten all the non haskell dependencies needed in debian-boostrap.sh right. From the list of nix dependencies here: https://github.com/taffybar/taffybar/blob/a67568e4bfaf6bf751f500c435a19901baf07d00/stack.yaml#L23 it seems like everything we have is needed, but I don't have a debian machine available to me to easily test this.
- haskell-gi needs a bump to 0.22.6 for the latest version of taffybar. This is a very backwards compatible change as far as I understand it, so it should be pretty safe.