### PR TITLE
Re-enable scalpel

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1908,8 +1908,8 @@ packages:
     "Will Coster <willcoster@gmail.com> @fimad":
         - prometheus-client
         - prometheus-metrics-ghc < 0 # Build failure: https://github.com/fimad/prometheus-haskell/issues/39
-        - scalpel < 0 # via scalpel-core
-        - scalpel-core < 0 # compilation error
+        - scalpel
+        - scalpel-core
         - wai-middleware-prometheus < 0 # GHC 8.4 via prometheus-client
 
     "William Casarin <bill@casarin.me> @jb55":


### PR DESCRIPTION
Version 0.6.1 was just published which works with the latest nightly stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
