### PR TITLE
Revert "Fix pairing and add elliptic-curve dependency"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2934,9 +2934,8 @@ packages:
         - pedersen-commitment
         - merkle-tree
         - oblivious-transfer
-        - pairing
+        - pairing < 0 # #4758
         - libraft
-        - elliptic-curve
         - galois-field
 
     "Daishi Nakajima <nakaji.dayo@gmail.com> @nakaji-dayo":


### PR DESCRIPTION
Reverts commercialhaskell/stackage#4942

galois-field (GHC 8.8 bounds failures, Stephen Diehl <stephen.m.diehl@gmail.com> @sdiehl) (not present) depended on by:
- [ ] elliptic-curve-0.3.0 (>=1 && < 2). Stephen Diehl <stephen.m.diehl@gmail.com> @sdiehl. @adjoint-io. Used by: library
- [ ] pairing-1.0.0 (>=1 && < 2). Stephen Diehl <stephen.m.diehl@gmail.com> @sdiehl. @adjoint-io. Used by: library


wl-pprint-text (GHC 8.8 bounds failures, Ivan Miljenovic <Ivan.Miljenovic@gmail.com> @ivan-m) (not present) depended on by:
- [ ] elliptic-curve-0.3.0 (-any). Stephen Diehl <stephen.m.diehl@gmail.com> @sdiehl. @adjoint-io. Used by: library
