### PR TITLE
Re-enable language-puppet

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4453,7 +4453,6 @@ packages:
         - amazonka-core < 0 # via http-client-0.6.1
         - github < 0 # via http-client-0.6.1
         - hailgun < 0 # via http-client-0.6.1
-        - language-puppet < 0 # via http-client-0.6.1
         - mbug < 0 # via http-client-0.6.1
 
         - antiope-athena < 0 # via amazonka


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack language-puppet  # latest version -> 1.4.5
      stack init --resolver nightly
      stack build --resolver nightly --test --bench --no-run-benchmarks

Extra notes:
- `stack.yaml` as been edited to enable nix with the approviate system deps.
- I had an haddock error with `basement-0.0.10` and removed the `--haddock` flag to get a successful build.