### PR TITLE
Revert "Add functor-combinators to stackage"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1948,7 +1948,6 @@ packages:
         - configurator-export
         - decidable
         - emd
-        - functor-combinators
         - hamilton
         - hmatrix-backprop
         - hmatrix-vector-sized


### PR DESCRIPTION
Reverts commercialhaskell/stackage#4631

hedgehog-0.6.1 (Jacob Stanley <jacob@stanley.io> @jacobstanley, Stackage upper bounds) is out of bounds for:
- [ ] functor-combinators-0.1.1.0 (>=1.0). Justin Le <justin@jle.im> @mstksg. @mstksg. Used by: test-suite


tasty-hedgehog-0.2.0.0 (George Wilson <george@wils.online> @gwils, Stackage upper bounds) is out of bounds for:
- [ ] functor-combinators-0.1.1.0 (>=1.0). Justin Le <justin@jle.im> @mstksg. @mstksg. Used by: test-suite


trivial-constraint (not present) depended on by:
- [ ] functor-combinators-0.1.1.0 (>=0.5.1 && < 0.5.2). Justin Le <justin@jle.im> @mstksg. @mstksg. Used by: library
