### PR TITLE
[ close #5801 ] reenable cabal-debian and tasty-silver < 3.2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5089,10 +5089,6 @@ packages:
       - decidable < 0
       - list-witnesses < 0
 
-      # https://github.com/commercialhaskell/stackage/issues/5801
-      - cabal-debian <0 # via debian
-      - tasty-silver < 0 # via tasty
-
       # https://github.com/commercialhaskell/stackage/issues/5834
       - call-stack < 0.3.0
       - HUnit < 1.6.2.0
@@ -5359,7 +5355,7 @@ skipped-tests:
     - clay # via hspec-discover-2.6.0
     - codec-rpm # via hspec-2.6.0
     - colour # QuickCheck-2.11.3
-    - dhall-json # tasty-silver https://github.com/commercialhaskell/stackage/issues/5801
+    - dhall-json # tasty-silver https://github.com/commercialhaskell/stackage/issues/5795
     - drawille # hspec 2.4
     - ed25519 # QuickCheck, hlint and more
     - elynx-tree # QuickCheck-2.14


### PR DESCRIPTION
[ close #5801 ] reenable cabal-debian and tasty-silver < 3.2

verify-package now works for
  * cabal-debian
  * tasty-silver-3.1.15

The latest tasty-silver depends on tasty >= 1.4 (issue #5795)

    tasty version 1.2.3 found
        - tasty-silver requires >=1.4

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version
