### PR TITLE
Re-enable gi-cairo-connector, gi-cairo-render, gtk-sni-tray and taffybar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4244,13 +4244,13 @@ packages:
     "Ivan Malison <IvanMalison@gmail.com> @IvanMalison":
         - ConfigFile
         - dbus-hslogger
-        - gi-cairo-connector <0 # needs gi-cairo-render
-        - gi-cairo-render <0    # https://github.com/cohomology/gi-cairo-render/issues/3
-        - gtk-sni-tray <0       # needs gi-cairo-render
+        - gi-cairo-connector
+        - gi-cairo-render
+        - gtk-sni-tray
         - gtk-strut
         - rate-limit
         - status-notifier-item
-        - taffybar < 0 # ghc 8.10
+        - taffybar
         - time-units
         - xml-helpers
         - xdg-desktop-entry


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
