### PR TITLE
Re-enable postgresql-typed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3454,7 +3454,7 @@ packages:
         - viewprof < 0 # via base-4.13.0.0
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
-        - postgresql-typed < 0 # via HDBC
+        - postgresql-typed
         - invertible < 0 # ghc 8.10.1 https://github.com/commercialhaskell/stackage/issues/5441
         - ztail < 0 # via time-1.9.3
         - zip-stream


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $pacakge-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

With postgresql-typed-0.6.1.2.
(Except for haddock which is failing for basement, and tests which are disabled.)