### PR TITLE
Reenable uri-bytestring and dependent packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4860,7 +4860,6 @@ packages:
         - rank2classes < 0 # via template-haskell-2.15.0.0
         - size-based < 0 # via template-haskell-2.15.0.0
         - static-text < 0 # via template-haskell-2.15.0.0
-        - uri-bytestring < 0 # via template-haskell-2.15.0.0
         - hyraxAbif < 0 # via text-1.2.4.0
         - sqlite-simple-errors < 0 # via text-1.2.4.0
         - universum < 0 # via text-1.2.4.0
@@ -5090,10 +5089,6 @@ packages:
         - polysemy < 0 # via unagi-chan
         - require < 0 # via universum
         - tintin < 0 # via universum
-        - dublincore-xml-conduit < 0 # via uri-bytestring
-        - uri-bytestring-aeson < 0 # via uri-bytestring
-        - wai-middleware-auth < 0 # via uri-bytestring
-        - yesod-auth-oauth2 < 0 # via uri-bytestring
         - hamilton < 0 # via vty
         - hledger-iadd < 0 # via vty
         - servant-rawm < 0 # via wai-app-static
@@ -5995,7 +5990,6 @@ skipped-tests:
     # Compilation failures
     - snappy # https://github.com/bos/snappy/issues/1
     - genvalidity-time # https://github.com/NorfairKing/validity/issues/51
-    - uri-bytestring # Could not deduce (SOP.All (SOP.All Arbitrary) xs) arising from a use of ‘SOP.hcpure’
     - cron # Could not deduce (SOP.All (SOP.All Arbitrary) xss) arising from a use of ‘SOP.hcpure’
     - config-ini # https://github.com/aisamanra/config-ini/issues/22
     - polysemy-plugin # https://github.com/commercialhaskell/stackage/issues/4733


### PR DESCRIPTION
I've sawed off the upper bounds for uri-bytestring and was able to successfully build it against nightlies. I've also dropped the sop stuff from the test suite and just switched to hedgehog.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
