### PR TITLE
Restore tidal

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2789,7 +2789,7 @@ packages:
         - binary-bits
 
     "Alex McLean <alex@slab.org> @yaxu":
-        - tidal < 0 # transformers https://github.com/commercialhaskell/stackage/issues/4408
+        - tidal
         - hosc
 
     "Kei Hibino <ex8k.hibino@gmail.com> @khibino":


### PR DESCRIPTION
Tidal is one of the most popular haskell packages there is, so I'm puzzled to see it was removed from stackage (again!), citing this: https://github.com/commercialhaskell/stackage/issues/4408

This issue was closed long ago. I fixed it within hours at the time.

I've just double checked, and tidal builds fine against lts-14.6 .

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
