### PR TITLE
Replace deprecated `conferer-provider-json` with `conferer-source-json` 

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3865,11 +3865,11 @@ packages:
         - map-syntax < 0 # GHC 8.4 via base-4.11.0.0
         - heist < 0 # GHC 8.4 via map-syntax
         - snap < 0 # GHC 8.4 via base-4.11.0.0
-        - conferer < 0.4.0.0 # https://github.com/commercialhaskell/stackage/issues/5374
-        # - conferer-snap # Because snap
-        - conferer-warp < 0.4.0.0 # https://github.com/commercialhaskell/stackage/issues/5374
-        - conferer-hspec < 0.4.0.0 # https://github.com/commercialhaskell/stackage/issues/5374
-        - conferer-provider-json
+        - conferer
+        #- conferer-snap # Because snap
+        - conferer-warp
+        - conferer-hspec
+        - conferer-source-json
 
     "Tim Humphries <tim+stackage@utf8.me> @thumphries":
         - transformers-either < 0 # via exceptions-0.10.0


### PR DESCRIPTION
conferer-provider-json was deprecated in favor of conferer-source-json, the former caused
constraints on conferer-* packages that are not necessary

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
