### PR TITLE
Mark password-instances as building.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2361,7 +2361,7 @@ packages:
         - hailgun < 0 # via http-client-0.6.1
         - natural-transformation
         - password
-        - password-instances < 0 # via persistent
+        - password-instances
         - pretty-simple
         - print-console-colors
         - read-env-var


### PR DESCRIPTION
Mark the `password-instances` package as building.

This requires a new release of password-instances (0.3.0.1), which I uploaded on 2020-01-17.

nightly-2020-01-17 only has the old version of password-instances (0.3.0.0), so this PR should probably only be merged in after nightly-2020-01-18 (or whatever the next version is).

----------------

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
