### PR TITLE
Trim transitive tracing dependencies

### DIFF
--- a/automated/build.sh
+++ b/automated/build.sh
@@ -63,12 +63,12 @@ BINDIR=$(cd $ROOT/work/bin ; pwd)
 cd $BINDIR
 rm -f curator stack *.bz2
 
-curl "https://download.fpcomplete.com/stackage-curator-2/curator-85b021a53833ff310fc66b3fdc5ca3f7828ce18b.bz2" | bunzip2 > curator
+curl -L "https://download.fpcomplete.com/stackage-curator-2/curator-85b021a53833ff310fc66b3fdc5ca3f7828ce18b.bz2" | bunzip2 > curator
 chmod +x curator
 echo -n "curator version: "
 docker run --rm -v $(pwd)/curator:/exe $IMAGE /exe --version
 
-curl "https://download.fpcomplete.com/stackage-curator-2/stack-4033c93815477e5b565d9a2a61b54e04da0863ef.bz2" | bunzip2 > stack
+curl -L "https://download.fpcomplete.com/stackage-curator-2/stack-4033c93815477e5b565d9a2a61b54e04da0863ef.bz2" | bunzip2 > stack
 chmod +x stack
 echo -n "stack version: "
 docker run --rm -v $(pwd)/stack:/exe $IMAGE /exe --version

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -133,7 +133,7 @@ packages:
         - PyF
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":
-        - mpi-hs < 0 # https://github.com/commercialhaskell/stackage/issues/5278
+        - mpi-hs
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
         - control-dsl < 0 # via doctest-discover

--- a/etc/check.sh
+++ b/etc/check.sh
@@ -11,7 +11,7 @@ export PATH=$HOME/.local/bin:$PATH
 curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 # Get new Stackage curator
-curl "https://download.fpcomplete.com/stackage-curator-2/curator-85b021a53833ff310fc66b3fdc5ca3f7828ce18b.bz2" | bunzip2 > curator
+curl -L "https://download.fpcomplete.com/stackage-curator-2/curator-85b021a53833ff310fc66b3fdc5ca3f7828ce18b.bz2" | bunzip2 > curator
 chmod +x curator
 
 # Install GHC


### PR DESCRIPTION
Most of the previous entries are not needed (anymore? - I'm not sure why they had been [added](https://github.com/commercialhaskell/stackage/commit/56ed3bd3a635b1b82b17c81a0aeaaccef97df6fe)). `ip` is the only dependency which isn't already referenced; it is now in @andrewthad's section (author of the library).

I noticed this while investigating a fix for [this issue](https://github.com/commercialhaskell/stackage/issues/5271), which requires an update to `small-bytearray-builder` which I don't own and AFAICT isn't used by `tracing`. For reference, here is the list of `tracing`'s transitive dependencies:

```
$ stack ls dependencies --no-include-base --test
HUnit 1.6.0.0
QuickCheck 2.13.1
aeson 1.4.3.0
ansi-terminal 0.9.1
async 2.2.2
attoparsec 0.13.2.2
base-compat 0.10.5
base16-bytestring 0.1.1.6
basement 0.0.10
binary 0.8.6.0
blaze-builder 0.4.1.0
bytestring 0.10.8.2
case-insensitive 1.2.0.11
containers 0.6.0.1
cookie 0.4.4
deepseq 1.4.4.0
directory 1.3.3.0
dlist 0.8.0.6
exceptions 0.10.2
ghc-prim 0.5.3
hashable 1.2.7.0
hspec 2.7.1
hspec-core 2.7.1
hspec-discover 2.7.1
hspec-expectations 0.8.2
http-client 0.6.4
http-types 0.12.3
integer-gmp 1.0.2.0
integer-logarithms 1.0.3
ip 1.5.0
memory 0.14.18
mime-types 0.1.0.9
mtl 2.2.2
network 2.8.0.1
network-uri 2.6.1.0
parsec 3.1.13.0
pretty 1.1.3.6
primitive 0.6.4.0
process 1.6.5.0
quickcheck-io 0.2.0
random 1.1
rts 1.0
scientific 0.3.6.2
setenv 0.1.1.3
splitmix 0.0.2
stm 2.5.0.0
streaming-commons 0.2.1.1
tagged 0.8.6
template-haskell 2.14.0.0
text 1.2.3.1
tf-random 0.5
th-abstraction 0.3.1.0
time 1.8.0.2
time-locale-compat 0.1.1.5
tracing 0.0.4.1
transformers-compat 0.6.5
unix 2.7.2.2
unliftio 0.2.11
unliftio-core 0.1.2.0
unordered-containers 0.2.10.0
uuid-types 1.0.3
vector 0.12.0.3
wide-word 0.1.0.8
zlib 0.6.2
```