### PR TITLE
Re-enable `flexible-defaults` and others that it was breaking:

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2527,9 +2527,9 @@ packages:
         - nix-paths
         - parsec-class
         - prim-uniq < 0 # via dependent-sum
-        - random-fu < 0 # via random-source
-        - random-source < 0 # via flexible-defaults
-        - rvar < 0 # via random-source
+        - random-fu
+        - random-source
+        - rvar
         - SafeSemaphore
         - streamproc < 0 # MonadFail
         - stringsearch # for cgi
@@ -4789,7 +4789,6 @@ packages:
     # be removed from this list if they are fixed.
     "Unmaintained packages with compilation failures":
         - doctest-discover-configurator < 0
-        - flexible-defaults < 0 # MonadFail
         - haskell-tools-builtin-refactorings < 0 # bounds failure
         - hpqtypes < 0 # bounds failure
         - stackage-types < 0


### PR DESCRIPTION
Looks like ghc support for `flexible-defaults` was fixed back in October in version `flexible-defaults-0.0.3` by @peti , but was never re-enabled. Including it back allows us to bring back these packages below as well:

* `random-sources`
* `rvar`
* and `random-fu`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
