### PR TITLE
re-add flat-mcmc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2562,7 +2562,7 @@ packages:
         - hasty-hamiltonian
         - declarative
         - sampling
-        - flat-mcmc < 0 # via monad-par
+        - flat-mcmc
         - urbit-hob
         - hnock
 
@@ -4083,7 +4083,7 @@ packages:
         - climb
         - heart-core
         - linenoise
-        
+
     "Jorah Gao <jorah@version.cloud> @gqk007":
         - vformat
         - hkd-default


### PR DESCRIPTION
(Not sure what had gone wrong with this one -- it builds fine for me on nightly.)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
