### PR TITLE
Enable tests for configurator-pg

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5374,7 +5374,6 @@ expected-test-failures:
 
     # Missing test files in sdist
     # Hopefully gets fixed in the next release...
-    - configurator-pg # 0.2.0 https://github.com/robx/configurator-pg/issues/9
     - crypto-pubkey # https://github.com/vincenthz/hs-crypto-pubkey/issues/23
     - doctest-discover # 0.1.0.9 https://github.com/karun012/doctest-discover/issues/22
     - graylog # 0.1.0.1 https://github.com/fpco/stackage/pull/1254


### PR DESCRIPTION
Version 0.2.1 has been released adding the missing files.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
