### PR TITLE
add these-skinny

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2204,6 +2204,7 @@ packages:
         - semirings
         - torsor
         - chronos
+        - these-skinny
 
     "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
         - SHA


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

```
[chessai@nixos:~/temp]$ stack unpack these-skinny-0.7.4
Unpacked these-skinny (from Hackage) to /home/chessai/temp/these-skinny-0.7.4/

[chessai@nixos:~/temp]$ cd these-skinny-0.7.4/

[chessai@nixos:~/temp/these-skinny-0.7.4]$ rm -rf stack.yaml && stack init --resolver nightly
Selected resolver: nightly-2020-07-12
Looking for .cabal or package.yaml files to use to init the project.
Using cabal packages:
- ./

Selected resolver: nightly-2020-07-12
Selected resolver: nightly-2020-07-12
Initialising configuration using resolver: nightly-2020-07-12
Total number of user packages considered: 1
Writing configuration to file: stack.yaml
All done.

[chessai@nixos:~/temp/these-skinny-0.7.4]$ stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
Selected resolver: nightly-2020-07-12
Selected resolver: nightly-2020-07-12
[1 of 2] Compiling Main             ( /home/chessai/.stack/setup-exe-src/setup-mPHDZzAJ.hs, /home/chessai/.stack/setup-exe-src/setup-mPHDZzAJ.o )
[2 of 2] Compiling StackSetupShim   ( /home/chessai/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /home/chessai/.stack/setup-exe-src/setup-shim-mPHDZzAJ.o )
Linking /home/chessai/.stack/setup-exe-cache/x86_64-linux-nix/tmp-Cabal-simple_mPHDZzAJ_3.2.0.0_ghc-8.10.1 ...
these-skinny> configure (lib)
Configuring these-skinny-0.7.4...
these-skinny> build (lib)
Preprocessing library for these-skinny-0.7.4..
Building library for these-skinny-0.7.4..
[1 of 1] Compiling Data.These

Warning: Failed to decode module interface:
         /home/chessai/temp/these-skinny-0.7.4/.stack-work/dist/x86_64-linux-nix/Cabal-3.2.0.0/build/Data/These.hi
         Decoding failure: Invalid magic: e49ceb0f
these-skinny> haddock
Preprocessing library for these-skinny-0.7.4..
Running Haddock on library for these-skinny-0.7.4..
Haddock coverage:
Warning: '_This' is out of scope.
    If you qualify the identifier, haddock can try to link it anyway.
Warning: '_That' is out of scope.
    If you qualify the identifier, haddock can try to link it anyway.
Warning: '_These' is out of scope.
    If you qualify the identifier, haddock can try to link it anyway.
 100% ( 27 / 27) in 'Data.These'
Documentation created:
.stack-work/dist/x86_64-linux-nix/Cabal-3.2.0.0/doc/html/these-skinny/index.html,
.stack-work/dist/x86_64-linux-nix/Cabal-3.2.0.0/doc/html/these-skinny/these-skinny.txt
these-skinny> copy/register
Installing library in /home/chessai/temp/these-skinny-0.7.4/.stack-work/install/x86_64-linux-nix/438f5a36aa2e7dfbb4495192fb92a9b218e62f80883781a65511b010e0b153eb/8.10.1/lib/x86_64-linux-ghc-8.10.1/these-skinny-0.7.4-570K9l78UeaKvx5kMoj36l
Registering library for these-skinny-0.7.4..
Updating Haddock index for local packages in
/home/chessai/temp/these-skinny-0.7.4/.stack-work/install/x86_64-linux-nix/438f5a36aa2e7dfbb4495192fb92a9b218e62f80883781a65511b010e0b153eb/8.10.1/doc/index.html
Updating Haddock index for local packages and dependencies in
/home/chessai/temp/these-skinny-0.7.4/.stack-work/install/x86_64-linux-nix/438f5a36aa2e7dfbb4495192fb92a9b218e62f80883781a65511b010e0b153eb/8.10.1/doc/all/index.html
Updating Haddock index for snapshot packages in
/home/chessai/.stack/snapshots/x86_64-linux-nix/438f5a36aa2e7dfbb4495192fb92a9b218e62f80883781a65511b010e0b153eb/8.10.1/doc/index.html

[chessai@nixos:~/temp/these-skinny-0.7.4]$ echo $?
0
```