### PR TITLE
Fix th-test-utils bound

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4261,7 +4261,7 @@ packages:
         - github-rest
         - graphql-client
         - hpc-lcov
-        - th-test-utils < 1.1 # https://github.com/commercialhaskell/stackage/issues/5657
+        - th-test-utils
 
     "Akshay Mankar <itsakshaymankar@gmail.com> @akshaymankar":
         - jsonpath


### PR DESCRIPTION
Resolves #5657  by uploading a new version of aeson-schemas that does not bound th-test-utils