### PR TITLE
Re-enable fusion-plugin

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -520,7 +520,7 @@ packages:
 
     "Pranay Sashank <pranaysashank@gmail.com> @pranaysashank":
         - fusion-plugin-types
-        - fusion-plugin < 0 # ghc-8.8.3
+        - fusion-plugin
 
     "Aleksey Uimanov <s9gf4ult@gmail.com> @s9gf4ult":
         # - postgresql-query # build errors


### PR DESCRIPTION
`fusion-plugin` updated to allow ghc < 8.11. #5238

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
