### PR TITLE
Adding slack-api

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4224,6 +4224,9 @@ packages:
 
     "Adrian Sieber <stackage@ad-si.com> @ad-si":
         - ulid
+        
+    "Rickey Visinski <rickeyvisinski+hs@gmail.com> @rickeyski":
+        - slack-api
 
     "Grandfathered dependencies":
         - network


### PR DESCRIPTION
I took over ownership of slack-api and I would like to add it to stackage. Thanks

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
