### PR TITLE
Re-enable universum and o-clock

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4637,7 +4637,6 @@ packages:
         - nvim-hs < 0 # via hslogger
         - nvim-hs-contrib < 0 # via nvim-hs
         - nvvm < 0 # via cuda
-        - o-clock < 0 # compilation failure
         - oblivious-transfer < 0 # via protolude
         - oeis < 0 # via test-framework
         - oeis < 0 # via test-framework-hunit
@@ -4816,7 +4815,6 @@ packages:
         - unbound-generics < 0 # MonadFail
         - union < 0 # via base-4.13.0.0
         - universe-dependent-sum < 0 # via some
-        - universum < 0 # via text-1.2.4.0
         - unliftio-streams < 0 # via io-streams
         - uri-templater < 0 # via HTTP
         - users-postgresql-simple < 0 # via postgresql-simple
@@ -5254,7 +5252,6 @@ skipped-tests:
     - speedy-slice
     - static-text
     - thyme
-    - universum
     - unordered-containers
     - unordered-intmap
     - vector-builder
@@ -5266,7 +5263,6 @@ skipped-tests:
 
     # Transitive outdated dependencies
     # These can also be checked for updates periodically.
-    - o-clock # tasty 0.12 via tasty-hedgehog
     - options # ansi-terminal-0.8 via chell
     - path # via genvalidity genvalidity-property
     - system-fileio # ansi-terminal-0.8 via chell


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack universum-1.6.1
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

  and

      stack unpack o-clock-1.1.0
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

