### PR TITLE
Reenable shortcut-links

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2296,7 +2296,6 @@ packages:
         - microlens-th
         - microlens-ghc
         - microlens-contra
-        - shortcut-links
         - cheapskate-highlight < 0 # via blaze-html
         - cheapskate-lucid < 0 # via blaze-html
         - cmark-lucid < 0 # GHC 8.4 via cmark
@@ -3556,6 +3555,7 @@ packages:
         - first-class-patterns
         - relude
         - shellmet
+        - shortcut-links
         - summoner < 0 # via base-4.13.0.0
         - tomland
         - typerep-map
@@ -4729,7 +4729,6 @@ packages:
         - sexpr-parser < 0 # via base-4.13.0.0
         - shake-language-c < 0 # via fclabels
         - shikensu < 0 # via flow
-        - shortcut-links < 0 # MonadFail
         - show-prettyprint < 0 # via trifecta
         - shower < 0 # via base-4.13.0.0
         - simple < 0 # https://github.com/alevy/simple/issues/23


### PR DESCRIPTION
Moving the package under Kowainik maintenance, reenable with the support of GHC-8.8.1.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
