### PR TITLE
Restore locators package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2500,11 +2500,11 @@ packages:
         - io-streams
         - openssl-streams
 
-    "Andrew Cowie <andrew@operationaldynamics.com> @afcowie":
+    "Andrew Cowie <istathar@gmail.com> @istathar":
         - chronologique
         - http-common
         - http-streams
-        - locators < 0 # via cryptohash
+        - locators
         - core-data
         - core-program
         - core-text


### PR DESCRIPTION
Restore previously included package **locators** temporarly excluded due to dependency on deprecated **cryptohash**; my package now patched to use replacement **cryptonite** directly.

Also updates my contact details.

Checklist:
- [x] Meaningful commit message
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, in a _new directory_, you have successfully run the following set of commands:

      stack unpack locators-0.3.0.3
      cd locators-0.3.0.3
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

passed.