### PR TITLE
Add myself as the maintainer of rdtsc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2203,6 +2203,7 @@ packages:
         - mtl-compat
         - ordered-containers
         - proxied
+        - rdtsc
         - singleton-nats
         - text-show
         - text-show-instances


### PR DESCRIPTION
The benchmark suites for my package `rcu` (which I working towards adding back to Stackage at some point) depends on the `rdtsc` library, which is not currently on Stackage. I'd like to make myself the maintainer.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
