### PR TITLE
reactivate 'hyper' and depending packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -451,17 +451,17 @@ packages:
         - netlib-comfort-array
         - blas-comfort-array
         - lapack-comfort-array
-        - lapack < 0 # via hyper
-        - hmm-lapack < 0 # via lapack
-        - magico < 0 # via lapack
-        - resistor-cube < 0 # via lapack
-        - linear-circuit < 0 # via lapack
+        - lapack
+        - hmm-lapack
+        - magico
+        - resistor-cube
+        - linear-circuit
         # Not a maintainer
         - cabal-plan
         - topograph
         - ix-shapable
         - hsshellscript
-        - hyper < 0 # via base-4.13.0.0
+        - hyper
         - storable-endian
 
     "Jeremy Barisch-Rooney <barischj@tcd.ie> @barischrooneyj":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $pacakge-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks