### PR TITLE
Revert "Install LLVM 9.0 in the docker image"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4823,6 +4823,10 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4809
         - elm-street < 0.1
 
+        # https://github.com/commercialhaskell/stackage/issues/4812
+        - llvm-hs < 9
+        - llvm-hs-pure < 9
+
         # https://github.com/commercialhaskell/stackage/issues/4816
         - trifecta < 2.1
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -165,11 +165,6 @@ curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources
 apt-get update
 ACCEPT_EULA=Y apt-get install msodbcsql17 -y
 
-# llvm for llvm-hs
-curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-apt-get update
-apt-get install llvm-9 -y
-
 locale-gen en_US.UTF-8
 
 # Buggy versions of ld.bfd fail to link some Haskell packages:


### PR DESCRIPTION
Reverts commercialhaskell/stackage#4813