### PR TITLE
Reinstate massiv-io, since netpbm is being included in snapshots

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3302,7 +3302,7 @@ packages:
         - wai-middleware-auth < 0 # via hoauth2
         # - hip # lens 4.16 via diagrams/chart
         - massiv
-        - massiv-io < 0 # via netpbm
+        - massiv-io
         - massiv-test
         - scheduler
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
