### PR TITLE
Fix blog links.

### DIFF
--- a/DATA-FLOW.md
+++ b/DATA-FLOW.md
@@ -26,7 +26,7 @@ There are three inputs into the data flow:
 ## Travis
 
 For [various
-reasons](https://www.fpcomplete.com/blog/2015/05/distributing-packages-without-sysadmin),
+reasons](https://tech.fpcomplete.com/blog/2015/05/distributing-packages-without-sysadmin),
 we leverage Travis CI for running some processes. In particular:
 
 * [all-cabal-files](https://github.com/commercialhaskell/all-cabal-files/blob/hackage/.travis.yml)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@ The idea behind Stackage is that, if all packages work with the newest versions 
 
 * All packages are buildable and testable from Hackage. We recommend [the Stack Travis script](https://docs.haskellstack.org/en/stable/travis_ci/), which ensures a package is not accidentally incomplete.
 * All packages are compatible with the newest versions of all dependencies (You can find restrictive upper bounds by visiting http://packdeps.haskellers.com/feed?needle=PACKAGENAME).
-* All packages in a snapshot are compatible with the versions of libraries that ship with the GHC used in the snapshot ([more information on lenient lower bounds](https://www.fpcomplete.com/blog/2014/05/lenient-lower-bounds)).
+* All packages in a snapshot are compatible with the versions of libraries that ship with the GHC used in the snapshot ([more information on lenient lower bounds](https://tech.fpcomplete.com/blog/2014/05/lenient-lower-bounds)).
 
 Packages in Stackage are not patched: all package changes occur upstream in Hackage.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We welcome all packages, provided:
 * The package author/maintainer agrees to the [maintainers agreement](https://github.com/commercialhaskell/stackage/blob/master/MAINTAINERS.md).
 * The package is buildable and testable from Hackage. We recommend [the Stack Travis script](https://docs.haskellstack.org/en/stable/travis_ci/), which ensures a package is not accidentally incomplete.
 * The package is compatible with the newest versions of all dependencies (You can find restrictive upper bounds by visiting http://packdeps.haskellers.com/feed?needle=PACKAGENAME).
-* The package is compatible with the versions of libraries that ship with GHC ([more information on lenient lower bounds](https://www.fpcomplete.com/blog/2014/05/lenient-lower-bounds)).
+* The package is compatible with the versions of libraries that ship with GHC ([more information on lenient lower bounds](https://tech.fpcomplete.com/blog/2014/05/lenient-lower-bounds)).
 
 Full details on how to add and test a package can be found in the [maintainers agreement](https://github.com/commercialhaskell/stackage/blob/master/MAINTAINERS.md#adding-a-package).
 
@@ -109,14 +109,14 @@ There are a number of answers to this question:
   and packages depending on them - are fixed to GHC versions. Common
   examples of this are containers and transformers. There's a lot more
   information on this in
-  [an FP Complete blog post](https://www.fpcomplete.com/blog/2014/05/lenient-lower-bounds)
+  [an FP Complete blog post](https://tech.fpcomplete.com/blog/2014/05/lenient-lower-bounds)
 
 __How long do you maintain an LTS build?__
 
 We only guarantee that we will maintain a single LTS major version at
 a time, and that it will be maintained for at least three months. This
 is the
-[originally proposed support window](https://www.fpcomplete.com/blog/2014/12/backporting-bug-fixes),
+[originally proposed support window](https://tech.fpcomplete.com/blog/2014/12/backporting-bug-fixes),
 and hasn't changed since then.
 
 That said, we do maintain the capability to keep multiple LTS runs


### PR DESCRIPTION
All the blog links were broken, going to an "Oops!" page.  Don't know when it happened, but I found the content under a subdomain.  FP Complete might consider also setting up redirects for the sake of URLs in the wild.