### PR TITLE
Add ELynx and Mcmc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4326,6 +4326,15 @@ packages:
 
     "Dominik Schrempf <dominik.schrempf@gmail.com> @dschrempf":
         - pava
+        - elynx-nexus
+        - elynx-markov
+        - elynx-seq
+        - elynx-tools
+        - elynx-tree
+        - slynx
+        - tlynx
+        - elynx
+        - mcmc
 
     "Eric Rochester <erochest@gmail.com> @erochest":
         - text-regex-replace


### PR DESCRIPTION
[ELynx](https://github.com/dschrempf/elynx) is a library and tool set for evolutionary biology. It handles sequence data such as DNA or Protein sequences, as well as evolutionary trees (phylogenies). It can be used for simulation as well as analysis.

[Mcmc](https://github.com/dschrempf/mcmc) is a general Metropolis-Hastings Markov chain Monte Carlo sampler.

I could not run the verify script on some of the packages, because they depend on each other. However, I ensured that they build well using the latest nightly resolver, when they are distributed together.