### PR TITLE
Reenable proto-lens and related packages.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4606,7 +4606,6 @@ packages:
     "GHC 8.8 bounds failures":
         - ShellCheck < 0 # via Cabal-3.0.0.0
         - cipher-aes128 < 0 # via Cabal-3.0.0.0
-        - proto-lens-setup < 0 # via Cabal-3.0.0.0
         - language-ecmascript < 0 # via Diff-0.4.0
         - pandoc < 0 # via HsYAML-0.2.0.0
         - MissingH < 0 # via array-0.5.4.0
@@ -4703,13 +4702,6 @@ packages:
         - partial-semigroup < 0 # via base-4.13.0.0
         - path-text-utf8 < 0 # via base-4.13.0.0
         - persistent < 0 # via base-4.13.0.0
-        - proto-lens < 0 # via base-4.13.0.0
-        - proto-lens-arbitrary < 0 # via base-4.13.0.0
-        - proto-lens-optparse < 0 # via base-4.13.0.0
-        - proto-lens-protobuf-types < 0 # via base-4.13.0.0
-        - proto-lens-protoc < 0 # via base-4.13.0.0
-        - proto-lens-runtime < 0 # via base-4.13.0.0
-        - proto-lens-setup < 0 # via base-4.13.0.0
         - raaz < 0 # via base-4.13.0.0
         - ratel < 0 # via base-4.13.0.0
         - ratel-wai < 0 # via base-4.13.0.0
@@ -4830,11 +4822,6 @@ packages:
         - gothic < 0 # via lens-aeson-1.1
         - hsdev < 0 # via lens-aeson-1.1
         - lens-simple < 0 # via lens-family-2.0.0
-        - proto-lens < 0 # via lens-family-2.0.0
-        - proto-lens-arbitrary < 0 # via lens-family-2.0.0
-        - proto-lens-protobuf-types < 0 # via lens-family-2.0.0
-        - proto-lens-protoc < 0 # via lens-family-2.0.0
-        - proto-lens-runtime < 0 # via lens-family-2.0.0
         - lens-simple < 0 # via lens-family-core-2.0.0
         - machines-binary < 0 # via machines-0.7
         - machines-directory < 0 # via machines-0.7
@@ -4850,7 +4837,6 @@ packages:
         - diagrams-lib < 0 # via optparse-applicative-0.15.1.0
         - diagrams-rasterific < 0 # via optparse-applicative-0.15.1.0
         - diagrams-svg < 0 # via optparse-applicative-0.15.1.0
-        - proto-lens-optparse < 0 # via optparse-applicative-0.15.1.0
         - wai-middleware-crowd < 0 # via optparse-applicative-0.15.1.0
         - hapistrano < 0 # via path-io-1.5.0
         - graphviz < 0 # via polyparse-1.13
@@ -4862,7 +4848,6 @@ packages:
         - blaze-colonnade < 0 # via profunctors-5.5
         - colonnade < 0 # via profunctors-5.5
         - invertible-grammar < 0 # via profunctors-5.5
-        - proto-lens < 0 # via profunctors-5.5
         - ixset-typed < 0 # via safecopy-0.10.0
         - selda-postgresql < 0 # via selda-0.5.0.0
         - selda-sqlite < 0 # via selda-0.5.0.0


### PR DESCRIPTION
The latest release (0.6.0.0) is compatible with the nightly build
(ghc-8.8, Cabal-3.0, etc.).

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
