### PR TITLE
re-enable persistent-mongoDB

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -556,7 +556,7 @@ packages:
         - hybrid-vectors
         - indents
         - language-c
-        - persistent-mongoDB < 0 # GHC 8.4 via mongoDB
+        - persistent-mongoDB
         - pretty-class
         - th-expand-syns
         - th-lift


### PR DESCRIPTION
This should be able to bring back `persistent-mongoDB`: https://github.com/yesodweb/persistent/pull/946.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
