### PR TITLE
Reenable servant-openapi3 tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5549,9 +5549,6 @@ skipped-tests:
     # https://github.com/commercialhaskell/stackage/issues/5746
     - parameterized
 
-    # https://github.com/commercialhaskell/stackage/issues/5756
-    - servant-openapi3
-
 
 # end of skipped-tests
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


See https://github.com/commercialhaskell/stackage/issues/5756#issuecomment-732316622