### PR TITLE
reenable and adopt haskell-src

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -28,6 +28,7 @@ packages:
         - Agda < 0  # https://github.com/commercialhaskell/stackage/issues/5826
         - agda2lagda
         - ListLike
+        - haskell-src
 
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
@@ -4660,7 +4661,6 @@ packages:
         - haskell-gi-overloading
         - haskell-lexer
         - haskell-lsp-types
-        - haskell-src < 0 # ghc 8.10
         - haskell-src-exts
         - haxl < 0 # via time-1.9.3
         - heap


### PR DESCRIPTION
I am now maintainer of haskell-src and released revision 1.0.3.1-r2 that accepts happy-1.20.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version
