### PR TITLE
Re-enable pusher-http-haskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4770,7 +4770,6 @@ packages:
         - proto-lens-runtime < 0 # via base-4.13.0.0
         - proto-lens-setup < 0 # via base-4.13.0.0
         - protolude < 0 # via base-4.13.0.0
-        - pusher-http-haskell < 0 # via base-4.13.0.0
         - raaz < 0 # via base-4.13.0.0
         - ratel < 0 # via base-4.13.0.0
         - ratel-wai < 0 # via base-4.13.0.0


### PR DESCRIPTION
Remove pusher-http-haskell from "GHC 8.8 bounds failures". It's compatible with base-4.13 since 1.5.1.11.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
