### PR TITLE
Reinstate rainbow

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4868,9 +4868,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/4992
       - swagger2 < 2.5
 
-      # https://github.com/commercialhaskell/stackage/issues/4994
-      - rainbow < 0.34.1
-
       # https://github.com/commercialhaskell/stackage/issues/4998
       -  monad-logger-syslog < 0.1.6.0
 # end of packages


### PR DESCRIPTION
Now compiles with nightly-2019-11-29.  Version 0.34.2.2 hopefully fixes

https://github.com/commercialhaskell/stackage/issues/4994

Checklist:
- [X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X ] At least 30 minutes have passed since uploading to Hackage
- [X ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
