### PR TITLE
Reinstate rainbox

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4696,7 +4696,6 @@ packages:
         - pure-zlib < 0 # via base-compat-0.11.0
         - raaz < 0 # via base-4.13.0.0
         - radius < 0 # via iproute
-        - rainbox < 0 # via lens-simple
         - random-source < 0 # via flexible-defaults
         - rasterific-svg < 0 # via Rasterific
         - ref-fd < 0 # bounds failure


### PR DESCRIPTION
It had been removed due to a dependency issue which has been resolved.  Now compiles against nightly.

Checklist:
- [X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X ] At least 30 minutes have passed since uploading to Hackage
- [X ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
