### PR TITLE
IPv6Addr package fixed in v1.1.3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2095,7 +2095,7 @@ packages:
         - matrices
 
     "Michel Boucey <michel.boucey@gmail.com> @MichelBoucey":
-        - IPv6Addr < 0 # via test-framework & test-framework-hunit
+        - IPv6Addr
         - ip6addr < 0 # via IPv6Addr
         - cayley-client < 0 # via lens-4.18.1
         - Spintax


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
