### PR TITLE
re-enabled hledger-lib tests, drop hledger-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5481,9 +5481,6 @@ expected-test-failures:
 
     # Requires a running server
     - persistent-mongoDB
-
-    # https://github.com/commercialhaskell/stackage/issues/4792
-    - hledger-lib
 # end of expected-test-failures
 
 # Benchmarks which are known not to build. Note that, currently we do not run

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1208,7 +1208,6 @@ packages:
         - hledger
         - hledger-ui
         - hledger-web
-        - hledger-api < 0 # build failure against swagger2
         #
         - quickbench
         - regex-compat-tdfa
@@ -5988,7 +5987,6 @@ no-revisions:
 - hledger-lib
 - hledger-ui
 - hledger-web
-- hledger-api
 
 
 # Do not build these packages in parallel with others. Useful for high memory


### PR DESCRIPTION
Followup for #4792, and another unrelated change.