### PR TITLE
Re-enable yesod-auth-oauth2 and hspec-expectations-json

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1061,7 +1061,7 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2 < 0 # hoauth2-1.16.0
+        - yesod-auth-oauth2
         - yesod-markdown < 0 # pandoc
         - yesod-paginator
 
@@ -1070,7 +1070,7 @@ packages:
         - bcp47-orphans < 0 # esqueleto, text
         - faktory < 0 # megaparsec
         - graphula < 0 # aeson, base, bytestring, generics-eot, unliftio-core
-        - hspec-expectations-json < 0 # base, text
+        - hspec-expectations-json
         - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1070,7 +1070,7 @@ packages:
         - bcp47-orphans < 0 # esqueleto, text
         - faktory < 0 # megaparsec
         - graphula < 0 # aeson, base, bytestring, generics-eot, unliftio-core
-        - hspec-expectations-json
+        - hspec-expectations-json < 0 # aeson, text
         - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":


### PR DESCRIPTION
Both packages have been released with passing nightly builds.


Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks