### PR TITLE
Re-enable yesod-auth-hashdb in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4851,7 +4851,6 @@ packages:
         - yeshql-core < 0 # MonadFail
         - yeshql-hdbc < 0 # via HDBC
         - yesod-alerts < 0 # via yesod-core
-        - yesod-auth-hashdb < 0 # via yesod-test
         - yesod-csp < 0 # via yesod-core
         - yesod-eventsource < 0 # via yesod-core
         - yesod-fb < 0 # via yesod-core


### PR DESCRIPTION
It was blocked on `yesod-test`, which now appears to be resolved and is in nightly.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
