### PR TITLE
Re-enabling linenoise-0.3.2 in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4216,8 +4216,8 @@ packages:
 
     "Eric Conlon <ejconlon@gmail.com> @ejconlon":
         - blanks
-        - climb < 0 # via linenoise
-        - linenoise < 0 # https://github.com/commercialhaskell/stackage/issues/5442
+        - climb < 0 # via linenoise, https://github.com/commercialhaskell/stackage/issues/5442
+        - linenoise
         - little-rio
         - little-logger
         # Maintainership with @23Skidoo


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks