### PR TITLE
Restore rainbow

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4696,7 +4696,6 @@ packages:
         - pure-zlib < 0 # via base-compat-0.11.0
         - raaz < 0 # via base-4.13.0.0
         - radius < 0 # via iproute
-        - rainbow < 0 # via lens-simple
         - rainbox < 0 # via lens-simple
         - random-source < 0 # via flexible-defaults
         - rasterific-svg < 0 # via Rasterific

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -639,7 +639,6 @@ packages:
         - ofx
         - accuerr
         - timelens
-        - non-empty-sequence
 
     "Neil Mitchell <ndmitchell@gmail.com> @ndmitchell":
         - hlint
@@ -4510,6 +4509,7 @@ packages:
     # See https://github.com/fpco/stackage/issues/1056
     "Abandoned packages":
         - curl
+        - non-empty-sequence
 
         # Purescript
         - bower-json


### PR DESCRIPTION
Restore the rainbow package.  Removed dependency on lens-simple, which is no longer in stockage-nightly.  It now builds with nightly-2019-11-11.

Checklist:
- [X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X ] At least 30 minutes have passed since uploading to Hackage
- [X ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
