### PR TITLE
Re-enable req packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4873,7 +4873,6 @@ packages:
         - hsexif < 0 # via time-1.9.3
         - pinboard < 0 # via time-1.9.3
         - postgresql-simple-migration < 0 # via time-1.9.3
-        - req < 0 # via time-1.9.3
         - rhine < 0 # via time-1.9.3
         - safe-json < 0 # via time-1.9.3
         - servant-auth-client < 0 # via time-1.9.3
@@ -5043,7 +5042,6 @@ packages:
         - yi-language < 0 # via regex-base-0.94.0.0
         - datasets < 0 # via req
         - elm2nix < 0 # via req
-        - req-conduit < 0 # via req
         - filter-logger < 0 # via scotty
         - line < 0 # via scotty
         - pg-harness-server < 0 # via scotty
@@ -5539,7 +5537,6 @@ packages:
         - data-textual < 0 # MonadFail
         - data-serializer < 0 # MonadFail
         - crypto-pubkey-openssh < 0 # MonadFail
-        - RSA < 0 # MonadFail
         # https://github.com/alevy/simple/issues/23
         - simple < 0
         - simple-session < 0
@@ -5552,7 +5549,6 @@ packages:
         - mmtf < 0 # via data-msgpack
         - gym-http-api < 0 # via servant servant-client
         - xmlbf-xeno < 0 # via xmlbf
-        - authenticate-oauth < 0 # via RSA
         - http-directory < 0 # via html-conduit
         - xml-html-qq < 0 # via html-conduit
         - scalpel < 0 # via scalpel-core


### PR DESCRIPTION
`req` and `req-conduit` now compile with GHC 8.8.1.
