### PR TITLE
Bring back HaTeX to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1045,7 +1045,7 @@ packages:
         - Clipboard
         - grouped-list < 0 # via base-4.13.0.0
         - haskintex < 0 # via hint
-        - HaTeX < 0 # MonadFail
+        - HaTeX
         - include-file
         - matrix
         - pcre-light


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
