### PR TITLE
Remove duplicate entry for vinyl

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2682,7 +2682,6 @@ packages:
 
     "Stanislav Chernichkin <schernichkin@gmail.com> @schernichkin":
         - partial-isomorphisms
-        - vinyl < 0 # kind stuff
 
     "Christoph Breitkopf <chbreitkopf@gmail.com> @bokesan":
         - IntervalMap


### PR DESCRIPTION
Removing a second entry for the `vinyl` package that seems to have prevented it from being included in Stackage releases since an earlier PR adding it under my name. I am the primary maintainer for the package.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $pacakge-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
