### PR TITLE
Reenable monad-par's tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5226,7 +5226,6 @@ skipped-tests:
     - kanji
     - megaparsec
     - mighty-metropolis
-    - monad-par
     - multiarg
     - mustache
     - opml-conduit


### PR DESCRIPTION
They were originally removed due to not compiling with GHC 8.6, but this is fixed as of `monad-par-0.3.5`.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
