### PR TITLE
Enable ‘mmark-ext’ and ‘mmark-cli’

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5058,8 +5058,6 @@ packages:
         - shake-language-c < 0 # via fclabels
         - download < 0 # via feed
         - shikensu < 0 # via flow
-        - mmark-cli < 0 # via ghc-syntax-highlighter
-        - mmark-ext < 0 # via ghc-syntax-highlighter
         - termonad < 0 # via gi-gtk
         - termonad < 0 # via gi-vte
         - apecs-gloss < 0 # via gloss
@@ -5171,7 +5169,6 @@ packages:
         - websockets-snap < 0 # via snap-core
         - websockets-snap < 0 # via snap-server
         - mbtiles < 0 # via sqlite-simple
-        - mmark-cli < 0 # via stache
         - mpi-hs < 0 # via store
         - datasets < 0 # via streaming
         - eventstore < 0 # via streaming
@@ -5251,8 +5248,6 @@ packages:
         - cmark-gfm < 0 # via blaze-html
         - highlighting-kate < 0 # via blaze-html
         - inliterate < 0 # via blaze-html
-        - skylighting < 0 # via blaze-html
-        - skylighting-core < 0 # via blaze-html
         - barrier < 0 # via blaze-svg
         - cabal-debian < 0 # via debian
         - xml-isogen < 0 # via dom-parser
@@ -5274,8 +5269,6 @@ packages:
         - highlighting-kate < 0 # via regex-pcre-builtin
         - html-email-validate < 0 # via regex-pcre-builtin
         - pcre-utils < 0 # via regex-pcre-builtin
-        - skylighting < 0 # via regex-pcre-builtin
-        - skylighting-core < 0 # via regex-pcre-builtin
         - template-toolkit < 0 # via regex-pcre-builtin
         - relational-record < 0 # via relational-query-HDBC
         - wikicfp-scraper < 0 # via scalpel-core
@@ -5649,7 +5642,6 @@ packages:
         - cassava-records < 0 # MonadFail
         - haskell-spacegoo < 0 # MonadFail
         - lens-typelevel < 0 # Wrong category of family instance (wat)
-        - regex-pcre-builtin < 0 # MonadFail
         - wai-predicates < 0 # MonadFail
         - sbv < 0 # MonadFail
         - crypto-pubkey-openssh < 0 # MonadFail


### PR DESCRIPTION
This enables `mmark-ext` and `mmark-cli`. Both should work fine with GHC 8.8.1.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
