### PR TITLE
Reenable streaming

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4797,7 +4797,6 @@ packages:
         - socks < 0 # via base-4.13.0.0
         - sqlite-simple < 0 # via base-4.13.0.0
         - statestack < 0 # via base-4.13.0.0
-        - streaming < 0 # via base-4.13.0.0
         - strive < 0 # via base-4.13.0.0
         - summoner < 0 # via base-4.13.0.0
         - sv < 0 # via base-4.13.0.0


### PR DESCRIPTION
`streaming-0.2.3.0` fully supports GHC 8.8.1.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
