### PR TITLE
Revives ghc-typelits-presburger and others (fixes #5438)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4250,10 +4250,10 @@ packages:
 
     "Hiromi Ishii <konn.jinro@gmail.com> @konn":
         - equational-reasoning
-        - ghc-typelits-presburger < 0 # ghc 8.10.1 https://github.com/commercialhaskell/stackage/issues/5438
-        - singletons-presburger < 0 # via ghc-typelits-presburger
-        - type-natural < 0 # ghc 8.10
-        - sized < 0 # ghc 8.10
+        - ghc-typelits-presburger
+        - singletons-presburger
+        - type-natural
+        - sized
 
     "Frank Doepper <stackage@woffs.de> @woffs":
         - amqp-utils


### PR DESCRIPTION
Just released new versions of `ghc-typelits-presburger`, `singletons-presburger`, `type-natural` and `sized` packages, which compile with the most recent Nightly (2020-06-21).
This fixes #5438 and brings back the packages mentioned above to Stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
