### PR TITLE
Please bump up libjwt version

### DIFF
--- a/debian-bootstrap.sh
+++ b/debian-bootstrap.sh
@@ -320,7 +320,7 @@ Z3_VER=4.8.8
     && ln -s /usr/local/z3-${Z3_VER}-x64-ubuntu-16.04/bin/z3 /usr/bin/z3
 )
 
-LIBJWT_VER=1.12.0
+LIBJWT_VER=1.12.1
 (
 pushd /tmp \
     && wget https://github.com/benmcollins/libjwt/archive/v${LIBJWT_VER}.zip \


### PR DESCRIPTION
This will allow `libjwt-typed` into Stackage. See https://github.com/commercialhaskell/stackage/pull/5648
