### PR TITLE
re-add packages about relational-record depend on HDBC.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2869,9 +2869,9 @@ packages:
         - th-data-compat
         - th-reify-compat
         - relational-query
-        - relational-query-HDBC < 0 # via HDBC
-        - persistable-types-HDBC-pg < 0 # via HDBC
-        - relational-record < 0 # via relational-query-HDBC
+        - relational-query-HDBC
+        - persistable-types-HDBC-pg
+        - relational-record
         - text-ldap
         - debian-build
         - aeson-generic-compat
@@ -4204,8 +4204,8 @@ packages:
         - GenericPretty
         - Glob
         - HasBigDecimal
-        - HDBC < 0 # via time-1.9.3
-        - HDBC-session < 0 # via HDBC
+        - HDBC
+        - HDBC-session
         - HTTP
         - HsOpenSSL
         - HsYAML


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

version constraint for time-1.9.3 is resolved in
http://hackage.haskell.org/package/HDBC-2.4.0.3