### PR TITLE
New packages mpi-hs-binary and mpi-hs-cereal

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -135,6 +135,8 @@ packages:
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":
         - mpi-hs
+        - mpi-hs-binary
+        - mpi-hs-cereal
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
         - control-dsl < 0 # via doctest-discover


### PR DESCRIPTION
There is also a package `mpi-hs-store`, but it depends on `store`, and that fell out of Stackage some time ago.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
