### PR TITLE
Re-enable servant-checked-exceptions.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2277,19 +2277,16 @@ packages:
         - irc
 
     "Dennis Gosnell <cdep.illabout@gmail.com> @cdepillabout":
-        - emailaddress < 0 # opaleye
         - envelope
         - from-sum
         - hailgun
-        - hailgun-simple < 0 # via hailgun
         - natural-transformation
-        # - opaleye-trans # product-profunctors 0.9
         - password
         - password-instances
         - pretty-simple
         - read-env-var
-        - servant-checked-exceptions < 0 # https://github.com/cdepillabout/servant-checked-exceptions/issues/29
-        - servant-checked-exceptions-core < 0 # servant 0.16
+        - servant-checked-exceptions
+        - servant-checked-exceptions-core
         - servant-rawm < 0 # https://github.com/cdepillabout/servant-rawm/issues/9
         - servant-static-th
         - termonad < 0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I have re-enabled the servant-checked-exceptions and servant-checked-exceptions-core packages:

http://hackage.haskell.org/package/servant-checked-exceptions-2.2.0.0
http://hackage.haskell.org/package/servant-checked-exceptions-core-2.2.0.0

I've also removed some of the packages I'm no longer maintaining or planning on keeping up to date.