### PR TITLE
Install LLVM 9.0 in the docker image

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4822,9 +4822,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4809
         - elm-street < 0.1
 
-        # https://github.com/commercialhaskell/stackage/issues/4811
-        - polysemy < 1.2.0.0
-
         # https://github.com/commercialhaskell/stackage/issues/4816
         - trifecta < 2.1
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4836,10 +4836,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4811
         - polysemy < 1.2.0.0
 
-        # https://github.com/commercialhaskell/stackage/issues/4812
-        - llvm-hs < 9
-        - llvm-hs-pure < 9
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -165,6 +165,11 @@ curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources
 apt-get update
 ACCEPT_EULA=Y apt-get install msodbcsql17 -y
 
+# llvm for llvm-hs
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+apt-get update
+apt-get install llvm-9 -y
+
 locale-gen en_US.UTF-8
 
 # Buggy versions of ld.bfd fail to link some Haskell packages:


### PR DESCRIPTION
This is required for the latest version of llvm-hs.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
