### PR TITLE
Reinstate servant-websockets

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3511,7 +3511,7 @@ packages:
         - elm-street
 
     "Lorenz Moesenlechner <moesenle@gmail.com> @moesenle":
-        - servant-websockets < 0 # https://github.com/moesenle/servant-websockets/issues/8
+        - servant-websockets
 
     "Daniel Campoverde <alx@sillybytes.net> @alx741":
         - currencies


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack servant-websockets-2.0.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

At the moment this is blocked on not having websockets, wai-websockets in nightly-2019-10-28.