### PR TITLE
Lift `aur` bounds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4755,7 +4755,6 @@ packages:
       - servant-lucid < 0.9.0.1
       - servant-mock < 0.8.6
       - servant-swagger < 1.1.8
-      - aur < 6.3.0
 
       # https://github.com/commercialhaskell/stackage/issues/5218
       - unliftio-core < 0.2


### PR DESCRIPTION
The latest release of `aur` drops the dependency on `servant`, ending the version dance we've had to keep doing.