### PR TITLE
Revert "Remove base-orphans' test suite from skipped-tests"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6245,6 +6245,9 @@ skipped-tests:
     # fails with ghc 8.8
     - alex # as of alex-3.2.4
 
+    # Cyclic dependencies
+    - base-orphans # via hspec
+
     # test-framework per ghc 8.8
     - stm-conduit # via test-framework
     - conduit-zstd # via test-framework


### PR DESCRIPTION
Reverts commercialhaskell/stackage#4850