### PR TITLE
Revert "Disable mpi-hs, #5444"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -164,9 +164,9 @@ packages:
         - PyF
 
     "Erik Schnetter <schnetter@gmail.com> @eschnett":
-        - mpi-hs < 0 # https://github.com/commercialhaskell/stackage/issues/5444
-        - mpi-hs-binary < 0 # via mpi-hs
-        - mpi-hs-cereal < 0 # via mpi-hs
+        - mpi-hs
+        - mpi-hs-binary
+        - mpi-hs-cereal
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
         - control-dsl < 0 # via doctest-discover


### PR DESCRIPTION
This reverts commit 91d928d36c1c50d3d36676336ca622d9c19dcca2.

I uploaded a new version of `mpi-hs` to Hackage that has this problem corrected.

Closes #5444.
