### PR TITLE
Add postgrest

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -82,6 +82,7 @@ packages:
 
     "Robert Vollmert <rob@vllmrt.net> @robx":
         - configurator-pg
+        - postgrest
 
     "Sandy Maguire <sandy@sandymaguire.me> @isovector":
         - ecstasy
@@ -5378,6 +5379,7 @@ expected-test-failures:
     - postgresql-simple-migration
     - postgresql-simple-queue
     - postgresql-typed # PostgreSQL
+    - postgrest # PostgreSQL
     - purescript # git 128 https://github.com/purescript/purescript/issues/2292
     - rattle # needs fsatrace
     - redis-io


### PR DESCRIPTION
This adds postgrest, as per https://github.com/PostgREST/postgrest/issues/1474. I'm not a  postgrest maintainer, but I've been keeping postgrest's dependency story up to date, and @steve-chavez asked me to be the stackage maintainer.

Tests are skipped because they rely on a running postgresql instance.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (except that tests fail because postgresql isn't running) On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
