### PR TITLE
Reenable blaze-markup, safecopy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4684,7 +4684,6 @@ packages:
         - base-noprelude < 0 # via base-4.13.0.0
         - benchpress < 0 # via base-4.13.0.0
         - bencode < 0 # via base-4.13.0.0
-        - blaze-markup < 0 # via base-4.13.0.0
         - boolean-normal-forms < 0 # via base-4.13.0.0
         - brick < 0 # via base-4.13.0.0
         - brittany < 0 # via base-4.13.0.0
@@ -4959,7 +4958,6 @@ packages:
         - interpolatedstring-qq2 < 0 # via template-haskell-2.15.0.0
         - quickcheck-arbitrary-template < 0 # via template-haskell-2.15.0.0
         - rank2classes < 0 # via template-haskell-2.15.0.0
-        - safecopy < 0 # via template-haskell-2.15.0.0
         - size-based < 0 # via template-haskell-2.15.0.0
         - static-text < 0 # via template-haskell-2.15.0.0
         - uri-bytestring < 0 # via template-haskell-2.15.0.0
@@ -6210,7 +6208,6 @@ skipped-tests:
     - attoparsec # QuickCheck-2.11.3
     - barrier # tasty 0.12 and tasty-hunit 0.10
     - binary-parser # tasty-1.0.1.1, tasty-quickcheck-0.10, tasty-hunit-0.10.0.1
-    - blaze-markup # tasty 1.1
     - cabal-install # tasty 1.1
     - cayley-client # via hspec-2.6.0
     - cborg # via tasty-1.2


### PR DESCRIPTION
Two more packages that are in my mantained packages' transitive
dependency graph.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
