### PR TITLE
add string-random

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4279,6 +4279,9 @@ packages:
     "Eric Rochester <erochest@gmail.com> @erochest":
         - text-regex-replace
 
+    "Masahiro Honma <hiratara@cpan.org> @hiratara":
+        - string-random
+
     "Grandfathered dependencies":
         - network
         - Boolean


### PR DESCRIPTION
This is requested by @psibi . See https://github.com/hiratara/hs-string-random/issues/12 and https://github.com/commercialhaskell/stackage/issues/5412 .

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
