### PR TITLE
re-enable pandoc-csv2table in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4033,7 +4033,7 @@ packages:
         - rope-utf16-splay
 
     "Venkateswara Rao Mandela <venkat.mandela@gmail.com> @vmandela":
-        - pandoc-csv2table < 0 # https://github.com/baig/pandoc-csv2table/issues/27
+        - pandoc-csv2table
 
     "Elben Shira <elben@shira.im> @elben":
         - pencil < 0 # via hsass


### PR DESCRIPTION
baig/pandoc-csv2table#27 is fixed with commit

https://github.com/baig/pandoc-csv2table/commit/0bc7c52dba1870feb2361bbc397c7fab8518f213

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

CI output - https://travis-ci.org/vmandela/pandoc-csv2table/builds/642254761
