### PR TITLE
Re-enable servant-purescript & servant-subscriber

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4867,7 +4867,6 @@ packages:
         - hschema-quickcheck < 0 # via hschema
         - hsexif < 0 # via time-1.9.3
         - hslogger < 0 # via network-3.1.1.0 & network-bsd
-        - hspec-expectations-pretty-diff < 0 # unknown
         - hspec-need-env < 0 # via base-4.13.0.0
         - hspec-pg-transact < 0 # via tmp-postgres
         - hspec-wai-json < 0 # via hspec-wai
@@ -5045,7 +5044,6 @@ packages:
         - protocol-buffers-descriptor < 0 # via protocol-buffers
         - psql-helpers < 0 # via postgresql-simple
         - pure-zlib < 0 # via base-compat-0.11.0
-        - purescript-bridge < 0 # via hspec-expectations-pretty-diff
         - qnap-decrypt < 0 # via cipher-aes128
         - quickbench < 0 # via docopt
         - quickcheck-arbitrary-template < 0 # via template-haskell-2.15.0.0
@@ -5929,7 +5927,6 @@ expected-test-failures:
     - conduit-throttle # https://github.com/mtesseract/conduit-throttle/issues/12
     - haddock
     - haskell-tools-builtin-refactorings
-    - hspec-expectations-pretty-diff # GHC 8 issue not reported upstream since issue tracker disabled
     - hweblib # https://github.com/aycanirican/hweblib/issues/3
     - libraft # https://github.com/commercialhaskell/stackage/issues/4337#issuecomment-462465921
     - multiset # doctests require Glob, a hidden package

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1071,8 +1071,8 @@ packages:
 
     "Robert Klotzner <robert.klotzner@gmx.at> @eskimor":
         - purescript-bridge
-        - servant-purescript < 0 # mainland-pretty <- srcloc
-        - servant-subscriber < 0 # build failure with servant 0.14: https://github.com/eskimor/servant-subscriber/issues/17
+        - servant-purescript
+        - servant-subscriber
 
     "Rodrigo Setti <rodrigosetti@gmail.com> @rodrigosetti":
         - messagepack


### PR DESCRIPTION
This depends on https://github.com/commercialhaskell/stackage/pull/4953

Note that `stack build --resolver nightly --test --bench --no-run-benchmarks` (without `--haddock`) worked fine, while `stack build --resolver nightly --haddock --test --bench --no-run-benchmarks` resulted in `vault` build failing. This is an expected build failure already registered in the build-constraints.yaml, so merging this should be fine.


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
