### PR TITLE
Reenable regex-posix, regex-tdfa

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5271,8 +5271,6 @@ packages:
         - regex-compat < 0 # via regex-base-0.94.0.0
         - regex-pcre < 0 # via regex-base-0.94.0.0
         - regex-pcre-text < 0 # via regex-base-0.94.0.0
-        - regex-posix < 0 # via regex-base-0.94.0.0
-        - regex-tdfa < 0 # via regex-base-0.94.0.0
         - yi-language < 0 # via regex-base-0.94.0.0
         - lens-regex < 0 # via regex-posix
         - regex-compat-tdfa < 0 # via regex-tdfa


### PR DESCRIPTION
These are no longer blocked on `regex-base`.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
