### PR TITLE
Unrestrict neat-interpolation

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1440,7 +1440,7 @@ packages:
         - hasql-transaction
         - list-t
         - mtl-prelude
-        - neat-interpolation < 0.4 # https://github.com/commercialhaskell/stackage/issues/5119
+        - neat-interpolation
         - partial-handler
         - postgresql-binary
         - slave-thread < 0
@@ -3659,8 +3659,8 @@ packages:
         - relude
         - shellmet
         - shortcut-links
-        - summoner
-        - summoner-tui
+        - summoner < 0 # neat-interpolation-0.4
+        - summoner-tui < 0 # neat-interpolation-0.4 via summoner
         - tomland
         - typerep-map
         - validation-selective


### PR DESCRIPTION
…and disable `summoner[-tui]`.

This reverts commit c815f235ed072c415bd160c1cc095b039d3de300.

Closes #5119.