### PR TITLE
Replace unbeliever package with core-text, core-data, core-program

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2348,7 +2348,9 @@ packages:
         - http-common
         - http-streams
         - locators
-        - unbeliever
+        - core-text
+        - core-data
+        - core-program
 
     "Sean Hunt <scshunt@csclub.uwaterloo.ca @scshunt":
         - cheapskate


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack unbeliever-0.10.0.0

Manual _stack.yaml_ as follows:
```yaml
resolver: nightly
extra-deps:
 - core-data-0.2.0.0
 - core-text-0.2.0.0
 - core-program-0.2.0.0
allow-newer: true
```


      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

succeeded.