### PR TITLE
yesod-auth-hashdb tests working again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5306,7 +5306,6 @@ expected-test-failures:
     - yeshql-core # https://github.com/tdammers/yeshql/issues/6
     - yeshql-hdbc # https://github.com/tdammers/yeshql/issues/6
     - yesod-gitrev # https://github.com/DanBurton/yesod-gitrev/issues/5
-    - yesod-auth-hashdb # https://github.com/commercialhaskell/stackage/issues/5047
 
     # Recursive deps https://github.com/fpco/stackage/issues/1818
     - options


### PR DESCRIPTION

Fixes #5047

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
