### PR TITLE
Re-enable stackcollapse-ghc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -29,7 +29,7 @@ packages:
 
     "Marcin Rzeźnicki <marcin.rzeznicki@gmail.com> @marcin-rzeznicki":
         - hspec-tables
-        - stackcollapse-ghc < 0 # ghc 8.10
+        - stackcollapse-ghc
 
     "Mauricio Fierro <mauriciofierrom@gmail.com> @mauriciofierrom":
         - dialogflow-fulfillment


### PR DESCRIPTION
0.0.1.1@rev:1 builds with GHC 8.10.1 and the most recent nightly

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
