### PR TITLE
Re-allow http-streams tests to be run

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4879,7 +4879,6 @@ skipped-tests:
     - hackage-security # QuickCheck
     - haddock-library # base-compat-0.10.1, hspec-2.5.1
     - haskell-names # via tasty-1.2
-    - http-streams # via snap-server-1.1.0.0
     - hw-balancedparens # via QuickCheck-2.12.6.1, via hspec-2.6.0
     - hw-bits # via QuickCheck-2.12.6.1
     - hw-excess # via QuickCheck-2.12.6.1, via hspec-2.6.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands 

```
$ stack unpack http-streams-0.8.7.1
$ cd http-streams-0.8.7.1
$ stack init --resolver lts-14.21
$ stack build --resolver lts-14.21 --haddock --test --bench --no-run-benchmarks
```

`nightly-2020-01-21` doesn't have some prerequisites (I'll see if I can work on that over the weekend) but at least this package can be removed from the "don't test" list.