### PR TITLE
Remove pandoc-pyplot from stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -172,7 +172,6 @@ packages:
         - control-dsl < 0 # via doctest-discover
 
     "Laurent P. René de Cotret <laurent.decotret@outlook.com> @LaurentRDC":
-        - pandoc-pyplot
         - pandoc-plot
 
     "Andrew Newman <andrewfnewman@gmail.com> @andrewfnewman":
@@ -5479,7 +5478,6 @@ expected-test-failures:
     - odbc # "Need ODBC_TEST_CONNECTION_STRING environment variable"
     - opaleye # PostgreSQL
     - pandoc-plot # requires matlab, etc and DISPLAY for tcltk
-    - pandoc-pyplot # requires DISPLAY for tcltk
     - pantry # https://github.com/commercialhaskell/stackage/issues/4628
     - persistent-redis # redis - https://github.com/fpco/stackage/pull/1581
     - pipes-mongodb


### PR DESCRIPTION
This has been discussed in #5426. The change removes the deprecated package `pandoc-pyplot`, which has no reverse dependencies.
