### PR TITLE
Enable concurrency, dejafu, {hunit,tasty}-dejafu

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5565,7 +5565,6 @@ packages:
         - exceptional < 0
         - true-name < 0
         - probability < 0
-        - concurrency < 0
         - cron < 0
         - store-core < 0
         - bitcoin-script < 0
@@ -5615,7 +5614,6 @@ packages:
 
         # Round 2 build failure transitive deps
         - cryptocipher < 0 # via cipher-blowfish
-        - dejafu < 0 # via concurrency
         - cublas < 0 # via cuda
         - cufft < 0 # via cuda
         - cusparse < 0 # via cuda
@@ -5638,8 +5636,6 @@ packages:
 
         # Round 3 build failure transitive deps
         - network-messagepack-rpc < 0 # via data-msgpack
-        - hunit-dejafu < 0 # via dejafu
-        - tasty-dejafu < 0 # via dejafu
 
         # More build failure transitive deps
         - random-source < 0 # via flexible-defaults


### PR DESCRIPTION
New releases have fixed GHC 8.8 build issues

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
