### PR TITLE
Install LLVM 9.0 in the docker image and upgrade llvm-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4826,10 +4826,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/4809
         - elm-street < 0.1
 
-        # https://github.com/commercialhaskell/stackage/issues/4812
-        - llvm-hs < 9
-        - llvm-hs-pure < 9
-
         # https://github.com/commercialhaskell/stackage/issues/4816
         - trifecta < 2.1
 

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -165,6 +165,12 @@ curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources
 apt-get update
 ACCEPT_EULA=Y apt-get install msodbcsql17 -y
 
+# llvm for llvm-hs
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
+apt-get update
+apt-get install llvm-9-dev -y
+
 locale-gen en_US.UTF-8
 
 # Buggy versions of ld.bfd fail to link some Haskell packages:


### PR DESCRIPTION
fixes #4812

I’m very sorry for the broken earlier attempt in #4813. This time I’ve
built the full docker image and did the `stack unpack; stack build …`
dance in the docker image so hopefully I didn’t screw it up again.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
