### PR TITLE
Remove `dhall-text` from Stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1000,7 +1000,6 @@ packages:
         - dhall-bash
         - dhall-json
         # - dhall-nix # deriving-compat via hnix
-        - dhall-text
 
     "Andrew Thaddeus Martin <andrew.thaddeus@gmail.com> @andrewthad":
         - colonnade


### PR DESCRIPTION
Fixes https://github.com/commercialhaskell/stackage/issues/4740

The `dhall-text` package is deprecated now, superseded by the
`dhall text` subcommand provided by the `dhall` package

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] (N/A) At least 30 minutes have passed since uploading to Hackage
- [ ] (N/A) On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
