### PR TITLE
Re-enable cron

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2049,7 +2049,7 @@ packages:
 
     "Michael Xavier <michael@michaelxavier.net> @MichaelXavier":
         - uri-bytestring
-        - cron < 0 # MonadFail
+        - cron
         # - tasty-tap # https://github.com/MichaelXavier/tasty-tap/issues/2
         # - tasty-fail-fast # https://github.com/MichaelXavier/tasty-tap/issues/2
         - drifter < 0


### PR DESCRIPTION
Cron now properly supports MonadFail and builds against GHC 8.4.4, 8.6.5, 8.8.1

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
