### PR TITLE
Re-enable `doctest-driver-gen`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3601,7 +3601,7 @@ packages:
         - docker < 0
 
     "Hexirp <hexirp@gmail.com> @Hexirp":
-        - doctest-driver-gen < 0 # via base-4.13.0.0
+        - doctest-driver-gen
 
     "Václav Haisman <vhaisman@gmail.com> @wilx":
         - hs-bibutils


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

The 3rd command caused a error:

<details>
<summary>Log</summary>

```
$ stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
Selected resolver: nightly-2019-11-02
Stack has not been tested with GHC versions above 8.6, and using 8.8.1, this may fail
Preparing to install GHC to an isolated location.
This will not interfere with any system-level installation.
Downloaded ghc-8.8.1.
Already downloaded.
Already downloaded.
Decompressing ghc-8.8.1.tar.xz...

7-Zip 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18

Processing archive: C:\Users\[private]\AppData\Local\Programs\stack\x86_64-windows\ghc-8.8.1.tar.xz

Extracting  ghc-8.8.1.tar

Everything is Ok

Size:       2551214080
Compressed: 395638616
Extracting ghc-8.8.1.tar...
Extracted total of 10065 files from ghc-8.8.1.tar
GHC installed to C:\Users\[private]\AppData\Local\Programs\stack\x86_64-windows\ghc-8.8.1\
Stack has not been tested with Cabal versions above 2.4, but version 3.0.0.0 was found, this may fail
[1 of 2] Compiling Main             ( C:\\sr\setup-exe-src\setup-Z6RU0evB.hs, C:\\sr\setup-exe-src\setup-Z6RU0evB.o )
[2 of 2] Compiling StackSetupShim   ( C:\\sr\setup-exe-src\setup-shim-Z6RU0evB.hs, C:\\sr\setup-exe-src\setup-shim-Z6RU0evB.o )
Linking C:\\sr\\setup-exe-cache\\x86_64-windows\\tmp-Cabal-simple_Z6RU0evB_3.0.0.0_ghc-8.8.1.exe ...
code-page         > configure
code-page         > Configuring code-page-0.2...
code-page         > build
ghc-paths         > configure
code-page         > Preprocessing library for code-page-0.2..
ghc-paths         > [1 of 2] Compiling Main             ( C:\\Users\[private]\AppData\Local\Temp\stack5792\ghc-paths-0.1.0.12\Setup.hs, C:\\Users\[private]\AppData\Local\Temp\stack5792\ghc-paths-0.1.0.12\.stack-work\dist\c9315887\setup\Main.o )
code-page         > Building library for code-page-0.2..
ghc-paths         > [2 of 2] Compiling StackSetupShim   ( C:\\sr\setup-exe-src\setup-shim-Z6RU0evB.hs, C:\\Users\[private]\AppData\Local\Temp\stack5792\ghc-paths-0.1.0.12\.stack-work\dist\c9315887\setup\StackSetupShim.o )
ghc-paths         > Linking C:\\Users\\[private]\\AppData\\Local\\Temp\\stack5792\\ghc-paths-0.1.0.12\\.stack-work\\dist\\c9315887\\setup\\setup.exe ...
code-page         > [1 of 3] Compiling System.Win32.CodePage
code-page         > [2 of 3] Compiling System.IO.CodePage.Internal
code-page         > [3 of 3] Compiling System.IO.CodePage
code-page         > haddock
code-page         > Preprocessing library for code-page-0.2..
code-page         > Running Haddock on library for code-page-0.2..
code-page         > Haddock coverage:
code-page         >   42% (  8 / 19) in 'System.Win32.CodePage'
code-page         >   Missing documentation for:
code-page         >     CodePage
code-page         >     getConsoleCP
code-page         >     getConsoleOutputCP
code-page         >     setConsoleCP
code-page         >     setConsoleOutputCP
code-page         >     getACP
code-page         >     getOEMCP
code-page         >     codePageEncoding
code-page         >     mkCodePageEncoding
code-page         >     isValidCodePage
code-page         >     stringToUnicode
code-page         > Warning: 'withCodePage' is out of scope.
code-page         >     If you qualify the identifier, haddock can try to link it anyway.
code-page         >  100% ( 14 / 14) in 'System.IO.CodePage.Internal'
code-page         >  100% ( 30 / 30) in 'System.IO.CodePage'
code-page         > haddock: internal error: couldn't find ast for .stack-work\dist\c9315887\build\System\Win32\CodePage.hs [".stack-work\\\\dist\\\\c9315887\\\\build\\\\System\\\\Win32\\\\CodePage.hs","src\\System\\Win32\\CodePage.hsc"]
code-page         > CallStack (from HasCallStack):
code-page         >   error, called at utils\haddock\haddock-api\src\Haddock\Backends\Hyperlinker.hs:78:28 in main:Haddock.Backends.Hyperlinker
ghc-paths         > Configuring ghc-paths-0.1.0.12...
ghc-paths         > build
syb               > configure
ghc-paths         > Preprocessing library for ghc-paths-0.1.0.12..
ghc-paths         > Building library for ghc-paths-0.1.0.12..
ghc-paths         > [1 of 1] Compiling GHC.Paths
ghc-paths         > haddock
syb               > Configuring syb-0.7.1...
ghc-paths         > Preprocessing library for ghc-paths-0.1.0.12..
ghc-paths         > Running Haddock on library for ghc-paths-0.1.0.12..
syb               > build
base-compat       > configure
ghc-paths         > Haddock coverage:
ghc-paths         >    0% (  0 /  5) in 'GHC.Paths'
ghc-paths         >   Missing documentation for:
ghc-paths         >     Module header
ghc-paths         >     ghc (GHC\\Paths.hs:7)
ghc-paths         >     ghc_pkg (GHC\\Paths.hs:7)
ghc-paths         >     libdir (GHC\\Paths.hs:7)
ghc-paths         >     docdir (GHC\\Paths.hs:7)
ghc-paths         > Documentation created:
ghc-paths         > .stack-work\dist\c9315887\doc\html\ghc-paths\index.html,
ghc-paths         > .stack-work\dist\c9315887\doc\html\ghc-paths\ghc-paths.txt
ghc-paths         > copy/register
ghc-paths         > Installing library in C:\sr\snapshots\dcef0976\lib\x86_64-windows-ghc-8.8.1\ghc-paths-0.1.0.12-6yfxCcKnGxxC3UhlLpLlce
syb               > Preprocessing library for syb-0.7.1..
syb               > Building library for syb-0.7.1..
ghc-paths         > Registering library for ghc-paths-0.1.0.12..
syb               > [ 1 of 16] Compiling Data.Generics.Aliases
base-compat       > Configuring base-compat-0.11.0...
syb               > [ 2 of 16] Compiling Data.Generics.Basics
syb               > [ 3 of 16] Compiling Data.Generics.Builders
base-compat       > build
syb               > [ 4 of 16] Compiling Data.Generics.Instances
base-compat       > Preprocessing library for base-compat-0.11.0..
base-compat       > Building library for base-compat-0.11.0..
syb               > [ 5 of 16] Compiling Data.Generics.Schemes
syb               > [ 6 of 16] Compiling Data.Generics.Text
syb               > [ 7 of 16] Compiling Data.Generics.Twins
syb               > [ 8 of 16] Compiling Data.Generics
syb               > [ 9 of 16] Compiling Generics.SYB
syb               > [10 of 16] Compiling Generics.SYB.Aliases
syb               > [11 of 16] Compiling Generics.SYB.Basics
syb               > [12 of 16] Compiling Generics.SYB.Builders
syb               > [13 of 16] Compiling Generics.SYB.Instances
syb               > [14 of 16] Compiling Generics.SYB.Schemes
syb               > [15 of 16] Compiling Generics.SYB.Text
syb               > [16 of 16] Compiling Generics.SYB.Twins
syb               > haddock
syb               > Preprocessing library for syb-0.7.1..
syb               > Running Haddock on library for syb-0.7.1..
base-compat       > [  1 of 114] Compiling Control.Concurrent.Compat
base-compat       > [  2 of 114] Compiling Control.Concurrent.Compat.Repl
base-compat       > [  3 of 114] Compiling Control.Concurrent.MVar.Compat
base-compat       > [  4 of 114] Compiling Control.Concurrent.MVar.Compat.Repl
base-compat       > [  5 of 114] Compiling Control.Exception.Compat
base-compat       > [  6 of 114] Compiling Control.Exception.Compat.Repl
base-compat       > [  7 of 114] Compiling Control.Monad.Compat
base-compat       > [  8 of 114] Compiling Control.Monad.Compat.Repl
base-compat       > [  9 of 114] Compiling Control.Monad.Fail.Compat
syb               > Haddock coverage:
syb               >   96% ( 43 / 45) in 'Data.Generics.Aliases'
syb               >   Missing documentation for:
syb               >     GenericQ' (src\\Data\\Generics\\Aliases.hs:268)
syb               >     GenericM' (src\\Data\\Generics\\Aliases.hs:269)
syb               >  100% (  2 /  2) in 'Data.Generics.Basics'
syb               >  100% (  3 /  3) in 'Data.Generics.Builders'
syb               >  100% (  1 /  1) in 'Data.Generics.Instances'
syb               >  100% ( 19 / 19) in 'Data.Generics.Schemes'
syb               >  100% (  6 /  6) in 'Data.Generics.Text'
syb               >  100% ( 17 / 17) in 'Data.Generics.Twins'
syb               >  100% (  8 /  8) in 'Data.Generics'
syb               >  100% (  2 /  2) in 'Generics.SYB'
syb               >  100% (  2 /  2) in 'Generics.SYB.Aliases'
syb               >  100% (  2 /  2) in 'Generics.SYB.Basics'
syb               >  100% (  2 /  2) in 'Generics.SYB.Builders'
syb               >  100% (  1 /  1) in 'Generics.SYB.Instances'
syb               >  100% (  2 /  2) in 'Generics.SYB.Schemes'
syb               >  100% (  2 /  2) in 'Generics.SYB.Text'
syb               >  100% (  2 /  2) in 'Generics.SYB.Twins'
syb               > Documentation created: .stack-work\dist\c9315887\doc\html\syb\index.html,
syb               > .stack-work\dist\c9315887\doc\html\syb\syb.txt
syb               > copy/register
base-compat       > [ 10 of 114] Compiling Control.Monad.Fail.Compat.Repl
base-compat       > [ 11 of 114] Compiling Control.Monad.IO.Class.Compat
syb               > Installing library in C:\sr\snapshots\dcef0976\lib\x86_64-windows-ghc-8.8.1\syb-0.7.1-HZot41yU46FEB2GjLEhNpM
base-compat       > [ 12 of 114] Compiling Control.Monad.IO.Class.Compat.Repl
base-compat       > [ 13 of 114] Compiling Control.Monad.ST.Lazy.Unsafe.Compat
base-compat       > [ 14 of 114] Compiling Control.Monad.ST.Lazy.Unsafe.Compat.Repl
syb               > Registering library for syb-0.7.1..
base-compat       > [ 15 of 114] Compiling Control.Monad.ST.Unsafe.Compat
base-compat       > [ 16 of 114] Compiling Control.Monad.ST.Unsafe.Compat.Repl
base-compat       > [ 17 of 114] Compiling Data.Bifoldable.Compat
base-compat       > [ 18 of 114] Compiling Data.Bifoldable.Compat.Repl
base-compat       > [ 19 of 114] Compiling Data.Bifunctor.Compat
base-compat       > [ 20 of 114] Compiling Data.Bifunctor.Compat.Repl
base-compat       > [ 21 of 114] Compiling Data.Bitraversable.Compat
base-compat       > [ 22 of 114] Compiling Data.Bitraversable.Compat.Repl
base-compat       > [ 23 of 114] Compiling Data.Bits.Compat
base-compat       > [ 24 of 114] Compiling Data.Bits.Compat.Repl
base-compat       > [ 25 of 114] Compiling Data.Bool.Compat
base-compat       > [ 26 of 114] Compiling Data.Bool.Compat.Repl
base-compat       > [ 27 of 114] Compiling Data.Complex.Compat
base-compat       > [ 28 of 114] Compiling Data.Complex.Compat.Repl
base-compat       > [ 29 of 114] Compiling Data.Either.Compat
base-compat       > [ 30 of 114] Compiling Data.Either.Compat.Repl
base-compat       > [ 31 of 114] Compiling Data.Foldable.Compat
base-compat       > [ 32 of 114] Compiling Data.Foldable.Compat.Repl
base-compat       > [ 33 of 114] Compiling Data.Function.Compat
base-compat       > [ 34 of 114] Compiling Data.Function.Compat.Repl
base-compat       > [ 35 of 114] Compiling Data.Functor.Compat
base-compat       > [ 36 of 114] Compiling Data.Functor.Compat.Repl
base-compat       > [ 37 of 114] Compiling Data.Functor.Compose.Compat
base-compat       > [ 38 of 114] Compiling Data.Functor.Compose.Compat.Repl
base-compat       > [ 39 of 114] Compiling Data.Functor.Const.Compat
base-compat       > [ 40 of 114] Compiling Data.Functor.Const.Compat.Repl
base-compat       > [ 41 of 114] Compiling Data.Functor.Contravariant.Compat
base-compat       > [ 42 of 114] Compiling Data.Functor.Contravariant.Compat.Repl
base-compat       > [ 43 of 114] Compiling Data.Functor.Identity.Compat
base-compat       > [ 44 of 114] Compiling Data.Functor.Identity.Compat.Repl
base-compat       > [ 45 of 114] Compiling Data.Functor.Product.Compat
base-compat       > [ 46 of 114] Compiling Data.Functor.Product.Compat.Repl
base-compat       > [ 47 of 114] Compiling Data.Functor.Sum.Compat
base-compat       > [ 48 of 114] Compiling Data.Functor.Sum.Compat.Repl
base-compat       > [ 49 of 114] Compiling Data.IORef.Compat
base-compat       > [ 50 of 114] Compiling Data.IORef.Compat.Repl
base-compat       > [ 51 of 114] Compiling Data.List.Compat
base-compat       > [ 52 of 114] Compiling Data.List.Compat.Repl
base-compat       > [ 53 of 114] Compiling Data.List.NonEmpty.Compat
base-compat       > [ 54 of 114] Compiling Data.List.NonEmpty.Compat.Repl
base-compat       > [ 55 of 114] Compiling Data.Monoid.Compat
base-compat       > [ 56 of 114] Compiling Data.Monoid.Compat.Repl
base-compat       > [ 57 of 114] Compiling Data.Proxy.Compat
base-compat       > [ 58 of 114] Compiling Data.Proxy.Compat.Repl
base-compat       > [ 59 of 114] Compiling Data.Ratio.Compat
base-compat       > [ 60 of 114] Compiling Data.Ratio.Compat.Repl
base-compat       > [ 61 of 114] Compiling Data.STRef.Compat
base-compat       > [ 62 of 114] Compiling Data.STRef.Compat.Repl
base-compat       > [ 63 of 114] Compiling Data.Semigroup.Compat
base-compat       > [ 64 of 114] Compiling Data.Semigroup.Compat.Repl
base-compat       > [ 65 of 114] Compiling Data.String.Compat
base-compat       > [ 66 of 114] Compiling Data.String.Compat.Repl
base-compat       > [ 67 of 114] Compiling Data.Type.Coercion.Compat
base-compat       > [ 68 of 114] Compiling Data.Type.Coercion.Compat.Repl
base-compat       > [ 69 of 114] Compiling Data.Type.Equality.Compat
base-compat       > [ 70 of 114] Compiling Data.Type.Equality.Compat.Repl
base-compat       > [ 71 of 114] Compiling Data.Version.Compat
base-compat       > [ 72 of 114] Compiling Data.Version.Compat.Repl
base-compat       > [ 73 of 114] Compiling Data.Void.Compat
base-compat       > [ 74 of 114] Compiling Data.Void.Compat.Repl
base-compat       > [ 75 of 114] Compiling Data.Word.Compat
base-compat       > [ 76 of 114] Compiling Data.Word.Compat.Repl
base-compat       > [ 77 of 114] Compiling Debug.Trace.Compat
base-compat       > [ 78 of 114] Compiling Debug.Trace.Compat.Repl
base-compat       > [ 79 of 114] Compiling Foreign.ForeignPtr.Compat
base-compat       > [ 80 of 114] Compiling Foreign.ForeignPtr.Compat.Repl
base-compat       > [ 81 of 114] Compiling Foreign.ForeignPtr.Safe.Compat
base-compat       > [ 82 of 114] Compiling Foreign.ForeignPtr.Safe.Compat.Repl
base-compat       > [ 83 of 114] Compiling Foreign.ForeignPtr.Unsafe.Compat
base-compat       > [ 84 of 114] Compiling Foreign.ForeignPtr.Unsafe.Compat.Repl
base-compat       > [ 85 of 114] Compiling Foreign.Marshal.Alloc.Compat
base-compat       > [ 86 of 114] Compiling Foreign.Marshal.Alloc.Compat.Repl
base-compat       > [ 87 of 114] Compiling Foreign.Marshal.Array.Compat
base-compat       > [ 88 of 114] Compiling Foreign.Marshal.Array.Compat.Repl
base-compat       > [ 89 of 114] Compiling Foreign.Marshal.Safe.Compat
base-compat       > [ 90 of 114] Compiling Foreign.Marshal.Safe.Compat.Repl
base-compat       > [ 91 of 114] Compiling Foreign.Marshal.Unsafe.Compat
base-compat       > [ 92 of 114] Compiling Foreign.Marshal.Unsafe.Compat.Repl
base-compat       > [ 93 of 114] Compiling Foreign.Marshal.Utils.Compat
base-compat       > [ 94 of 114] Compiling Foreign.Marshal.Compat
base-compat       > [ 95 of 114] Compiling Foreign.Marshal.Compat.Repl
base-compat       > [ 96 of 114] Compiling Foreign.Compat
base-compat       > [ 97 of 114] Compiling Foreign.Compat.Repl
base-compat       > [ 98 of 114] Compiling Foreign.Marshal.Utils.Compat.Repl
base-compat       > [ 99 of 114] Compiling Numeric.Compat
base-compat       > [100 of 114] Compiling Numeric.Compat.Repl
base-compat       > [101 of 114] Compiling Numeric.Natural.Compat
base-compat       > [102 of 114] Compiling Numeric.Natural.Compat.Repl
base-compat       > [103 of 114] Compiling Prelude.Compat
base-compat       > [104 of 114] Compiling Prelude.Compat.Repl
base-compat       > [105 of 114] Compiling System.Environment.Compat
base-compat       > [106 of 114] Compiling System.Environment.Compat.Repl
base-compat       > [107 of 114] Compiling System.Exit.Compat
base-compat       > [108 of 114] Compiling System.Exit.Compat.Repl
base-compat       > [109 of 114] Compiling System.IO.Unsafe.Compat
base-compat       > [110 of 114] Compiling System.IO.Unsafe.Compat.Repl
base-compat       > [111 of 114] Compiling Text.Read.Compat
base-compat       > [112 of 114] Compiling Text.Read.Compat.Repl
base-compat       > [113 of 114] Compiling Type.Reflection.Compat
base-compat       > [114 of 114] Compiling Type.Reflection.Compat.Repl
base-compat       > haddock
base-compat       > Preprocessing library for base-compat-0.11.0..
base-compat       > Running Haddock on library for base-compat-0.11.0..
base-compat       > Haddock coverage:
base-compat       >   75% (  3 /  4) in 'Control.Concurrent.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Concurrent.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Control.Concurrent.MVar.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Concurrent.MVar.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Control.Exception.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Exception.Compat.Repl'
base-compat       >   95% ( 39 / 41) in 'Control.Monad.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >     fail
base-compat       >  100% (  2 /  2) in 'Control.Monad.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Control.Monad.Fail.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Monad.Fail.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Control.Monad.IO.Class.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Monad.IO.Class.Compat.Repl'
base-compat       >   25% (  1 /  4) in 'Control.Monad.ST.Lazy.Unsafe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >     unsafeInterleaveST
base-compat       >     unsafeIOToST
base-compat       >  100% (  2 /  2) in 'Control.Monad.ST.Lazy.Unsafe.Compat.Repl'
base-compat       >   80% (  4 /  5) in 'Control.Monad.ST.Unsafe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Control.Monad.ST.Unsafe.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Bifoldable.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Bifoldable.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Bifunctor.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Bifunctor.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Bitraversable.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Bitraversable.Compat.Repl'
base-compat       >   83% (  5 /  6) in 'Data.Bits.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Bits.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.Bool.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Bool.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Complex.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Complex.Compat.Repl'
base-compat       >   83% (  5 /  6) in 'Data.Either.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Either.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Foldable.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Foldable.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.Function.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Function.Compat.Repl'
base-compat       >   83% (  5 /  6) in 'Data.Functor.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Compose.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Compose.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Const.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Const.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Contravariant.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Contravariant.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Identity.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Identity.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Product.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Product.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Functor.Sum.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Functor.Sum.Compat.Repl'
base-compat       >   80% (  4 /  5) in 'Data.IORef.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.IORef.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.List.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.List.Compat.Repl'
base-compat       >  100% ( 68 / 68) in 'Data.List.NonEmpty.Compat'
base-compat       >  100% (  2 /  2) in 'Data.List.NonEmpty.Compat.Repl'
base-compat       >   92% ( 12 / 13) in 'Data.Monoid.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Monoid.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.Proxy.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Proxy.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Ratio.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Ratio.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.STRef.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.STRef.Compat.Repl'
base-compat       >   86% ( 25 / 29) in 'Data.Semigroup.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Min
base-compat       >     Max
base-compat       >     ArgMin
base-compat       >     ArgMax
base-compat       >  100% (  2 /  2) in 'Data.Semigroup.Compat.Repl'
base-compat       >   86% (  6 /  7) in 'Data.String.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.String.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.Type.Coercion.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Type.Coercion.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Type.Equality.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Type.Equality.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Data.Version.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Version.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Data.Void.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Void.Compat.Repl'
base-compat       >   80% (  4 /  5) in 'Data.Word.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Data.Word.Compat.Repl'
base-compat       >   83% (  5 /  6) in 'Debug.Trace.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Debug.Trace.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Foreign.ForeignPtr.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.ForeignPtr.Compat.Repl'
base-compat       >   90% ( 19 / 21) in 'Foreign.ForeignPtr.Safe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >     FinalizerEnvPtr
base-compat       >  100% (  2 /  2) in 'Foreign.ForeignPtr.Safe.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Foreign.ForeignPtr.Unsafe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.ForeignPtr.Unsafe.Compat.Repl'
base-compat       >   75% (  3 /  4) in 'Foreign.Marshal.Alloc.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Alloc.Compat.Repl'
base-compat       >   75% (  3 /  4) in 'Foreign.Marshal.Array.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Array.Compat.Repl'
base-compat       >   86% (  6 /  7) in 'Foreign.Marshal.Safe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Safe.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Foreign.Marshal.Unsafe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Unsafe.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Foreign.Marshal.Utils.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >   80% (  4 /  5) in 'Foreign.Marshal.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Foreign.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Foreign.Compat.Repl'
base-compat       >  100% (  2 /  2) in 'Foreign.Marshal.Utils.Compat.Repl'
base-compat       >   80% (  4 /  5) in 'Numeric.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Numeric.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Numeric.Natural.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Numeric.Natural.Compat.Repl'
base-compat       >   50% (  1 /  2) in 'Prelude.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Prelude.Compat.Repl'
base-compat       >  100% ( 10 / 10) in 'System.Environment.Compat'
base-compat       >  100% (  2 /  2) in 'System.Environment.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'System.Exit.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'System.Exit.Compat.Repl'
base-compat       >   75% (  3 /  4) in 'System.IO.Unsafe.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'System.IO.Unsafe.Compat.Repl'
base-compat       >   89% ( 16 / 18) in 'Text.Read.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >     Lexeme
base-compat       >  100% (  2 /  2) in 'Text.Read.Compat.Repl'
base-compat       >   67% (  2 /  3) in 'Type.Reflection.Compat'
base-compat       >   Missing documentation for:
base-compat       >     Module header
base-compat       >  100% (  2 /  2) in 'Type.Reflection.Compat.Repl'
base-compat       > Warning: Control.Monad.Compat: could not find link destinations for:
base-compat       >     P
base-compat       > Warning: Data.Functor.Compat: could not find link destinations for:
base-compat       >     P
base-compat       > Documentation created:
base-compat       > .stack-work\dist\c9315887\doc\html\base-compat\index.html,
base-compat       > .stack-work\dist\c9315887\doc\html\base-compat\base-compat.txt
base-compat       > copy/register
base-compat       > Installing library in C:\sr\snapshots\dcef0976\lib\x86_64-windows-ghc-8.8.1\base-compat-0.11.0-IUGBGeJIgNtP5NwLNHE37
base-compat       > Registering library for base-compat-0.11.0..

--  While building package code-page-0.2 using:
      C:\sr\setup-exe-cache\x86_64-windows\Cabal-simple_Z6RU0evB_3.0.0.0_ghc-8.8.1.exe --builddir=.stack-work\dist\c9315887 haddock --html --hoogle --html-location=../$pkg-$version/ --haddock-option=--hyperlinked-source --haddock-option=--quickjump
    Process exited with code: ExitFailure 1
Progress 4/7

$ stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
Selected resolver: nightly-2019-11-02
Stack has not been tested with GHC versions above 8.6, and using 8.8.1, this may fail
Stack has not been tested with Cabal versions above 2.4, but version 3.0.0.0 was found, this may fail
code-page         > configure
code-page         > Configuring code-page-0.2...
code-page         > build
code-page         > Preprocessing library for code-page-0.2..
code-page         > Building library for code-page-0.2..
code-page         > [1 of 3] Compiling System.Win32.CodePage
code-page         > [2 of 3] Compiling System.IO.CodePage.Internal
code-page         > [3 of 3] Compiling System.IO.CodePage
code-page         > haddock
code-page         > Preprocessing library for code-page-0.2..
code-page         > Running Haddock on library for code-page-0.2..
code-page         > Haddock coverage:
code-page         >   42% (  8 / 19) in 'System.Win32.CodePage'
code-page         >   Missing documentation for:
code-page         >     CodePage
code-page         >     getConsoleCP
code-page         >     getConsoleOutputCP
code-page         >     setConsoleCP
code-page         >     setConsoleOutputCP
code-page         >     getACP
code-page         >     getOEMCP
code-page         >     codePageEncoding
code-page         >     mkCodePageEncoding
code-page         >     isValidCodePage
code-page         >     stringToUnicode
code-page         > Warning: 'withCodePage' is out of scope.
code-page         >     If you qualify the identifier, haddock can try to link it anyway.
code-page         >  100% ( 14 / 14) in 'System.IO.CodePage.Internal'
code-page         >  100% ( 30 / 30) in 'System.IO.CodePage'
code-page         > haddock: internal error: couldn't find ast for .stack-work\dist\c9315887\build\System\Win32\CodePage.hs [".stack-work\\\\dist\\\\c9315887\\\\build\\\\System\\\\Win32\\\\CodePage.hs","src\\System\\Win32\\CodePage.hsc"]
code-page         > CallStack (from HasCallStack):
code-page         >   error, called at utils\haddock\haddock-api\src\Haddock\Backends\Hyperlinker.hs:78:28 in main:Haddock.Backends.Hyperlinker

--  While building package code-page-0.2 using:
      C:\sr\setup-exe-cache\x86_64-windows\Cabal-simple_Z6RU0evB_3.0.0.0_ghc-8.8.1.exe --builddir=.stack-work\dist\c9315887 haddock --html --hoogle --html-location=../$pkg-$version/ --haddock-option=--hyperlinked-source --haddock-option=--quickjump
    Process exited with code: ExitFailure 1
Progress 1/4
```

</details>

I have successfully run `stack build --resolver nightly --haddock --no-haddock-deps --test --bench --no-run-benchmarks`.