### PR TITLE
Reenable tests and benchmarks for machines, rcu

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6416,7 +6416,6 @@ skipped-tests:
     - quickcheck-state-machine
     - rakuten
     - rank1dynamic
-    - rcu
     - rss-conduit
     - servant-auth-server
     - servant-blaze
@@ -7003,7 +7002,6 @@ skipped-benchmarks:
     - lifted-async
     - lifted-base
     - loop
-    - machines
     - matrices
     - matrix
     - megaparsec
@@ -7019,7 +7017,6 @@ skipped-benchmarks:
     - prettyprinter
     - prometheus-client
     - ramus
-    - rcu
     - reinterpret-cast
     - rng-utils
     - sampling


### PR DESCRIPTION
These were blocked some time ago due to not compiling against GHC 8.6, but as far as I can tell, this is no longer an issue.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
