### PR TITLE
Re-enable hopenpgp-tools

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1250,7 +1250,7 @@ packages:
         - openpgp-asciiarmor
         - MusicBrainz
         - DAV
-        - hopenpgp-tools < 0 # ghc 8.10
+        - hopenpgp-tools
         - opensource
         - debian
         - cabal-debian < 0 # https://github.com/ddssff/cabal-debian/issues/71


### PR DESCRIPTION
I am not sure why this was disabled, but hopenpgp-tools appears to build with GHC 8.10.