### PR TITLE
Remove tmp-postgres version constraint #4790

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3230,7 +3230,7 @@ packages:
         - next-ref < 0
         - threads-extras < 0
         - postgres-options
-        - tmp-postgres < 0.3 # https://github.com/commercialhaskell/stackage/issues/4790
+        - tmp-postgres
         - pg-transact
         - hspec-pg-transact < 0 # via tmp-postgres
         - postgresql-simple-queue


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
