### PR TITLE
Reinstate `dhall`/`dhall-json`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4654,11 +4654,9 @@ packages:
         - ShellCheck < 0 # via Cabal-3.0.0.0
         - cipher-aes128 < 0 # via Cabal-3.0.0.0
         - proto-lens-setup < 0 # via Cabal-3.0.0.0
-        - dhall < 0 # via Diff-0.4.0
         - language-ecmascript < 0 # via Diff-0.4.0
         - pandoc < 0 # via Diff-0.4.0
         - pandoc < 0 # via HsYAML-0.2.0.0
-        - dhall-json < 0 # via ansi-terminal-0.10
         - MissingH < 0 # via array-0.5.4.0
         - MissingH < 0 # via base-4.13.0.0
         - Strafunski-StrategyLib < 0 # via base-4.13.0.0
@@ -4963,8 +4961,6 @@ packages:
         - core-data < 0 # via prettyprinter-1.3.0
         - core-program < 0 # via prettyprinter-1.3.0
         - core-text < 0 # via prettyprinter-1.3.0
-        - dhall < 0 # via prettyprinter-1.3.0
-        - dhall-json < 0 # via prettyprinter-1.3.0
         - invertible-grammar < 0 # via prettyprinter-1.3.0
         - sexp-grammar < 0 # via prettyprinter-1.3.0
         - primitive-extras < 0 # via primitive-unlifted
@@ -4997,7 +4993,6 @@ packages:
         - core-text < 0 # via template-haskell-2.15.0.0
         - data-accessor-template < 0 # via template-haskell-2.15.0.0
         - dbus < 0 # via template-haskell-2.15.0.0
-        - dhall < 0 # via template-haskell-2.15.0.0
         - email-validate < 0 # via template-haskell-2.15.0.0
         - fclabels < 0 # via template-haskell-2.15.0.0
         - flow < 0 # via template-haskell-2.15.0.0
@@ -5149,10 +5144,6 @@ packages:
         - functor-combinators < 0 # via dependent-sum
         - prim-uniq < 0 # via dependent-sum
         - typelits-witnesses < 0 # via dependent-sum
-        - dhall-bash < 0 # via dhall
-        - hpack-dhall < 0 # via dhall
-        - verbosity < 0 # via dhall
-        - hpack-dhall < 0 # via dhall-json
         - diagrams < 0 # via diagrams-contrib
         - Chart-diagrams < 0 # via diagrams-core
         - SVGFonts < 0 # via diagrams-core
@@ -6745,7 +6736,6 @@ expected-test-failures:
     # Missing test files in sdist
     # Hopefully gets fixed in the next release...
     - crypto-pubkey # https://github.com/vincenthz/hs-crypto-pubkey/issues/23
-    - dhall-json # https://github.com/dhall-lang/dhall-haskell/issues/996
     - doctest-discover # 0.1.0.9 https://github.com/karun012/doctest-discover/issues/22
     - graylog # 0.1.0.1 https://github.com/fpco/stackage/pull/1254
     - tomland # https://github.com/kowainik/tomland/issues/141
@@ -6869,9 +6859,6 @@ expected-test-failures:
 
     # Cannot reproduce locally, looks like it may be a bug in Stack or curator
     - shake-language-c
-
-    # https://github.com/commercialhaskell/stackage/issues/4706
-    - dhall
 
     # https://github.com/commercialhaskell/stackage/issues/4707
     - blaze-colonnade


### PR DESCRIPTION
... and any reverse dependencies that were blocked on them

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
