### PR TITLE
Re-enable ginger after 0.10 release

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -475,7 +475,7 @@ packages:
         - type-map
 
     "Tobias Dammers <tdammers@gmail.com> @tdammers":
-        - ginger < 0 # via regex-tdfa-1.3.0
+        - ginger
         - yeshql < 0 # via yeshql-hdbc
 
     "Yair Chuchem <yairchu@gmail.com> @yairchu":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
