### PR TITLE
Reinstate `massiv-io` and `Color`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3378,10 +3378,10 @@ packages:
         - wai-middleware-auth < 0 # via hoauth2
         # - hip # lens 4.16 via diagrams/chart
         - massiv
-        - massiv-io < 0.3.0.0 # https://github.com/lehins/massiv-io/issues/1
+        - massiv-io
         - massiv-test
         - scheduler
-        - Color < 0.2.0 # https://github.com/commercialhaskell/stackage/issues/5475
+        - Color
         - safe-decimal
         - flush-queue
         - pvar


### PR DESCRIPTION
Fixes #5475 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (I've done so for Color-0.2.0, massiv-0.3.0.1, will build too once Color-0.2.0 is in). On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
