### PR TITLE
Re-enable and add Freckle packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1069,7 +1069,7 @@ packages:
         - bcp47-orphans < 0 # esqueleto, text
         - faktory < 0 # megaparsec
         - graphula < 0 # aeson, base, bytestring, generics-eot, unliftio-core
-        - hspec-expectations-json # base, text
+        - hspec-expectations-json < 0 # base, text
         - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1060,17 +1060,16 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2
-        - yesod-markdown
+        - yesod-auth-oauth2 < 0 # hoauth2-1.16.0
+        - yesod-markdown < 0 # pandoc
         - yesod-paginator
         
         # Freckle packages I'm maintaining for us
-        - bcp47
-        - bcp47-orphans
-        - faktory
-        - graphula
-        - generics-eot # 3rd party, but needed by Graphula
-        - hspec-expectations-json
+        - bcp47 < 0 # aeson, megaparsec, text
+        - bcp47-orphans < 0 # esqueleto, text
+        - faktory < 0 # megaparsec
+        - graphula < 0 # aeson, base, bytestring, generics-eot, unliftio-core
+        - hspec-expectations-json # base, text
         - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1066,7 +1066,7 @@ packages:
         
         # Freckle packages I'm maintaining for us
         - bcp47
-        - bcp47-orphan
+        - bcp47-orphans
         - faktory
         - graphula
         - generics-eot # 3rd party, but needed by Graphula

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1057,12 +1057,21 @@ packages:
         - asciidiagram
 
     "Patrick Brisbin @pbrisbin":
-        - bugsnag-haskell < 0 # via yesod-core
+        - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2 < 0 # via hoauth2 & yesod-core
-        - yesod-markdown < 0 # pbrisbin/yesod-markdown#65
-        - yesod-paginator < 0 # via persistent
+        - yesod-auth-oauth2
+        - yesod-markdown
+        - yesod-paginator
+        
+        # Freckle packages I'm maintaining for us
+        - bcp47
+        - bcp47-orphan
+        - faktory
+        - graphula
+        - generics-eot # 3rd party, but needed by Graphula
+        - hspec-expectations-json
+        - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
         - fb
@@ -4072,7 +4081,7 @@ packages:
         - codec-beam
 
     "Chris Parks <christopher.daniel.parks@gmail.com> @cdparks":
-        - closed < 0 # via persistent
+        - closed
 
     "Chris Coffey <chris@foldl.io> @ChrisCoffey":
         - servant-tracing < 0 # via servant-server


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

  ~~**Working on this now**. I thought it would be more efficient for me to do that concurrently with CI, since I'm re-enabling a lot of packages here it will take me a bit.~~ If this is a hard requirement, I would suggest removing the "edit right on GitHub" suggestion in the README, since a local clone is better for this step.