### PR TITLE
Re-enable haskell-works packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3019,8 +3019,8 @@ packages:
         - hw-conduit
         - hw-conduit-merges
         - hw-diagnostics
-        - hw-dsv < 0 # generic-lens 2.0.0.0
-        - hw-eliasfano < 0 # generic-lens 2.0.0.0
+        - hw-dsv
+        - hw-eliasfano
         - hw-excess
         - hw-fingertree
         - hw-fingertree-strict
@@ -3028,19 +3028,19 @@ packages:
         - hw-hspec-hedgehog
         - hw-int
         - hw-ip
-        - hw-json < 0 # generic-lens 2.0.0.0
-        - hw-json-simple-cursor < 0 # generic-lens 2.0.0.0
-        - hw-json-standard-cursor < 0 # generic-lens 2.0.0.0
+        - hw-json
+        - hw-json-simple-cursor
+        - hw-json-standard-cursor
         - hw-mquery
-        - hw-packed-vector < 0 # generic-lens 2.0.0.0
+        - hw-packed-vector
         - hw-parser
         - hw-prim
-        - hw-rankselect < 0 # generic-lens 2.0.0.0
+        - hw-rankselect
         - hw-rankselect-base
-        - hw-simd < 0 # hw-rankselect due to generic-lens 2.0.0.0
+        - hw-simd
         - hw-streams
-        - hw-succinct < 0 # hw-rankselect due to generic-lens 2.0.0.0
-        - hw-xml < 0 # generic-lens 2.0.0.0
+        - hw-succinct
+        - hw-xml
         - tasty-discover
 
     "George Wilson <george@wils.online> @gwils":


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
