### PR TITLE
Enable hedn

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1972,7 +1972,7 @@ packages:
         - maximal-cliques
 
     "Alexander Bondarenko <aenor.realm@gmail.com> @dpwiz":
-        - hedn < 0 # ghc 8.10
+        - hedn
         - soap
         - soap-tls
         - soap-openssl


### PR DESCRIPTION
Megaparsec bounds updated, 8.10 warnings fixed in 0.3.0.2.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
