### PR TITLE
Re-enable simple web framework

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2668,9 +2668,9 @@ packages:
         - dawg-ord < 0
 
     "Amit Levy <amit@amitlevy.com> @alevy":
-        - simple < 0 # GHC 8.4 via simple-templates
-        - simple-templates < 0 # BuildFailureException Process exited with ExitFailure 1: ./Setup build
-        - simple-session < 0 # GHC 8.4 via simple
+        - simple
+        - simple-templates
+        - simple-session
         - postgresql-orm
 
     "Sergey Astanin <s.astanin@gmail.com> @astanin":


### PR DESCRIPTION
Build failure for simple-templates fixed in version >=0.9 which should resolve build failures for dependent `simple and `simple-postgresql-orm`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
