### PR TITLE
Drop apecs-physics constraint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4759,9 +4759,6 @@ packages:
         - dependent-map < 0.3
         - dependent-sum-template < 0.1
 
-        # https://github.com/jonascarpay/apecs/issues/51
-        - apecs-physics < 0.4.3
-
         # https://github.com/commercialhaskell/stackage/issues/4775
         - polyparse < 1.13
 # end of packages


### PR DESCRIPTION
See https://github.com/jonascarpay/apecs/issues/51
This issue has been fixed with the upload of [0.2.3](https://hackage.haskell.org/package/apecs-gloss)

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
