### PR TITLE
Add back cabal-appimage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4420,7 +4420,7 @@ packages:
         - it-has
 
     "Gabriele Sales <gbrsales@gmail.com> @gbrsales":
-        - cabal-appimage < 0 # ghc 8.10
+        - cabal-appimage
 
     "Dominik Schrempf <dominik.schrempf@gmail.com> @dschrempf":
         - pava


### PR DESCRIPTION
Now builds with GHC 8.10.3.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command:

      ./verify-package cabal-appimage-0.3.0.1