### PR TITLE
Enable string-interpolation.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1367,7 +1367,7 @@ packages:
         - here
         - hlibgit2
         # - gitlib-libgit2 # via gitlib: https://github.com/jwiegley/gitlib/issues/72
-        - interpolatedstring-perl6 < 0
+        - interpolatedstring-perl6
         - iproute
         - missing-foreign
         - MissingH < 0 # via array-0.5.4.0 & base-4.13.0.0 & containers-0.6.2.1 & directory-1.3.3.2 & filepath-1.4.2.1 & old-time-1.1.0.3 & process-1.6.5.1 & time-1.9.3 & unix-2.7.2.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -85,7 +85,7 @@ packages:
         - loopbreaker
 
     "William Yao <williamyaoh@gmail.com> @williamyaoh":
-        - string-interpolate < 0 # via interpolatedstring-perl6
+        - string-interpolate
 
     "Roel van Dijk <roel@lambdacube.nl> @roelvandijk":
         - terminal-progress-bar


### PR DESCRIPTION
This is on top of #5232. string-interpolation was blocked because of interpolatedstring-perl6.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage): (no because interpolatedstring-perl6 is not in stackage yet)

Instead this ran successfully with manual stack.yaml and extra-dep for interpolatedstring-perl6:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      cat stack.yaml
        resolver: nightly-2020-03-07
        packages:
        - .
        extra-deps:
        - interpolatedstring-perl6-1.0.2
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
