### PR TITLE
Reenable servant

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1556,24 +1556,24 @@ packages:
 
     "Haskell Servant <haskell-servant-maintainers@googlegroups.com>":
         - servant
-        - servant-blaze < 0 # ghc 8.10 via servant
+        - servant-blaze
         - servant-cassava < 0 # ghc 8.10 via servant
-        - servant-client < 0 # ghc 8.10 via servant
-        - servant-client-core < 0 # ghc 8.10 via servant
-        - servant-conduit < 0 # ghc 8.10 via servant & unliftio-core
-        - servant-docs < 0 # ghc 8.10 via servant
-        - servant-foreign < 0 # ghc 8.10 via servant
-        - servant-http-streams < 0 # via servant
+        - servant-client
+        - servant-client-core
+        - servant-conduit
+        - servant-docs
+        - servant-foreign
+        - servant-http-streams
         - servant-js < 0 # ghc 8.10 via servant
         - servant-lucid < 0 # ghc 8.10 via servant
-        - servant-machines < 0 # ghc 8.10 via servant
+        - servant-machines
         - servant-mock < 0 # ghc 8.10 via servant
-        - servant-multipart < 0 # via servant
-        - servant-pipes < 0 # ghc 8.10 via servant
-        - servant-server < 0 # ghc 8.10 via servant
-        - servant-swagger < 0 # ghc 8.10 via servant & swagger2
-        - servant-swagger-ui < 0 # ghc 8.10 via servant & swagger2
-        - servant-swagger-ui-core < 0 # ghc 8.10 via servant & swagger2
+        - servant-multipart
+        - servant-pipes
+        - servant-server
+        - servant-swagger
+        - servant-swagger-ui
+        - servant-swagger-ui-core
 
     "Optics <optics@well-typed.com>":
         - indexed-profunctors


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


Note that some of these packages have Hackage revisions that fix version bounds.

I'm going to update the rest of Servant family in the next few days.

Fixes https://github.com/haskell-servant/servant/issues/1340