### PR TITLE
Re-enable data-dword

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4139,7 +4139,7 @@ packages:
         - data-default-instances-containers
         - data-default-instances-dlist
         - data-default-instances-old-locale
-        - data-dword < 0 # template-haskell
+        - data-dword
         - data-endian
         - data-inttrie
         - data-lens-light


### PR DESCRIPTION
Re-enable data-dword

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
