### PR TITLE
Reinstate 'scheduler' benchmarks.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5493,7 +5493,6 @@ skipped-benchmarks:
     - identicon # via criterion-1.5.0.0
     - pipes # optparse-applicative 0.13
     - psqueues # ghc 8.4 via PSQueue build failure
-    - scheduler # https://github.com/commercialhaskell/stackage/issues/4983
     - serialise
     - skylighting-core # via criterion-1.5.0.0
     - snap-server # via criterion-1.5.0.0


### PR DESCRIPTION
 Upper bound on streamly was removed. Fix #4983

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
