### PR TITLE
Re-enable mpi-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -133,7 +133,7 @@ packages:
         - PyF
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":
-        - mpi-hs < 0 # via store
+        - mpi-hs
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
         - control-dsl < 0 # via doctest-discover


### PR DESCRIPTION
I split mpi-hs into multiple packages. The base package has no dependency on "store" any more. I will submit the other packages to stackage once mpi-hs is active again.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
