### PR TITLE
Restore xlsx and xlsx-tabular

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2258,7 +2258,7 @@ packages:
         - type-equality
 
     "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
-        - xlsx < 0 # MonadFail
+        - xlsx
 
     "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
         - monad-logger-prefix
@@ -2831,7 +2831,7 @@ packages:
         - free-vl
 
     "Kazuo Koga <obiwanko@me.com> @kkazuo":
-        - xlsx-tabular < 0 # via xlsx
+        - xlsx-tabular
 
     "Mikhail Glushenkov <mikhail.glushenkov@gmail.com> @23Skidoo":
         - Cabal


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

xlsx 0.8.0 fixed the MonadFail related issues with GHC 8.8.