### PR TITLE
Re-enable yesod-auth-hashdb

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1388,7 +1388,7 @@ packages:
         - mysql-simple
         - sphinx < 0 # Could not find module Network
         - xmlhtml < 0 # GHC 8.4 via hspec-2.5.0
-        - yesod-auth-hashdb < 0 # aeson 1.5 via yesod-persistent
+        - yesod-auth-hashdb
 
     "Toralf Wittner <tw@dtex.org> @twittner":
         - bytestring-conversion


### PR DESCRIPTION
`yesod-auth-hashdb` is OK now that `yesod-auth` is in nightly

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
