### PR TITLE
Remove upper bounds on th-orphans, wai-middleware-static

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5020,9 +5020,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/5633
       - language-c < 0.9
 
-      # https://github.com/commercialhaskell/stackage/issues/5669
-      - th-orphans < 0.13.11
-
       # https://github.com/commercialhaskell/stackage/issues/5668
       - th-abstraction < 0.4
       - bifunctors < 5.5.8
@@ -5037,9 +5034,6 @@ packages:
 
       # https://github.com/commercialhaskell/stackage/issues/5666
       - generic-deriving < 1.14
-
-      # https://github.com/commercialhaskell/stackage/issues/5672
-      - wai-middleware-static < 0.9.0
 
       # https://github.com/commercialhaskell/stackage/issues/5673
       - text-show < 3.9


### PR DESCRIPTION
The libraries that were preventing the latest versions of `th-orphans` and `wai-middleware-static` from being used in Stackage have since upgraded.

Fixes #5669. Fixes #5672.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
