### PR TITLE
Reenable type-errors-pretty

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4726,7 +4726,6 @@ packages:
         - threepenny-gui < 0 # via base-4.13.0.0
         - timer-wheel < 0 # via base-4.13.0.0
         - token-bucket < 0 # via base-4.13.0.0
-        - type-errors-pretty < 0 # via base-4.13.0.0
         - ucam-webauth < 0 # via base-4.13.0.0
         - ucam-webauth-types < 0 # via base-4.13.0.0
         - unagi-chan < 0 # via base-4.13.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack type-errors-pretty-0.0.1.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
