### PR TITLE
Add back some of my packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5721,7 +5721,6 @@ packages:
         - attoparsec-uri < 0 # via ip
         - string-interpolate < 0 # via text-conversions
         - xmlbf-xeno < 0 # via xeno
-        - text-show-instances < 0 # via text-show
         - random-fu < 0 # via random-source
         - Hoed < 0 # via regex-tdfa
         - Hoed < 0 # via regex-tdfa-text
@@ -6424,7 +6423,6 @@ skipped-tests:
     - distributed-closure
     - dotenv
     - enum-subset-generate
-    - folds
     - generic-lens
     - geojson
     - github-types
@@ -6457,7 +6455,6 @@ skipped-tests:
     - skylighting-core
     - speedy-slice
     - static-text
-    - structs
     - thyme
     - universum
     - unordered-containers
@@ -6821,10 +6818,6 @@ expected-test-failures:
     - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
 
-    # Linting failures (these may break every time HLint gets updated so keep them disabled)
-    # https://www.snoyman.com/blog/2017/11/future-proofing-test-suites
-    - folds
-
     # https://github.com/pruvisto/heap/issues/11
     - heap
 
@@ -6993,7 +6986,6 @@ skipped-benchmarks:
     - binary-tagged
     - Earley
     - IntervalMap
-    - ad
     - attoparsec
     - binary-list
     - binary-tagged
@@ -7085,7 +7077,6 @@ skipped-benchmarks:
     - text-builder
     - text-manipulate
     - text-metrics
-    - thread-local-storage
     - tinylog
     - turtle
     - type-of-html
@@ -7102,7 +7093,6 @@ skipped-benchmarks:
     - xlsx
     - xmlgen
     - yi-rope
-    - zippers
 
     # Transitive outdated dependencies
     # These packages


### PR DESCRIPTION
* `ad`, `thread-local-storage`, and `zippers` were removed due to their benchmarks not building with GHC 8.8.1. As far as I can tell, this is no longer an issue, as `criterion` now builds without issue on 8.8.1.
* `folds` was removed due to its flaky `hlint` test suite, but version 0.7.5 of `folds` has removed this test suite.
* `structs` was removed due to its test suite not building on GHC 8.6. This is no longer an issue, as far as I can tell.
* `text-show-instances` was removed due to `text-show`, but `text-show` is no longer blacklisted, so this should be fine now.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
