### PR TITLE
Enable hint and libmpd back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4778,7 +4778,6 @@ packages:
         - hw-rankselect < 0 # via generic-lens-1.2.0.0
         - apply-refact < 0 # via ghc-8.8.1
         - ghc-parser < 0 # via ghc-8.8.1
-        - hint < 0 # via ghc-8.8.1
         - ihaskell < 0 # via ghc-8.8.1
         - loopbreaker < 0 # via ghc-8.8.1
         - hsdev < 0 # via ghc-boot-8.8.1
@@ -4880,7 +4879,6 @@ packages:
         - hquantlib-time < 0 # via time-1.9.3
         - hsdev < 0 # via time-1.9.3
         - hsexif < 0 # via time-1.9.3
-        - libmpd < 0 # via time-1.9.3
         - pinboard < 0 # via time-1.9.3
         - postgresql-simple-migration < 0 # via time-1.9.3
         - req < 0 # via time-1.9.3
@@ -6137,7 +6135,6 @@ expected-test-failures:
     - hastache
     - idris # https://github.com/fpco/stackage/issues/1382
     - ihaskell # https://github.com/gibiansky/IHaskell/issues/551
-    - libmpd # https://github.com/vimus/libmpd-haskell/issues/104
     - math-functions # https://github.com/bos/math-functions/issues/25
     - matplotlib # https://github.com/fpco/stackage/issues/2365
     - mltool # https://github.com/Alexander-Ignatyev/mltool/issues/1


### PR DESCRIPTION
This is needed for xmonad-extras

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
