### PR TITLE
Re-enable wikicfp-scraper

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2982,7 +2982,7 @@ packages:
         - fold-debounce
         - fold-debounce-conduit
         - stopwatch
-        - wikicfp-scraper < 0 # via scalpel-core
+        - wikicfp-scraper
         - wild-bind
         - wild-bind-x11
         - greskell


### PR DESCRIPTION
Now scalpel-core is fixed and included in stackage nightly.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
