### PR TITLE
Remove duplicate "Agda" entry

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2435,7 +2435,7 @@ packages:
         - ipython-kernel
 
     "Andrés Sicard-Ramírez <asr@eafit.edu.co> @asr":
-        - Agda < 0
+        [] # - Agda moved to Andreas Abel
 
     "James Cook <mokus@deepbondi.net> @mokus0":
         - dependent-map < 0 # via constraints-extras


### PR DESCRIPTION
The "Agda < 0" under @ars contradicts the "Agda" entry under @andreasabel.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage

Does not apply, Agda is already enabled:
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
