### PR TITLE
CURATORS.md: clarify fpco/stack-build docker instructions for new LTS…

### DIFF
--- a/CURATORS.md
+++ b/CURATORS.md
@@ -294,7 +294,9 @@ problems on nightly or LTS major, you need to fix build-constraints.yaml (see
 info above).
 
 ### Building LTS minor releases
-Before running the build, please make sure that the Dockerfile in `automated/dockerfiles/lts-X.Y` is up to date, where X is the major version that you're building and Y is the latest minor version of X for which a Dockerfile exists. If any changes need to be made, (eg, new GHC version), copy `lts-X.Y/Dockerfile` to `lts-X.Z/Dockerfile`, where Z is the minor version you're building, and include the new changes.
+Before running the build, please make sure that the Dockerfile in `automated/dockerfiles/lts-X.Y` is up to date, where X is the major version that you're building and Y is the latest minor version of X for which a Dockerfile exists.
+  * If any changes need to be made, (eg, new GHC version), copy `automated/lts-X.Y/Dockerfile` to `automated/lts-X.Z/Dockerfile`, where Z is the minor version you're building, and include the new changes.
+  * If you are building the first release of a new LTS major version, create a new `lts-X.Z/Dockerfile` based on the previous LTS's, and adjust the variables at the top to match the requirements of the snapshot.  Ensure that `STACK_VERSION` is the latest release of Stack, and `BOOTSTRAP_COMMIT` is the commit ID of this repo containing the version of the `bootstrap-commit.sh` used to build the snapshot.
 
 First run `build.sh` to regenerate updated `ltsXX/work/constraints.yaml` and `ltsXX/work/snapshot-incomplete.yaml` files.
 


### PR DESCRIPTION
The previous instructions didn't offer any guidance for what to do for the fpco/stack-build Dockerfiles when releasing a new major LTS release.