### PR TITLE
Relax pretty-show (#5118 resolved)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4394,7 +4394,7 @@ packages:
         - postgresql-simple
         - postgresql-simple-url < 0 # via postgresql-simple
         - pretty-hex
-        - pretty-show < 1.10 # https://github.com/commercialhaskell/stackage/issues/5118
+        - pretty-show
         - prettyprinter-convert-ansi-wl-pprint
         - primes
         - primitive


### PR DESCRIPTION
#5118 should now be resolved with the following updates:

- `hedgehog-1.0.2@rev:2`
- `pretty-sop-0.2.0.3@rev:1`
