### PR TITLE
Re-add sparse-tensor

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -61,7 +61,7 @@ packages:
         - generic-monoid
 
     "Tobias Reinhart <tobi.reinhart@fau.de> @TobiReinhart":
-        - sparse-tensor < 0 # ghc 8.10
+        - sparse-tensor
 
     "Stephan Schiffels <stephan_schiffels@mac.com> @stschiff":
         - sequence-formats


### PR DESCRIPTION
dependencies fixed in new hackage release sparse-tensor-0.2.1.4

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
