### PR TITLE
Reenable relude

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5072,7 +5072,6 @@ packages:
         - relational-query-HDBC < 0 # via HDBC
         - relational-record < 0 # via persistable-types-HDBC-pg
         - relational-record < 0 # via relational-query-HDBC
-        - relude < 0 # hashable-1.3.0
         - repa < 0 # via base-4.13.0.0
         - repa-algorithms < 0 # via base-4.13.0.0
         - repa-io < 0 # via base-4.13.0.0
@@ -5969,6 +5968,7 @@ expected-test-failures:
     - pg-transact # https://github.com/jfischoff/pg-transact/issues/2
     - postgresql-simple-queue # same issue as before, see also https://github.com/fpco/stackage/issues/2592 as that will fix both
     - rattletrap # OOM? https://github.com/fpco/stackage/issues/2232
+    - relude # doctest fails due to GHC bugs, will be fixed in the next `relude` release
     - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
     - prettyprinter # Could not load module ‘Test.QuickCheck.Modifiers’ (member of the hidden package ‘QuickCheck-2.13.2’)


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack relude-0.6.0.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I marked `relude` temporary with `expected-test-failure` because a few `doctest` cases don't work in that release due to unexpected and silent changes in GHC behaviour and they slipped into release. This will be fixed in the next `relude` version and I will enable tests back again.
