### PR TITLE
Re-enable rhine* and essence-of-live-coding*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -196,14 +196,13 @@ packages:
 
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
         - dunai
-        - rhine < 0 # via base-4.13.0.0
-        - rhine-gloss < 0 # via base-4.13.0.0
-        - dunai-core < 0 # via base-4.13.0.0
+        - rhine
+        - rhine-gloss
         - finite-typelits
-        - essence-of-live-coding < 0 # via base-4.13.0.0
-        - essence-of-live-coding-gloss < 0 # via base-4.13.0.0
-        - essence-of-live-coding-pulse < 0 # via base-4.13.0.0
-        - essence-of-live-coding-quickcheck < 0 # via base-4.13.0.0
+        - essence-of-live-coding
+        - essence-of-live-coding-gloss
+        - essence-of-live-coding-pulse
+        - essence-of-live-coding-quickcheck
         - pulse-simple
         - simple-affine-space
 


### PR DESCRIPTION
The restrictive upper bounds have been removed in the latest hackage releases.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
