### PR TITLE
Modify persistent-test blocker message

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -655,7 +655,7 @@ packages:
         - persistent-postgresql < 2.11 # via persistent-2.11
         - persistent-sqlite < 2.11 # via persistent-2.11
         - persistent-template < 2.8.3 # via persistent-2.11 (#5347/closed)
-        - persistent-test < 0 # https://github.com/commercialhaskell/stackage/issues/5641
+        - persistent-test < 0 # via persistent-2.11
         # - stackage-curator # http-conduit 2.3 via amazonka
         - store
         - wai-extra


### PR DESCRIPTION
I've updated `persistent-test` on Hackage to have appropriate version bounds, so it should build when `persistent-2.11` is on Stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
