### PR TITLE
remove yam and yam-*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3200,9 +3200,6 @@ packages:
         - salak-yaml
         - salak-toml
         - tensors
-        - yam
-        - yam-datasource
-        - yam-redis
         - menshen
         - crc32c
 


### PR DESCRIPTION
The libraries are too experimental and useless as common libraries which need too many dependencies. I want to remove it from stackage. Thanks.