### PR TITLE
[ #5801 ] Reenable process-extras and Earley after fix of ListLike

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5094,10 +5094,8 @@ packages:
 
       # https://github.com/commercialhaskell/stackage/issues/5801
       # https://github.com/ddssff/listlike/issues/8 [fixed]
-      - Earley < 0 # via ListLike
-      - debian < 0 # via ListLike
+      - debian < 0 # via process-extras
       - cabal-debian <0 # via debian
-      - process-extras < 0 # via ListLike
       - pdfinfo < 0 # via process-extra
       - tasty-silver < 0 # via process-extras
       - hoogle < 0 # via process-extra


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
