### PR TITLE
Break some new dependency cycles

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5078,6 +5078,7 @@ skipped-tests:
     - clock
     - js-flot
     - js-jquery
+    - splitmix
 
     # Requires filesystem access
     - json-autotype
@@ -5624,6 +5625,7 @@ skipped-benchmarks:
     - nanospec
     - scientific
     - vector-binary-instances
+    - clock
 
 # end of skipped-benchmarks
 


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

@snoyberg found it by running build with new curator - looks like our cycle checks in curator are not quite complete - `curator build` (running Stack) failed with errors like:
```
In the dependencies for fuzzy-dates-0.1.1.1:
    hspec dependency cycle detected: hspec, microstache, criterion, clock, hspec-core, hspec,
          base-compat-batteries, splitmix, QuickCheck, half, OpenGLRaw, GLURaw, OpenGL, OpenAL, ALUT
needed since fuzzy-dates is a build target.
```