### PR TITLE
Revert "Add hex-text"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3818,7 +3818,6 @@ packages:
         - aws-cloudfront-signed-cookies
         - data-ascii
         - d10
-        - hex-text
         - stripe-concepts
         - stripe-signature < 0 # criterion 0.27
         - stripe-scotty < 0 # via scotty


### PR DESCRIPTION
Reverts commercialhaskell/stackage#5719

---

Ping @chris-martin: sorry about this, but it looks like we're blocked on `base16-bytestring-1.0.0.0` for the moment so I've had to revert the `hex-text` addition. I'll add it to the list in #5649 and tag you there as well.