### PR TITLE
Add BNFC

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9,6 +9,9 @@ cabal-format-version: "3.0"
 
 # Constraints for brand new builds
 packages:
+    "Andreas Abel <andreas.abel@gu.se> @andreasabel":
+        - BNFC
+
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
 


### PR DESCRIPTION
Add https://hackage.haskell.org/package/BNFC-2.8.4 to stackage.
A file `stack-8.10.2.yaml` is included in the BNFC cabal package.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
