### PR TITLE
Update build instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@ Checklist:
 - [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):
 
       stack unpack $package-$version  # $version is optional
-      stack init --resolver nightly
+      cd $package-$version
+      rm -f stack.yaml && stack init --resolver nightly
       stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### PR DESCRIPTION
... to bring them closer to what's described in MAINTAINERS.md.

In particular, the `cd` and `rm -f stack.yaml` steps were missing.