### PR TITLE
add zydiskell package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4443,6 +4443,9 @@ packages:
 
     "Alexander Batischev <eual.jp@gmail.com> @Minoru":
         - hakyll-convert
+        
+    "Edward Nerd <nerded.nerded@gmail.com> @nerded1337":
+        - zydiskell
 
     "Grandfathered dependencies":
         - Boolean


### PR DESCRIPTION
Hi guys,

I am developing a [Haskell language binding](https://github.com/nerded1337/zydiskell) for the [Zydis library](https://github.com/zyantific/zydis).
It would be a good thing to list it in stackage as I plan to maintain it!

What do you think?

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
