### PR TITLE
Re-enable shikensu

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3649,7 +3649,7 @@ packages:
         # - alerta # servant-client 0.12
 
     "Steven Vandevelde <icid.asset@gmail.com> @icidasset":
-        - shikensu < 0 # via flow
+        - shikensu
 
     "George Pollard <porges@porg.es> @Porges":
         - email-validate


### PR DESCRIPTION
Tested with latest nightly, verify was succesful, and `flow` seems to enabled too.
Thanks!

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
