### PR TITLE
Restore ghc-syntax-highlighter & revdeps

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2515,7 +2515,7 @@ packages:
         - flac
         - flac-picture
         - forma
-        - ghc-syntax-highlighter < 0 # https://github.com/mrkkrp/ghc-syntax-highlighter/issues/14
+        - ghc-syntax-highlighter
         - hspec-megaparsec
         - htaglib
         - html-entity-map
@@ -2524,8 +2524,8 @@ packages:
         - megaparsec
         - megaparsec-tests
         - mmark
-        - mmark-cli < 0 # via ghc-syntax-highlighter
-        - mmark-ext < 0 # via ghc-syntax-highlighter
+        - mmark-cli
+        - mmark-ext
         - modern-uri
         - pagination
         - parser-combinators


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

(Tested ghc-syntax-highlighter only; haddocks untested)