### PR TITLE
Restore wreq and mustache

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4628,7 +4628,6 @@ packages:
         - mpi-hs < 0 # via store
         - msgpack < 0 # via base-4.13.0.0
         - msgpack-aeson < 0 # via msgpack
-        - mustache < 0 # Lift Text
         - mwc-probability-transition < 0 # via logging-effect
         - mysql-haskell < 0 # via memory-0.15.0
         - mysql-haskell-nem < 0 # via io-streams
@@ -4833,7 +4832,6 @@ packages:
         - witherable < 0 # via monoidal-containers
         - wl-pprint-text < 0 # via base-compat-0.11.0
         - wordpress-auth < 0 # via http-types
-        - wreq < 0 # via authenticate-oauth
         - ws < 0 # via attoparsec-uri
         - ws < 0 # via wuss
         - xenstore < 0 # sClose not in scope
@@ -5223,7 +5221,6 @@ skipped-tests:
     - megaparsec
     - mighty-metropolis
     - multiarg
-    - mustache
     - opml-conduit
     - pipes-csv
     - postgresql-simple


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Tests pass for mustache. Tests still skipped for wreq because of incompatible snap-server dependency.