### PR TITLE
Die on build failure hidden by pipe

### DIFF
--- a/automated/build-next.sh
+++ b/automated/build-next.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu +x
+set -eu +x -o pipefail
 
 ROOT=$(cd $(dirname $0) ; pwd)
 TARGET=$1


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

@snoyberg this for example resulted in haddocks not getting generated in the yesterday's build.
And in the log I see 27 failures, I guess some of them should be resolved by updating Stack/curator (probably we should use the latest release of Stack?) but for example `singletons` test won't so I suppose we need to mark those left as `expected-test-failures` and report failure or maybe create a PR if it's something trivial.