### PR TITLE
Add `cardano-coin-selection` package to Stackage.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3295,6 +3295,8 @@ packages:
     "Jonathan Knowles <stackage@jonathanknowles.net> @jonathanknowles":
         - bech32
         - bech32-th
+        - cardano-coin-selection
+        - quiet
         - roc-id
 
     "Mahdi Dibaiee <mdibaiee@aol.com> @mdibaiee":


### PR DESCRIPTION
This PR adds [`cardano-coin-selection`](https://github.com/input-output-hk/cardano-coin-selection) to Stackage.

Since the [`quiet`](https://github.com/jacobstanley/quiet) package is a dependency, but not yet part of Stackage, this commit also adds `quiet` to `build-constraints.yaml`.

(Note that the original author of `quiet` is @jacobstanley.)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
