### PR TITLE
Re-enable mpi-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -133,7 +133,7 @@ packages:
         - PyF
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":
-        - mpi-hs < 0 # https://github.com/commercialhaskell/stackage/issues/5278
+        - mpi-hs
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
         - control-dsl < 0 # via doctest-discover

--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -92,13 +92,13 @@ apt-get install -y \
     libmono-2.0-dev \
     libmp3lame-dev \
     libmpfr-dev \
+    libmpich-dev \
     libmysqlclient-dev \
     libncurses5-dev \
     libnfc-dev \
     liboath-dev \
     libnotify-dev \
     libopenal-dev \
-    libopenmpi-dev \
     libpango1.0-dev \
     libpcap0.8-dev \
     libpcre2-dev \


### PR DESCRIPTION
Switch MPI library dependency from OpenMPI to MPICH. (This is very likely fine since OpenMPI was added for mpi-hs.) We use MPICH since OpenMPI in Xenial does not support multi-threading yet.

Closes #5278.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
