### PR TITLE
reintroduce gloss

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1892,8 +1892,6 @@ packages:
 
         - bmp # @benl23x5
         - ekg-statsd < 0 # @tibbe via base-4.13.0.0 & time-1.9.3
-        - gloss < 0 # @benl23x5 # via base-4.13.0.0
-        - gloss-rendering < 0 # @benl23x5 # via base-4.13.0.0
         - gpolyline # @fegu
         - postgresql-simple-migration < 0 # via time-1.9.3 # @ameingast
         - statestack


### PR DESCRIPTION
gloss and gloss rendering were multiply listed in build-constraints.yaml

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
