### PR TITLE
Remove th-test-utils from build failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6063,7 +6063,6 @@ packages:
         - haskell-spacegoo < 0 # MonadFail
         - lens-typelevel < 0 # Wrong category of family instance (wat)
         - regex-pcre-builtin < 0 # MonadFail
-        - th-test-utils < 0 # Template Haskell changes. https://github.com/commercialhaskell/stackage/pull/4839
         - wai-predicates < 0 # MonadFail
 
         # Round 2 transitive from Some more failures
@@ -6078,7 +6077,6 @@ packages:
         - cql-io < 0 # via cql
         - groundhog-mysql < 0 # via groundhog
         - logging-effect < 0 # via prettyprinter
-        - aeson-schemas < 0 # via th-test-utils
 
 
     "GHC upper bounds":


### PR DESCRIPTION
Checklist:
- Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- At least 30 minutes have passed since uploading to Hackage
- On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
