### PR TITLE
Remove mighty-metropolis < 2 constraint.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2583,7 +2583,7 @@ packages:
     "Jared Tobin <jared@jtobin.ca> @jtobin":
         - mwc-probability
         - mcmc-types
-        - mighty-metropolis < 2 # https://github.com/commercialhaskell/stackage/issues/5384
+        - mighty-metropolis
         - speedy-slice
         - hasty-hamiltonian
         - declarative


### PR DESCRIPTION
I've uploaded a new version of declarative (declarative-0.5.3) that removes the need for this constraint.

Resolves #5384.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
