### PR TITLE
Reenable crypto-enigma package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4951,7 +4951,7 @@ packages:
       - hslua-module-text < 0.3
 
       # https://github.com/commercialhaskell/stackage/issues/5603
-      - crypto-enigma < 0 # base 4.14.1.0
+      - crypto-enigma
 
 # end of packages
 


### PR DESCRIPTION
Correct previous pull request to actually re-enable (corrects  #5607; closes #5603)

----

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $pacakge # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
