### PR TITLE
Make myself the maintainer of ordered-containers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2169,6 +2169,7 @@ packages:
         - monad-par
         - monad-par-extras
         - mtl-compat
+        - ordered-containers
         - proxied
         - singleton-nats
         - text-show


### PR DESCRIPTION
The next version of `th-desugar` will depend on the `ordered-containers` library (goldfirere/th-desugar#120). I believe Stackage requires that all dependencies explicitly be listed out in `build-constraints.yaml` nowadays, so I'm preemptively adding `ordered-containers` now so that there aren't issues once the next `th-desugar` release happens.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
