### PR TITLE
Remove persistent-typed-db from skipped-tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5123,7 +5123,6 @@ skipped-tests:
     - cron # Could not deduce (SOP.All (SOP.All Arbitrary) xss) arising from a use of ‘SOP.hcpure’
     - config-ini # https://github.com/aisamanra/config-ini/issues/22
     - polysemy-plugin # https://github.com/commercialhaskell/stackage/issues/4733
-    - persistent-typed-db # https://github.com/parsonsmatt/persistent-typed-db/pull/7
     - primitive-extras # https://github.com/commercialhaskell/stackage/issues/5210
 
     # Runtime issues


### PR DESCRIPTION
Issue is fixed in 0.1.0.1

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
