### PR TITLE
Re-enable o-clock

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3648,7 +3648,7 @@ packages:
     "Serokell <hi@serokell.io> @serokell":
         # - importify
         - log-warper < 0 # GHC 8.4 via lifted-async-0.10.0.1
-        - o-clock < 0 # ghc 8.10
+        - o-clock
         - universum
         - with-utf8
 


### PR DESCRIPTION
GHC-8.10 compatibility should be resolved in 1.2.0.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
