### PR TITLE
Re-enabled alarmclock and bank-holidays-england

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1457,8 +1457,8 @@ packages:
         - shake-language-c < 0 # via fclabels
 
     "David Turner <dave.c.turner@gmail.com> @davecturner":
-        - alarmclock < 0 # via base-4.13.0.0
-        - bank-holidays-england < 0 # via base-4.13.0.0
+        - alarmclock
+        - bank-holidays-england
 
     "Haskell Servant <haskell-servant-maintainers@googlegroups.com>":
         - servant


### PR DESCRIPTION
I'm now joint maintainer on both these packages and have released new versions that work on 8.8

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
