### PR TITLE
allow megaparsec 9 (#5632) and dhall >= 1.34 (#5580)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -31,7 +31,7 @@ packages:
         - safe-tensor
 
     "Artur Gajowy <artur.gajowy@gmail.com> @ArturGajowy":
-        - ghc-clippy-plugin
+        - ghc-clippy-plugin < 0 # dhall (and text-1.3)
 
     "Daniel Rolls <daniel.rolls.27@googlemail.com> @danielrolls":
         - byte-count-reader < 0 # ghc 8.10
@@ -4989,14 +4989,6 @@ packages:
       # blocked by 5535
       - recursion-schemes < 5.2
       - stackcollapse-ghc < 0.0.1.3
-      - egison-pattern-src < 0.2.1.1
-
-      # https://github.com/commercialhaskell/stackage/issues/5580
-      - dhall < 1.34.0
-      - dhall-bash < 1.0.32
-      # - dhall-nix < 1.1.16
-      - dhall-json < 1.7.1
-      - dhall-lsp-server < 1.0.9
 
       # https://github.com/commercialhaskell/stackage/issues/5592
       - ansi-terminal < 0.11
@@ -5017,11 +5009,6 @@ packages:
 
       # https://github.com/commercialhaskell/stackage/issues/5623
       - http-api-data < 0.4.2
-
-      # https://github.com/commercialhaskell/stackage/issues/5632
-      - megaparsec < 9.0.0
-      - hspec-megaparsec < 2.2.0
-      - megaparsec-tests < 9.0.0
 
       # https://github.com/commercialhaskell/stackage/issues/5633
       - language-c < 0.9


### PR DESCRIPTION
disable ghc-clippy-plugin (ArturGajowy/ghc-clippy-plugin#3) until fixed

also also egison-pattern-src-0.2.1.2 (egison/egison-pattern-src#25)