### PR TITLE
Enable hspec-wai-json.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -921,7 +921,7 @@ packages:
         - hspec-core
         - hspec-discover
         - hspec-wai
-        - hspec-wai-json < 0 # via hspec-wai
+        - hspec-wai-json
         - aeson-qq
         - interpolate
         - doctest


### PR DESCRIPTION
The comment claimed this was due to hspec-wai, but hspec-wai is in. Anyway, it seems to build fine.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
