### PR TITLE
Reenable world-peace package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2463,7 +2463,7 @@ packages:
         - servant-rawm
         - servant-static-th < 0 # ghc 8.10 via servant
         - termonad < 0 # via gi-vte
-        - world-peace < 0 # ghc 8.10.1 #5452/closed
+        - world-peace
         - xml-html-qq < 0 # via heterocephalus
         - xml-indexed-cursor
 


### PR DESCRIPTION
Reenable the `world-peace` package.  The latest 1.0.2.0 version compiles with GHC-8.10.

------------------------------

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
