### PR TITLE
Restore core-text, core-data, core-program

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2416,9 +2416,9 @@ packages:
         - http-common
         - http-streams < 0 # via io-streams & openssl-streams
         - locators
-        - core-data < 0 # via prettyprinter-1.3.0
-        - core-program < 0 # via prettyprinter-1.3.0 and template-haskell-2.15
-        - core-text < 0 # via prettyprinter-1.3.0 and template-haskell-2.15
+        - core-data
+        - core-program
+        - core-text
 
     "Sean Hunt <scshunt@csclub.uwaterloo.ca @scshunt":
         - cheapskate < 0 # via blaze-html


### PR DESCRIPTION
Upper bounds have been relaxed for the dependencies on **prettyprinter** and **template-haskell**; testing with GHC 8.6.5 via `lts-14.14` and GHC 8.8.1 via `nightly-2019-11-11` has shown full compatibility.
