### PR TITLE
Adds `subcategories`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4330,6 +4330,7 @@ packages:
         - ghc-typelits-presburger
         - singletons-presburger
         - type-natural
+        - subcategories
         - sized
 
     "Frank Doepper <stackage@woffs.de> @woffs":


### PR DESCRIPTION
A new version of `sized` package, which has just been uploaded, now uses newly written packge `subcategories`.
This pull-request adds `subcategories` to get `sized` remain on Stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks