### PR TITLE
Enable some of my packages (which now work)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4870,7 +4870,6 @@ packages:
         - apply-refact < 0 # via ghc-8.8.1
         - brittany < 0 # via ghc-8.8.1
         - ghc-parser < 0 # via ghc-8.8.1
-        - ghc-syntax-highlighter < 0 # via ghc-8.8.1
         - hint < 0 # via ghc-8.8.1
         - ihaskell < 0 # via ghc-8.8.1
         - loopbreaker < 0 # via ghc-8.8.1
@@ -4997,7 +4996,6 @@ packages:
         - tz < 0 # via time-1.9.3
         - web3 < 0 # via time-1.9.3
         - wild-bind-x11 < 0 # via time-1.9.3
-        - zip < 0 # via time-1.9.3
         - ztail < 0 # via time-1.9.3
         - mysql-haskell < 0 # via tls-1.5.1
         - universe < 0 # via universe-some
@@ -5099,7 +5097,6 @@ packages:
         - eventstore < 0 # via ekg-core
         - monad-metrics < 0 # via ekg-core
         - check-email < 0 # via email-validate
-        - mmark < 0 # via email-validate
         - yesod-auth < 0 # via email-validate
         - yesod-form < 0 # via email-validate
         - persistent-pagination < 0 # via esqueleto
@@ -5215,7 +5212,6 @@ packages:
         - rainbow < 0 # via lens-simple
         - rainbox < 0 # via lens-simple
         - polysemy < 0 # via loopbreaker
-        - mmark < 0 # via modern-uri
         - mmark-ext < 0 # via modern-uri
         - witherable < 0 # via monoidal-containers
         - msgpack-aeson < 0 # via msgpack


### PR DESCRIPTION
I made new revisions for some of these, for others I released new versions
compatible with GHC 8.8.1. I confirmed on CI that all of these build and
pass the tests with the latest GHC.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
