### PR TITLE
Remove the deprecated gc package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -809,7 +809,6 @@ packages:
         - fixed
         - folds
         - free
-        - gc
         - gl
         - graphs
         - half
@@ -6446,7 +6445,6 @@ skipped-tests:
     - dotenv
     - enum-subset-generate
     - folds
-    - gc
     - generic-lens
     - geojson
     - github-types


### PR DESCRIPTION
The `gc` package is now deprecated (see its [Hackage page](http://hackage.haskell.org/package/gc-0.0.3)). As co-maintainer, I'd like to remove it from Stackage.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
