### PR TITLE
Change deprecated `conferer-source-json` with `conferer-aeson`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3987,7 +3987,7 @@ packages:
         #- conferer-snap # Because snap
         - conferer-warp
         - conferer-hspec
-        - conferer-source-json
+        - conferer-aeson
 
     "Tim Humphries <tim+stackage@utf8.me> @thumphries":
         - transformers-either < 0 # via exceptions-0.10.0


### PR DESCRIPTION
This fixes #5808 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
