### PR TITLE
Add smash, smash-aeson, smash-microlens, smash-lens

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -54,6 +54,10 @@ packages:
         - lens-process < 0 # via lens-4.18.1
         - microlens-process
         - nonempty-vector
+        - smash
+        - smash-aeson
+        - smash-microlens
+        - smash-lens
 
     "Matthieu Monsch <mtth@apache.org> @mtth":
         - flags-applicative


### PR DESCRIPTION
This PR adds support for the `smash`, `smash-aeson`, `smash-microlens`, and `smash-lens` packages.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
