### PR TITLE
Re-enable text-builder, network-ip, postgresql-binary and hasql

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1342,7 +1342,7 @@ packages:
         - base-prelude
         - cases
         - focus
-        - hasql < 0 # via postgresql-binary
+        - hasql
         - hasql-optparse-applicative < 0 # via hasql
         - hasql-pool < 0 # via hasql
         - hasql-transaction < 0 # via hasql
@@ -4624,7 +4624,6 @@ packages:
         - network-attoparsec < 0 # via network-simple
         - network-bsd < 0 # via network-3.1.1.0
         - network-house < 0 # MonadFail
-        - network-ip < 0 # via data-dword
         - network-messagepack-rpc < 0 # via data-msgpack
         - network-multicast < 0 # via network-bsd
         - network-simple < 0 # via network-bsd
@@ -4680,7 +4679,6 @@ packages:
         - plot-light < 0 # transitive compilation failure
         - polysemy-plugin < 0 # via polysemy
         - polysemy-zoo < 0 # via hedis
-        - postgresql-binary < 0 # via network-ip
         - postgresql-schema < 0 # via postgresql-simple
         - postgresql-simple-migration < 0 # via time-1.9.3
         - postgresql-simple-queue < 0 # via pg-transact
@@ -4795,7 +4793,6 @@ packages:
         - termonad < 0 # via gi-vte
         - testing-feat < 0 # via size-based
         - texmath < 0 # via pandoc-types
-        - text-builder < 0 # via deferred-folds
         - text-format < 0 # via base-4.13.0.0
         - th-nowq < 0 # via time-1.9.3
         - th-utilities < 0 # template-haskell
@@ -5077,7 +5074,6 @@ skipped-tests:
     - crypto-api-tests # via test-framework
     - crypto-cipher-tests # via test-framework
     - ctrie # via test-framework
-    - data-textual # via test-framework
     - deepseq-generics # via test-framework
     - doldol # via test-framework
     - double-conversion # via test-framework


### PR DESCRIPTION
- text-builder's dependency on deferred-folds is already satisfied.
- network-ip's dependencies are now satisfied
- postgresql-binary was blocked on network-ip
- hasql was blocked on postgresql-binary and text-builder

Also:

- re-enable tests of data-textual (works with GHC 8.8 as of 0.3.0.3)

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
