### PR TITLE
Reenable hoogle

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -735,7 +735,7 @@ packages:
 
     "Neil Mitchell <ndmitchell@gmail.com> @ndmitchell":
         - hlint
-        - hoogle < 0 # via wai-logger
+        - hoogle
         - shake
         - tagsoup
         - cmdargs


### PR DESCRIPTION
wai-logger is back in nightly, so should be able to be enabled. Tested via CI.