### PR TITLE
Reenable termonad

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2302,7 +2302,7 @@ packages:
         - servant-checked-exceptions-core
         - servant-rawm < 0 # https://github.com/cdepillabout/servant-rawm/issues/9
         - servant-static-th
-        - termonad < 0
+        - termonad
         - world-peace
         - xml-html-qq
         - xml-indexed-cursor


### PR DESCRIPTION
Re-enable the [termonad](http://hackage.haskell.org/package/termonad-2.0.0.0) package.

Note that termonad requires the `libvte-2.91-dev` system library, greater than version 0.46.  This is confusing, but `libvte-2.91` is actually a package name.  Termonad requires at least version 0.46 of the `libvte-2.91` package.

I sent a PR a while ago adding this to `debian-bootstrap.sh`:

https://github.com/commercialhaskell/stackage/pull/3870

It is possible that the version of `libvte-2.91` used by the stackage builder machine is not yet at least 0.46.  If `libvte-2.91` is not yet at least version 0.46, then Termonad should not be re-enabled (since it will fail to build).

I don't think Termonad requires any other system libraries that aren't pulled in by `libvte-2.91-dev`, but if so I will update this PR to add them.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
