### PR TITLE
Preserves snapshot-incomplete with NOPLAN=1

### DIFF
--- a/automated/build.sh
+++ b/automated/build.sh
@@ -108,7 +108,7 @@ then
         docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator update && curator constraints --target $TARGET && curator snapshot-incomplete --target $TARGET && curator snapshot"
     fi
 else
-    docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator snapshot-incomplete --target $TARGET && curator snapshot"
+    docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator snapshot"
 fi
 
 


### PR DESCRIPTION
Just opening this as a matter of courtesy/record; the commit message sums things up nicely:
```
Previously, 'NOPLAN=1' would overwrite the 'snapshot-incomplete.yaml'
file. This makes it difficult tweak things (e.g. by explicitly bumping a
package in response to maintainer request).

Now 'NOPLAN=1' will skip generating 'snapshot-incomplete.yaml' entirely,
and it will be up to a previous run w/out a 'NOPLAN' override to set
this up properly.
```