### PR TITLE
Add clash-{prelude,lib,ghc}

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1980,14 +1980,14 @@ packages:
         - timer-wheel < 0 # via base-4.13.0.0
         - wai-middleware-travisci < 0 # via base-4.13.0.0
 
-    "Christiaan Baaij <christiaan.baaij@gmail.com> @christiaanb":
+    "QBayLogic B.V. <devops@qbaylogic.com>":
         - ghc-tcplugins-extra
         - ghc-typelits-extra
         - ghc-typelits-knownnat
         - ghc-typelits-natnormalise
-        - clash-prelude < 0
-        - clash-lib < 0
-        - clash-ghc < 0
+        - clash-prelude
+        - clash-lib
+        - clash-ghc
 
     "Athan Clark <athan.clark@gmail.com> @athanclark":
         - aeson-attoparsec


### PR DESCRIPTION
Notes:

1. I've checked the last command (`stack build --resolver nightly ..`) for `clash-prelude`. `clash-lib` and `clash-ghc` depend on `clash-prelude`, so I wasn't able to test those. However, over at https://github.com/clash-lang/clash-compiler we test these things on every commit, so I'm fairly confident it will just work.

2. The ownership/maintainer has been transferred to QBayLogic B.V, as can be seen in the "Maintainer" column of http://hackage.haskell.org/packages/browse.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
