### PR TITLE
Unrestrict prettyprinter-ansi-terminal, maintainership updates

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5896,7 +5896,6 @@ skipped-benchmarks:
     - openpgp-asciiarmor
     - phantom-state
     - pretty-simple
-    - prettyprinter
     - prometheus-client
     - ramus
     - reinterpret-cast
@@ -5995,6 +5994,7 @@ skipped-benchmarks:
     - dlist-nonempty # criterion-1.3
     - splitmix # criterion-1.3
     # @sjakobi
+    - prettyprinter
     - prettyprinter-ansi-terminal # https://github.com/commercialhaskell/stackage/issues/5560
 
     # Due to cycles, which are actually just limitations in Stack right now.

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5994,6 +5994,8 @@ skipped-benchmarks:
     # @phadej
     - dlist-nonempty # criterion-1.3
     - splitmix # criterion-1.3
+    # @sjakobi
+    - prettyprinter-ansi-terminal # https://github.com/commercialhaskell/stackage/issues/5560
 
     # Due to cycles, which are actually just limitations in Stack right now.
     - criterion

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -492,6 +492,12 @@ packages:
         - monadlist
         - ref-tf
         - unordered-containers
+        - prettyprinter < 1.7.0 # https://github.com/commercialhaskell/stackage/issues/5558
+        - prettyprinter-ansi-terminal
+        - prettyprinter-compat-wl-pprint
+        - prettyprinter-compat-ansi-wl-pprint
+        - prettyprinter-compat-annotated-wl-pprint
+        - prettyprinter-convert-ansi-wl-pprint
 
     "Joe M <joe9mail@gmail.com> @joe9":
         - logger-thread < 0 # via protolude
@@ -2749,11 +2755,6 @@ packages:
     "David Luposchainsky <dluposchainsky (λ) googles email service> @quchen":
         - pgp-wordlist
         - show-prettyprint < 0 # via trifecta
-        - prettyprinter < 1.7.0 # https://github.com/commercialhaskell/stackage/issues/5558
-        - prettyprinter-ansi-terminal
-        - prettyprinter-compat-wl-pprint
-        - prettyprinter-compat-ansi-wl-pprint
-        - prettyprinter-compat-annotated-wl-pprint
 
     "Jeremy Shaw <jeremy@n-heptane.com> @stepcut":
         - boomerang < 0 # GHC 8.4 via template-haskell-2.13.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2750,7 +2750,7 @@ packages:
         - pgp-wordlist
         - show-prettyprint < 0 # via trifecta
         - prettyprinter < 1.7.0 # https://github.com/commercialhaskell/stackage/issues/5558
-        - prettyprinter-ansi-terminal < 1.1.2 # https://github.com/commercialhaskell/stackage/issues/5560
+        - prettyprinter-ansi-terminal
         - prettyprinter-compat-wl-pprint
         - prettyprinter-compat-ansi-wl-pprint
         - prettyprinter-compat-annotated-wl-pprint

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5643,7 +5643,6 @@ expected-test-failures:
     - relude # doctest fails due to GHC bugs, will be fixed in the next `relude` release
     - stm-delay # https://github.com/joeyadams/haskell-stm-delay/issues/5
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
-    - prettyprinter # Could not load module ‘Test.QuickCheck.Modifiers’ (member of the hidden package ‘QuickCheck-2.13.2’)
 
     # https://github.com/pruvisto/heap/issues/11
     - heap


### PR DESCRIPTION
I have moved the `prettyprinter*` packages to my packages since I'm their most active maintainer these days. (CC @quchen)

I have also added `prettyprinter-convert-ansi-wl-pprint` which wasn't included previously.

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $pacakge-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
