### PR TITLE
Remove dhall-lsp-server from expected-test-failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5927,9 +5927,6 @@ expected-test-failures:
     # https://github.com/kazu-yamamoto/dns/issues/153
     - dns
 
-    # https://github.com/dhall-lang/dhall-haskell/issues/1891
-    - dhall-lsp-server
-
     # https://github.com/cdornan/fmt/issues/30
     - fmt
 


### PR DESCRIPTION
Context: https://github.com/dhall-lang/dhall-haskell/issues/1891

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
