### PR TITLE
Restore caching on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ addons:
 script:
 - ./etc/check.sh
 
-# Caching doesn't work with sudo: true
-#cache:
-#  directories:
-#    - $HOME/.stack
-#    - $HOME/.stackage/curator/cache
+cache:
+  directories:
+    - $HOME/.stack
+    - $HOME/.stackage/curator/cache


### PR DESCRIPTION
This reverts a change from 2 years ago supplied with a comment
> Caching doesn't work with sudo: true

Currently, the caching seems to work though. See the first build for this branch that populated the cache:
https://travis-ci.com/github/ArturGajowy/stackage/builds/171122592
and a subsequent, manually-triggered build for that branch that benefited from the cache being hot:
https://travis-ci.com/github/ArturGajowy/stackage/builds/171124240

This shaves the build time from ~9 minutes to ~3 minutes.

Of course, I might not have the full context for the original comment.
If that was a travis-ci only issue though, it seems to be resolved :tada: 