### PR TITLE
Enable linear-1.21

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -867,7 +867,7 @@ packages:
         - lens-action
         - lens-aeson
         - lens-properties
-        - linear < 1.21 # https://github.com/commercialhaskell/stackage/issues/5123
+        - linear
         - linear-accelerate < 0 # GHC 8.4 via accelerate
         - log-domain
         - machines
@@ -4142,7 +4142,7 @@ packages:
 
     "8c6794b6 <8c6794b6@gmail.com> @8c6794b6":
         - hpc-codecov
-    
+
     "Hiromi Ishii <konn.jinro@gmail.com> @konn":
         - equational-reasoning
         - ghc-typelits-presburger


### PR DESCRIPTION
All of the dependencies listed in #5123 that were blocking version
1.21 of `linear` have been updated to allow building with it.

Fixes #5123.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
