### PR TITLE
safe-json-1.0.0's tests work now

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5382,7 +5382,6 @@ expected-test-failures:
     - doctest-discover # 0.1.0.9 https://github.com/karun012/doctest-discover/issues/22
     - graylog # 0.1.0.1 https://github.com/fpco/stackage/pull/1254
     - tomland # https://github.com/kowainik/tomland/issues/141
-    - safe-json # 0.1.0 https://github.com/Vlix/safe-json/issues/1
 
     # Assertion failures, these can be real bugs or just limitations
     # in the test cases.


### PR DESCRIPTION
The new version has working tests which include the `.json` files it needs to do so in the `sdist`.

Should this change also automatically update the version? The nightly build seems to still use `0.1.0` instead of the new `1.0.0`

Checklist:
- [ X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ X ] At least 30 minutes have passed since uploading to Hackage
- [ X ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
