### PR TITLE
Re-add servant-exceptions

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3918,7 +3918,8 @@ packages:
 
     "Sebastian Nagel <sebastian.nagel@ncoding.at> @ch1bo":
         - hdevtools < 0 # compilation failure
-        - servant-exceptions < 0 # https://github.com/ch1bo/servant-exceptions/issues/9
+        - servant-exceptions
+        - servant-exceptions-server
 
     "Vaibhav Sagar <vaibhavsagar@gmail.com> @vaibhavsagar":
         - ihaskell


### PR DESCRIPTION
Build issues vs. servant-0.16 (and newer) have been resolved and released as version 0.2.1

Checklist:

* [x]  Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)

* [x]  At least 30 minutes have passed since uploading to Hackage

* [x]  On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):
      ```
      ./verify-package $package # or $package-$version
      ```


The script runs virtually the following commands in a clean directory:

```
  stack unpack $package-$version  # $version is optional
  cd $package-$version
  rm -f stack.yaml && stack init --resolver nightly
  stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
```
