### PR TITLE
Add express

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2274,6 +2274,7 @@ packages:
         - leancheck
         - leancheck-instances
         - fitspec
+        - express
         - speculate
         - extrapolate
         - percent-format
@@ -4759,10 +4760,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4753
         - dependent-map < 0.3
         - dependent-sum-template < 0.1
-
-        # https://github.com/commercialhaskell/stackage/issues/4754
-        - extrapolate < 0.4
-        - speculate < 0.4
 
 # end of packages
 


### PR DESCRIPTION
Add "express" and remove constraints for "speculate" and "extrapolate", fixing #4754.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
