### PR TITLE
[ #5801 ] Reenable debian, hoogle, pdfinfo (via process-extras)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5090,12 +5090,8 @@ packages:
       - list-witnesses < 0
 
       # https://github.com/commercialhaskell/stackage/issues/5801
-      # https://github.com/ddssff/listlike/issues/8 [fixed]
-      - debian < 0 # via process-extras
       - cabal-debian <0 # via debian
-      - pdfinfo < 0 # via process-extra
-      - tasty-silver < 0 # via process-extras
-      - hoogle < 0 # via process-extra
+      - tasty-silver < 0 # via tasty
 
 # end of packages
 


### PR DESCRIPTION
[ #5801 ] Reenable debian, hoogle, pdfinfo (via process-extras)
process-extras is back in nightly, these packages build now

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version
