### PR TITLE
Remove constraint on universum

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3732,7 +3732,7 @@ packages:
         - log-warper < 0 # GHC 8.4 via lifted-async-0.10.0.1
         - o-clock
         - tasty-hunit-compat
-        - universum < 1.6.0 # text-1.2.4: https://github.com/commercialhaskell/stackage/issues/5796
+        - universum
         - with-utf8
         - uncaught-exception
 


### PR DESCRIPTION
Problem: universum-1.6.0 and newer doesn't support `text-1.2.4.1` which is the latest version of `text`.
It was reported in https://github.com/commercialhaskell/stackage/issues/5796
Because of that `build-constraints.yaml` now constrains universum's version to be less than 1.6.0.

Solution: now that universum-1.7.2 has been released and supports the latest `text`, the constraint can be dropped entirely.

Resolves #5796

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
