### PR TITLE
Add krank and pretty-terminal

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -131,6 +131,8 @@ packages:
         - modular
 
     "Guillaume Bouchard <guillaum.bouchard@gmail.com> @guibou":
+        - krank
+        - pretty-terminal
         - PyF
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":


### PR DESCRIPTION
`pretty-terminal` is a dependency of `krank`, so I'm adding it at the same
time. It is a really simple package (with only dependency to `base` and
`text`).

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Note: `krank` depends on `pretty-terminal`, so I had to cheat a bit the previous instructions.
I did the instruction for `pretty-terminal` with success. I did the same instructions for `krank` and just added `pretty-terminal` in the `extra-deps` field of `stack.yaml` for it to succeed.

This closes https://github.com/guibou/krank/issues/70 (issue tracking the inclusion of `krank` in `stackage`).
