### PR TITLE
Return typerep-map back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4649,9 +4649,6 @@ packages:
         - stm-hamt < 0
         - stm-containers < 0
 
-        - typerep-map < 0 # https://github.com/kowainik/typerep-map/issues/77
-        - co-log < 0
-
         # https://github.com/commercialhaskell/stackage/issues/4568
         - prettyprinter < 1.3.0
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack typerep-map-0.3.2
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Follow up on: https://github.com/kowainik/typerep-map/issues/77