### PR TITLE
Re-enable hspec-expectations-pretty-diff

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4867,7 +4867,6 @@ packages:
         - hschema-quickcheck < 0 # via hschema
         - hsexif < 0 # via time-1.9.3
         - hslogger < 0 # via network-3.1.1.0 & network-bsd
-        - hspec-expectations-pretty-diff < 0 # unknown
         - hspec-need-env < 0 # via base-4.13.0.0
         - hspec-pg-transact < 0 # via tmp-postgres
         - hspec-wai-json < 0 # via hspec-wai
@@ -5045,7 +5044,6 @@ packages:
         - protocol-buffers-descriptor < 0 # via protocol-buffers
         - psql-helpers < 0 # via postgresql-simple
         - pure-zlib < 0 # via base-compat-0.11.0
-        - purescript-bridge < 0 # via hspec-expectations-pretty-diff
         - qnap-decrypt < 0 # via cipher-aes128
         - quickbench < 0 # via docopt
         - quickcheck-arbitrary-template < 0 # via template-haskell-2.15.0.0
@@ -5929,7 +5927,6 @@ expected-test-failures:
     - conduit-throttle # https://github.com/mtesseract/conduit-throttle/issues/12
     - haddock
     - haskell-tools-builtin-refactorings
-    - hspec-expectations-pretty-diff # GHC 8 issue not reported upstream since issue tracker disabled
     - hweblib # https://github.com/aycanirican/hweblib/issues/3
     - libraft # https://github.com/commercialhaskell/stackage/issues/4337#issuecomment-462465921
     - multiset # doctests require Glob, a hidden package


### PR DESCRIPTION
Note that the issue tracker does not seem to be disabled upstream... https://github.com/myfreeweb/hspec-expectations-pretty-diff/issues

It will allow to add purescript-bridge, and then servant-subscriber and servant-purescript back.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
