### PR TITLE
Reenable control-dsl

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -210,7 +210,7 @@ packages:
         - mpi-hs-cereal
 
     "Yang Bo <pop.atry@gmail.com> @Atry":
-        - control-dsl < 0 # via doctest-discover
+        - control-dsl
 
     "Laurent P. René de Cotret <laurent.decotret@outlook.com> @LaurentRDC":
         - pandoc-plot < 0 # ghc 8.10 via pandoc


### PR DESCRIPTION
Reenable control-dsl since doctest-discover is not causing any problems.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command:
    ```
    $ ./verify-package control-dsl
    Unpacked control-dsl (from Hackage) to /Users/atry/github/stackage/tmp.PkrF/control-dsl-0.2.1.3/
    Looking for .cabal or package.yaml files to use to init the project.
    Using cabal packages:
    - ./

    Selected resolver: nightly-2021-01-27
    Selected resolver: nightly-2021-01-27
    Initialising configuration using resolver: nightly-2021-01-27
    Total number of user packages considered: 1
    Writing configuration to file: stack.yaml
    All done.
    Selected resolver: nightly-2021-01-27
    base-compat          > using precompiled package
    base-orphans         > using precompiled package
    code-page            > using precompiled package
    dlist                > using precompiled package
    ghc-paths            > using precompiled package
    hashable             > using precompiled package
    indexed-traversable  > using precompiled package
    integer-logarithms   > using precompiled package
    primitive            > using precompiled package
    random               > using precompiled package
    syb                  > using precompiled package
    tagged               > using precompiled package
    th-abstraction       > using precompiled package
    transformers-compat  > using precompiled package
    base-compat-batteries> using precompiled package
    time-compat          > using precompiled package                                data-fix             > using precompiled package                                unordered-containers > using precompiled package                                scientific           > using precompiled package                                vector               > using precompiled package                                temporary            > using precompiled package                                uuid-types           > using precompiled package                                doctest              > using precompiled package                                distributive         > using precompiled package                               attoparsec           > using precompiled package                                comonad              > using precompiled package                                rbifunctors           > using precompiled package
    assoc                > using precompiled package
    these                > using precompiled package
    strict               > using precompiled package
    aeson                > using precompiled package
    doctest-discover     > using precompiled package
    control-dsl          > configure (lib + test)
    Configuring control-dsl-0.2.1.3...
    control-dsl          > build (lib + test)
    Preprocessing library for control-dsl-0.2.1.3..
    Building library for control-dsl-0.2.1.3..
    [ 1 of 13] Compiling Control.Dsl.PolyCont
    [ 2 of 13] Compiling Control.Dsl.Monadic
    [ 3 of 13] Compiling Control.Dsl.Empty
    [ 4 of 13] Compiling Control.Dsl.Return
    [ 5 of 13] Compiling Control.Dsl.Cont
    [ 6 of 13] Compiling Control.Dsl.Dsl
    [ 7 of 13] Compiling Control.Dsl.Shift
    [ 8 of 13] Compiling Control.Dsl.State.State
    [ 9 of 13] Compiling Control.Dsl.State.Put
    [10 of 13] Compiling Control.Dsl.State.Get
    [11 of 13] Compiling Control.Dsl.State
    [12 of 13] Compiling Control.Dsl.Yield
    [13 of 13] Compiling Control.Dsl
    Preprocessing test suite 'doctests' for control-dsl-0.2.1.3..
    Building test suite 'doctests' for control-dsl-0.2.1.3..
    [1 of 2] Compiling Main    
    [2 of 2] Compiling Paths_control_dsl
    Linking .stack-work/dist/x86_64-osx/Cabal-3.2.1.0/build/doctests/doctests ...
    control-dsl          > haddock
    Preprocessing library for control-dsl-0.2.1.3..
    Running Haddock on library for control-dsl-0.2.1.3..
    Haddock coverage:          
    50% (  1 /  2) in 'Control.Dsl.PolyCont'
    Missing documentation for:
        Module header          
    50% (  1 /  2) in 'Control.Dsl.Monadic'
    Missing documentation for:
        Module header          
    33% (  1 /  3) in 'Control.Dsl.Empty'
    Missing documentation for:
        Module header          
        Empty (src/Control/Dsl/Empty.hs:13)
    50% (  2 /  4) in 'Control.Dsl.Return'
    Missing documentation for:
        Module header          
        Return (src/Control/Dsl/Return.hs:16)
    42% (  3 /  7) in 'Control.Dsl.Cont'
    Missing documentation for:
        Module header          
        when (src/Control/Dsl/Cont.hs:59)
        unless (src/Control/Dsl/Cont.hs:63)
        guard (src/Control/Dsl/Cont.hs:66)
    100% (  2 /  2) in 'Control.Dsl.Shift'
    0% (  0 /  2) in 'Control.Dsl.State.Put'
    Missing documentation for:
        Module header          
        Put (src/Control/Dsl/State/Put.hs:12)
    0% (  0 /  2) in 'Control.Dsl.State.Get'
    Missing documentation for:
        Module header          
        Get (src/Control/Dsl/State/Get.hs:13)
    100% (  4 /  4) in 'Control.Dsl.State'
    Warning: 'Dsl' is out of scope.
        If you qualify the identifier, haddock can try to link it anyway.
    100% (  2 /  2) in 'Control.Dsl.Yield'
    42% (  6 / 14) in 'Control.Dsl'
    Missing documentation for:
        =<< (src/Control/Dsl/Dsl.hs:113)
        >=> (src/Control/Dsl/Dsl.hs:115)
        <=< (src/Control/Dsl/Dsl.hs:117)
        forever (src/Control/Dsl/Dsl.hs:130)
        ifThenElse (src/Control/Dsl/Dsl.hs:133)
        when (src/Control/Dsl/Cont.hs:59)
        unless (src/Control/Dsl/Cont.hs:63)
        guard (src/Control/Dsl/Cont.hs:66)
    Warning: Control.Dsl.Cont: could not find link destinations for:
        cpsApply               
    Warning: Control.Dsl: could not find link destinations for:
        cpsApply               
    Documentation created:     
    .stack-work/dist/x86_64-osx/Cabal-3.2.1.0/doc/html/control-dsl/index.html,
    .stack-work/dist/x86_64-osx/Cabal-3.2.1.0/doc/html/control-dsl/control-dsl.txt
    Preprocessing test suite 'doctests' for control-dsl-0.2.1.3..
    control-dsl          > copy/register
    Installing library in /Users/atry/github/stackage/tmp.PkrF/control-dsl-0.2.1.3/.stack-work/install/x86_64-osx/7a0c9209d30523fe960572b45b211c9fd9929d7fbd2f46cfe079ea50b5c5ae5f/8.10.3/lib/x86_64-osx-ghc-8.10.3/control-dsl-0.2.1.3-F1SYDm4U0olJc6ClHmKYTA
    Registering library for control-dsl-0.2.1.3..
    control-dsl          > test (suite: doctests)
                            
    Examples: 108  Tried: 108  Errors: 0  Failures: 0

    control-dsl          > Test suite doctests passed
    Completed 34 action(s).
    Updating Haddock index for local packages in
    /Users/atry/github/stackage/tmp.PkrF/control-dsl-0.2.1.3/.stack-work/install/x86_64-osx/7a0c9209d30523fe960572b45b211c9fd9929d7fbd2f46cfe079ea50b5c5ae5f/8.10.3/doc/index.html
    Updating Haddock index for local packages and dependencies in
    /Users/atry/github/stackage/tmp.PkrF/control-dsl-0.2.1.3/.stack-work/install/x86_64-osx/7a0c9209d30523fe960572b45b211c9fd9929d7fbd2f46cfe079ea50b5c5ae5f/8.10.3/doc/all/index.html
    Updating Haddock index for snapshot packages in
    /Users/atry/.stack/snapshots/x86_64-osx/7a0c9209d30523fe960572b45b211c9fd9929d7fbd2f46cfe079ea50b5c5ae5f/8.10.3/doc/index.html


    🎉 It looks good!

    ```

