### PR TITLE
Remove 'pantry-tmp'

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -581,7 +581,6 @@ packages:
 
         - time-manager
         - pantry
-        - pantry-tmp
         - mega-sdist
         - http-download
         - hi-file-parser
@@ -5229,7 +5228,6 @@ expected-test-failures:
     - opaleye # PostgreSQL
     - pandoc-pyplot # requires DISPLAY for tcltk
     - pantry # https://github.com/commercialhaskell/stackage/issues/4628
-    - pantry-tmp # https://github.com/commercialhaskell/stackage/issues/4628
     - persistent-redis # redis - https://github.com/fpco/stackage/pull/1581
     - pipes-mongodb
     - postgresql-query # PostgreSQL
@@ -5893,7 +5891,6 @@ no-revisions:
 - stack
 - http-download
 - pantry
-- pantry-tmp
 - rio-prettyprint
 - hi-file-parser
 # https://github.com/commercialhaskell/stackage/issues/3706:


### PR DESCRIPTION
It has been replaced by `pantry`, and will no longer get updated.