### PR TITLE
Remove phadej mentions from build-constraints

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5752,9 +5752,6 @@ github-users:
         - RyanGlScott
     haskell-compat:
         - RyanGlScott
-    haskell-servant:
-        - phadej
-        - jkarni
     vivid:
         - vivid-synth
     midair:
@@ -5768,14 +5765,11 @@ github-users:
     arithmoi:
         - Bodigrim
         - cartazio
-        - phadej
     IxpertaSolutions:
         - Siprj
         - liskin
         - trskop
         - xkollar
-    futurice:
-        - phadej
     ekmett:
         - RyanGlScott
     onrock-eng:


### PR DESCRIPTION
- julian karni weren't active in servant maintenance,
  i'm not active either
- I don't know why I was under `arithmoi` (maybe integer-logarithms, but
  that's grandfathered dependency atm)
- futurice don't have any projects on stackage afaik,
  and I'm not even employee for some time already.

This leaves servant without a go to maintainer on Stackage, I hope someone would volunteer.