### PR TITLE
Re-enable prettyprinter-compat-annotated-wl-pprint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -528,7 +528,7 @@ packages:
         - prettyprinter-ansi-terminal
         - prettyprinter-compat-wl-pprint
         - prettyprinter-compat-ansi-wl-pprint
-        - prettyprinter-compat-annotated-wl-pprint < 0 # https://github.com/commercialhaskell/stackage/issues/5779
+        - prettyprinter-compat-annotated-wl-pprint
         - prettyprinter-convert-ansi-wl-pprint
 
     "Joe M <joe9mail@gmail.com> @joe9":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
