### PR TITLE
Restore hLibsass & hSass

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2228,8 +2228,8 @@ packages:
         - bytestring-to-vector
 
     "Jakub Fijałkowski <kuba@codinginfinity.me> @jakubfijalkowski":
-        - hlibsass < 0 # https://github.com/commercialhaskell/stackage/issues/5075
-        - hsass < 0 # via hlibsass
+        - hlibsass
+        - hsass
 
     "Robert Massaioli <robertmassaioli@gmail.com> @robertmassaioli":
         - range


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

This should close #5075 as hlibsass works with Cabal-3 now.