### PR TITLE
Reinstate libjwt-typed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -49,7 +49,7 @@ packages:
     "Marcin Rzeźnicki <marcin.rzeznicki@gmail.com> @marcin-rzeznicki":
         - hspec-tables
         - stackcollapse-ghc
-        - libjwt-typed < 0 # https://github.com/commercialhaskell/stackage/pull/5648#issuecomment-694239692
+        - libjwt-typed
 
     "Mauricio Fierro <mauriciofierrom@gmail.com> @mauriciofierrom":
         - dialogflow-fulfillment


### PR DESCRIPTION
There was a problem with C library dependency that supposedly has been fixed in #5696 . Tests that were failing (see #5648 ) should now be fixed.
