### PR TITLE
Re-enable 'stack' and remove from expected-test-failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1387,7 +1387,6 @@ packages:
         - hpack
         - bindings-uname
         - stack < 9.9.9 # see https://github.com/fpco/stackage/issues/3563
-        - stack < 0 # build issues with Cabal
 
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
         - th-orphans

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5425,7 +5425,6 @@ expected-test-failures:
     - serialport # "The tests need two serial ports as command line arguments" https://github.com/jputcu/serialport/issues/30
     - serversession-backend-redis # redis
     - shake # Needs ghc on $PATH with some installed haskell packages
-    - stack # https://github.com/fpco/stackage/issues/3707
     - stripe-http-streams # https://github.com/fpco/stackage/issues/2945, needs Stripe account
     - users-persistent # sqlite
     - users-postgresql-simple # PostgreSQL


### PR DESCRIPTION
https://github.com/fpco/stackage/issues/3707 has been closed for some time, and stack no longer depends on 'store'.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
