### PR TITLE
Add postgresql-libpq-notify and hasql-queue

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3300,14 +3300,12 @@ packages:
 
     "Jonathan Fischoff <jonathangfischoff@gmail.com> @jfischoff":
         - clock-extras
-        - next-ref < 0
-        - threads-extras < 0
         - postgres-options
         - tmp-postgres
         - pg-transact
-        - hspec-pg-transact < 0 # compilation failure (against tmp-postgres?)
-        - postgresql-simple-queue < 0 # via hspec-pg-transact
         - port-utils
+        - postgresql-libpq-notify
+        - hasql-queue
 
     "Jonathan Knowles <stackage@jonathanknowles.net> @jonathanknowles":
         - bech32


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

postgresq-libpq-notify worked but hasql-queue complained about postgresq-libpq-notify not being available. I am hoping if I add both at the same time it will work.
