### PR TITLE
Remove a few packages from "GHC 8.8 bounds failures"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5509,7 +5509,6 @@ packages:
         - crypto-pubkey < 0 # via crypto-pubkey-types
         - cabal-debian < 0 # via debian
         - xml-isogen < 0 # via dom-parser
-        - scheduler < 0 # via fib
         - cabal2nix < 0 # via hpack
         - postgresql-simple-queue < 0 # via hspec-pg-transact
         - hspec-wai-json < 0 # via hspec-wai
@@ -5623,8 +5622,6 @@ packages:
         - psql-helpers < 0 # via postgresql-simple
         - users-postgresql-simple < 0 # via postgresql-simple
         - protocol-buffers-descriptor < 0 # via protocol-buffers
-        - massiv < 0 # via scheduler
-        - massiv-test < 0 # via scheduler
         - servant-ruby < 0 # via servant-foreign
         - filecache < 0 # via strict-base-types
         - pcre-heavy < 0 # via string-conversions


### PR DESCRIPTION
Remove `scheduler`, `massiv` and `massiv-test` from "GHC 8.8 bounds failures", since `scheduler` no longer depends on `fib`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
