### PR TITLE
[ #5801 ] Reenable ListLike

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -27,6 +27,7 @@ packages:
         - STMonadTrans
         - Agda
         - agda2lagda
+        - ListLike
 
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
@@ -4504,7 +4505,6 @@ packages:
         - HsOpenSSL
         - HsYAML
         - JuicyPixels-scale-dct
-        - ListLike
         - MemoTrie
         - NumInstances
         - Only

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5090,11 +5090,11 @@ packages:
       - list-witnesses < 0
 
       # https://github.com/commercialhaskell/stackage/issues/5801
-      - ListLike < 0 # https://github.com/ddssff/listlike/issues/8
-      - Earley < 0
-      - debian < 0
+      # https://github.com/ddssff/listlike/issues/8 [fixed]
+      - Earley < 0 # via ListLike
+      - debian < 0 # via ListLike
       - cabal-debian <0 # via debian
-      - process-extras < 0
+      - process-extras < 0 # via ListLike
       - pdfinfo < 0 # via process-extra
       - tasty-silver < 0 # via process-extras
       - hoogle < 0 # via process-extra


### PR DESCRIPTION
[ #5801 ] Reenable ListLike
Packages depending on ListLike should be reenabled in the next step.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
