### PR TITLE
Reenable vault

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6020,7 +6020,6 @@ packages:
 
         # Misc
         - cuda < 0
-        - vault < 0
         - vivid-osc < 0
         - flay < 0
         - barbies < 0
@@ -6965,6 +6964,9 @@ expected-haddock-failures:
     - bins
     - emd
     - hmatrix-backprop
+
+    # https://github.com/haskell/haddock/issues/1091
+    - vault
 # end of expected-haddock-failures
 
 # For packages with haddock issues


### PR DESCRIPTION
`vault` was listed in `"GHC 8.8-related build failures"`, but that is much too restrictive, since the library actually builds without issue on GHC 8.8. The only part that doesn't build correctly is its Haddocks, which is due to a Haddock bug (reported upstream at haskell/haddock#1091). I've listed `vault` in `expected-haddock-failures` as a result.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --test --bench --no-run-benchmarks
