### PR TITLE
Remove datadog from skipped tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5123,7 +5123,6 @@ skipped-tests:
     - system-fileio # ansi-terminal-0.8 via chell
     - system-filepath # ansi-terminal-0.8 via chell
     - buffer-builder # per HTF per cpphs per polyparse (ghc 8.6 failure)
-    - datadog # https://github.com/commercialhaskell/stackage/issues/5297
 
     # Blocked by stackage upper bounds. These can be re-enabled once
     # the relevant stackage upper bound is lifted.


### PR DESCRIPTION
Closes #5297 

I released a new version (0.2.5.0) this morning wherein the tests compile: `stack build --test --no-run-tests --resolver nightly`. I don't have the environment variables for the tests but I presume they are fine.

The release is here: http://hackage.haskell.org/package/datadog-0.2.5.0
The change is here: https://github.com/iand675/datadog/pull/35/files#diff-18cd9f3468928c88b15c331e62a74cfe