### PR TITLE
Reenable tasty-rerun

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2194,7 +2194,6 @@ packages:
         - exhaustive < 0 # GHC 8.4 via base-4.11.0.0
         - libsystemd-journal < 0 # GHC 8.4 via base-4.11.0.0
         - network-carbon < 0 # GHC 8.4 via base-4.11.0.0
-        - tasty-rerun < 0 # GHC 8.4 via base-4.11.0.0
         - logging-effect
         - dhall-to-cabal < 0
         # - reactive-banana # pqueue-1.4.1
@@ -3075,6 +3074,7 @@ packages:
         - data-interval
         - vector-rotcev
         - mod
+        - tasty-rerun
 
     "Ashley Yakeley <ashley@semantic.org> @AshleyYakeley":
         - countable


### PR DESCRIPTION
I moved the package under my section, because I am a new comaintainer and responsible for the latest release. Closes https://github.com/ocharles/tasty-rerun/issues/12

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
