### PR TITLE
Enable interpolatedstring-perl6.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1367,7 +1367,7 @@ packages:
         - here
         - hlibgit2
         # - gitlib-libgit2 # via gitlib: https://github.com/jwiegley/gitlib/issues/72
-        - interpolatedstring-perl6 < 0
+        - interpolatedstring-perl6
         - iproute
         - missing-foreign
         - MissingH < 0 # via array-0.5.4.0 & base-4.13.0.0 & containers-0.6.2.1 & directory-1.3.3.2 & filepath-1.4.2.1 & old-time-1.1.0.3 & process-1.6.5.1 & time-1.9.3 & unix-2.7.2.2


### PR DESCRIPTION
This was disabled in 33c842ddf91a199e5 as a miscellaneous GHC 8.8-
related build failure. It builds fine for me now with nightly.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
