### PR TITLE
Reenable wai-extra, warp

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5905,8 +5905,6 @@ packages:
         - list-witnesses < 0 # via vinyl
         - wai-handler-launch < 0 # via wai
         - wai-handler-launch < 0 # via warp
-        - wai-extra < 0 # via http2
-        - warp < 0 # via http2
         - lsp-test < 0 # via conduit-parse
         - groundhog-inspector < 0 # via groundhog
         - groundhog-inspector < 0 # via groundhog-sqlite


### PR DESCRIPTION
Now that `http2` is back in Stackage, there is no longer any reason to block `wai-extra` or `warp`, which incur `http2` as a dependency.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
