### PR TITLE
Re-enable invertible, ztail

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3453,8 +3453,8 @@ packages:
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed
-        - invertible < 0 # ghc 8.10.1 https://github.com/commercialhaskell/stackage/issues/5441
-        - ztail < 0 # via time-1.9.3
+        - invertible
+        - ztail
         - zip-stream
 
     "Louis Pan <louis@pan.me> @louispan":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

invertible-0.2.0.7
ztail-1.2.0.2-r2