### PR TITLE
Re-enable additional hasql modules

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1343,9 +1343,9 @@ packages:
         - cases
         - focus
         - hasql
-        - hasql-optparse-applicative < 0 # via hasql
-        - hasql-pool < 0 # via hasql
-        - hasql-transaction < 0 # via hasql
+        - hasql-optparse-applicative
+        - hasql-pool
+        - hasql-transaction
         - list-t
         - mtl-prelude
         - neat-interpolation


### PR DESCRIPTION
Now that the base hasql module is available, also re-enable

- hasql-transaction
- hasql-pool
- hasql-optparse-applicative

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
