### PR TITLE
Make myself the maintainer of type-equality

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2202,6 +2202,7 @@ packages:
         - text-show-instances
         - th-abstraction
         - thread-local-storage
+        - type-equality
 
     "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
         - xlsx


### PR DESCRIPTION
The next version of `lens` (and possibly other libraries) will depend on the recently revamped [`type-equality`](http://hackage.haskell.org/package/type-equality) package. Since I co-maintain `type-equality`, I'm preemptively adding it to Stackage so that it's available when the next version of `lens` is released.