### PR TITLE
PyF: remove from the list of broken packages with ghc 8.8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4849,7 +4849,6 @@ packages:
         - selda-postgresql < 0 # via selda-0.5.0.0
         - selda-sqlite < 0 # via selda-0.5.0.0
         - universe-dependent-sum < 0 # via some
-        - PyF < 0 # via template-haskell-2.15.0.0
         - data-accessor-template < 0 # via template-haskell-2.15.0.0
         - interpolatedstring-qq2 < 0 # via template-haskell-2.15.0.0
         - quickcheck-arbitrary-template < 0 # via template-haskell-2.15.0.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

`PyF` was removed from nightly because of a boundary incompatibility with `template-haskell`. This is now fixed.