### PR TITLE
New version of massiv-test has been uploaded to hackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3308,7 +3308,7 @@ packages:
         # - hip # lens 4.16 via diagrams/chart
         - massiv
         - massiv-io
-        # - massiv-test # https://github.com/lehins/massiv/issues/90
+        - massiv-test
         - scheduler
         - Color
 


### PR DESCRIPTION
Fix for lehins/massiv#90

@juhp, sorry for delaying the upload of a new version and thanks for catching the build issue.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
