### PR TITLE
Allow text-show-3.9

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5024,9 +5024,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/5666
       - generic-deriving < 1.14
 
-      # https://github.com/commercialhaskell/stackage/issues/5673
-      - text-show < 3.9
-
       # https://github.com/commercialhaskell/stackage/issues/5676
       - haskell-lsp < 0.23
       - haskell-lsp-types < 0.23


### PR DESCRIPTION
This was previously [blocked on `clash-lib` and `clash-prelude`](https://github.com/commercialhaskell/stackage/commit/4d220110df847a9791defa8ccafcb4e2e6a2a69c), but their latest Hackage versions now allow `text-show-3.9`.

Fixes #5673.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
