### PR TITLE
Re-add benchpress

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2653,7 +2653,7 @@ packages:
         - fuzzyset
 
     "Will Sewell <me@willsewell.com> @willsewell":
-        - benchpress < 0 # via base-4.13.0.0
+        - benchpress
         - pusher-http-haskell
 
     "Yorick Laupa yo.eight@gmail.com @YoEight":


### PR DESCRIPTION
The latest version (https://hackage.haskell.org/package/benchpress-0.2.2.13) is compatible up with base < 4.14 .

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
