### PR TITLE
Re-enable giphy-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2681,7 +2681,7 @@ packages:
         # - language-dockerfile # https://github.com/beijaflor-io/haskell-language-dockerfile/issues/11
 
     "Pascal Hartig <phartig@rdrei.net> @passy":
-        - giphy-api < 0 # https://github.com/passy/giphy-api/issues/18
+        - giphy-api
         - optparse-text
 
     "rightfold <rightfold@gmail.com> @rightfold":


### PR DESCRIPTION
Published `0.7.0` which builds against the latest version of `servant-client` in LTS and Nightly.

Thanks for the ping in https://github.com/passy/giphy-api/issues/18.