### PR TITLE
Re-enable debian, which has been switched to bz2 from bzlib

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1172,13 +1172,13 @@ packages:
         - HandsomeSoup
 
     "Clint Adams <clint@debian.org> @clinty":
-        - hOpenPGP < 0 # via bzlib, https://github.com/commercialhaskell/stackage/issues/5175
+        - hOpenPGP < 0 # via ixset-typed, https://github.com/commercialhaskell/stackage/issues/5175
         - openpgp-asciiarmor
         - MusicBrainz
         - DAV
         - hopenpgp-tools < 0 # hOpenPGP & ixset-typed
         - opensource
-        - debian < 0 # via bzlib
+        - debian
         - cabal-debian < 0 # via debian
 
     "Piyush P Kurur <ppk@cse.iitk.ac.in> @piyush-kurur":


### PR DESCRIPTION
Partially addresses https://github.com/commercialhaskell/stackage/issues/5175