### PR TITLE
Remove duplicated shortcut-links

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2456,7 +2456,6 @@ packages:
         - microlens-th
         - microlens-ghc < 0.4.13 # https://github.com/commercialhaskell/stackage/issues/5749
         - microlens-contra
-        - shortcut-links < 0 # MonadFail
         - cheapskate-highlight
         - cheapskate-lucid
         - cmark-lucid


### PR DESCRIPTION
`shortcut-links` has been moved under @kowainik maintenance long ago (see line 3750: https://github.com/commercialhaskell/stackage/blob/9969cca46dfb94674f3124b9650159568543ba82/build-constraints.yaml#L3750).

Though, we just figured out that `shortcut-links` is not on Stackage due to this line (`shortcut-links < 0`).

Maybe there is a way to prevent such a situation by disallowing the duplicated packages or using a bit more concrete logic to exclude/include the packages? For example, we were not notified about the package being removed from Stackage even though we have our names on this package (though it goes after this restriction under the Monadfix section).