### PR TITLE
Remove version constraint for reanimate-svg (#5677)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5015,9 +5015,6 @@ packages:
       - haskell-lsp-types < 0.23
       - lsp-test < 0.11.0.6
 
-      # https://github.com/commercialhaskell/stackage/issues/5677
-      - reanimate-svg < 0.12
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
