### PR TITLE
Re-enabled alarmclock and bank-holidays-england

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1523,8 +1523,8 @@ packages:
         - shake-language-c < 0 # via fclabels
 
     "David Turner <dave.c.turner@gmail.com> @davecturner":
-        - alarmclock < 0 # ghc 8.10
-        - bank-holidays-england < 0 # ghc 8.10
+        - alarmclock
+        - bank-holidays-england
 
     "Haskell Servant <haskell-servant-maintainers@googlegroups.com>":
         - servant


### PR DESCRIPTION
base bounds relaxed in new versions

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
