### PR TITLE
Re-enable packages that were blocked by vinyl

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2174,17 +2174,17 @@ packages:
     "Justin Le <justin@jle.im> @mstksg":
         - advent-of-code-api < 0 # ghc 8.10 via servant
         - auto
-        - backprop < 0 # via vinyl
+        - backprop
         - bins
         - configurator-export
-        - decidable < 0 # via vinyl
+        - decidable
         - emd < 0 # via typelits-witnesses
-        - functor-products < 0 # via vinyl
+        - functor-products
         - hamilton < 0 # via vty
-        - hmatrix-backprop < 0 # via backprop
+        - hmatrix-backprop
         - hmatrix-vector-sized
         - lens-typelevel < 0 # GHC 8.8 via ghc-typelits-presburger (konn/equational-reasoning-in-haskell#4)
-        - list-witnesses < 0 # via vinyl
+        - list-witnesses
         - nonempty-containers
         - one-liner-instances
         - prompt


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
