### PR TITLE
re-enable data-clist and dependers brick, hledger-ui, etc. (#4542)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1190,7 +1190,7 @@ packages:
         #
         - hledger-lib
         - hledger
-        - hledger-ui < 0  # via brick, via data-clist, via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
+        - hledger-ui
         - hledger-web
         - hledger-api < 0 # build failure against swagger2
         #
@@ -3225,7 +3225,7 @@ packages:
         - scheduler
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
-        - hledger-iadd < 0  # via brick, via data-clist, via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
+        - hledger-iadd
 
     "Roy Levien <royl@aldaron.com> @orome":
         - crypto-enigma
@@ -3253,7 +3253,7 @@ packages:
     "Mitsutoshi Aoe <maoe@foldr.in> @maoe":
         - influxdb
         - sensu-run < 0 # GHC 8.4 via base-4.11.0.0
-        - viewprof < 0  # via brick, via data-clist, via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
+        - viewprof
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed
@@ -3982,7 +3982,7 @@ packages:
         - blaze-svg
         - blaze-textual
         - boring
-        - brick < 0  # via data-clist, via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
+        - brick
         - buffer-builder
         - byteable
         - bytestring-builder
@@ -4037,7 +4037,7 @@ packages:
         - data-binary-ieee754
         - data-bword
         - data-checked
-        - data-clist < 0 # via QuickCheck https://github.com/commercialhaskell/stackage/issues/4444
+        - data-clist
         - data-default
         - data-default-class
         - data-default-instances-containers


### PR DESCRIPTION
data-clist-0.1.2.3 now allows current QuickCheck.