### PR TITLE
Allow vector-0.12.2, skip lens tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5111,9 +5111,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/5849
       - cryptonite < 0.28
 
-      # https://github.com/commercialhaskell/stackage/issues/5851
-      - vector < 0.12.2
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of
@@ -5642,6 +5639,8 @@ skipped-tests:
     # via tasty-1.4 https://github.com/commercialhaskell/stackage/issues/5795
     - lukko
 
+    # via vector-0.12.2 https://github.com/commercialhaskell/stackage/issues/5851
+    - lens
 
 # end of skipped-tests
 


### PR DESCRIPTION
This implements the plan set out in https://github.com/commercialhaskell/stackage/issues/5851#issuecomment-770405905.

Fixes #5851.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
