### PR TITLE
Add lens-csv & lens-regex-pcre

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -89,7 +89,8 @@ packages:
         - ENIG
 
     "Chris Penner <christopher.penner@gmail.com> @ChrisPenner":
-        - lens-regex-pcre < 0 # via pcre-heavy
+        - lens-regex-pcre
+        - lens-csv
 
     "Emily Pillmore <emilypi@cohomolo.gy> @topos":
         - base16


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

It appears lens-regex-pcre was previously restricted by pcre-heavy; but it seems to build on stackage nightly at the moment. Is there anything else I need to check here?