### PR TITLE
Create verify-package script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,11 @@
 Checklist:
 - [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
 - [ ] At least 30 minutes have passed since uploading to Hackage
-- [ ] On your own machine, in a _new directory_, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):
+- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):
+
+      ./verify-package $pacakge # or $pacakge-$version
+
+The script runs virtually the following commands in a clean directory:
 
       stack unpack $package-$version  # $version is optional
       cd $package-$version

--- a/verify-package
+++ b/verify-package
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Script to verify a package to build successfully
+# Provide pacakge name by the first argument
+#
+# Example:
+#  ./verify-package mtl
+# or
+#  ./verify-package mtl-2.2.2
+
+set -eu
+
+die() {
+    >&2 echo "$1"
+    exit 1
+}
+
+package="${1:-}"
+if [[ -z $package ]]; then
+    die "Package name is not given"
+fi
+
+
+here="$(cd "$(dirname "$0")" > /dev/null; pwd)"
+dir="$(mktemp -d tmp.XXXX)"
+
+exit() {
+    cd "$here"
+    rm -rf "$dir"
+}
+trap exit EXIT
+
+cd "$dir"
+stack unpack "$package"
+cd "$(ls | head -n 1)"
+rm -f stack.yaml
+stack init --resolver nightly
+stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
+
+
+cat <<EOF
+
+
+ 🎉 It looks good!
+
+EOF


### PR DESCRIPTION
I have written a script which runs suggested commands when opening a PR.

With this script, you can just tell a PR opener to run:

```console
$ ./verify-package <package-name>
```

instead of a series of commands.

Please take a look.
Thanks!