### PR TITLE
Unhide newtype-generics

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6415,7 +6415,6 @@ hide:
 - nanospec # conflicts with Test.Hspec in hspec
 - HTF # conflicts with Test.Framework in test-framework
 - courier # conflicts with Network.Transport in network-transport
-- newtype-generics # conflicts with Control.Newtype in newtype
 - objective # conflicts with Control.Object in natural-transformation
 - binary-ieee754 # conflicts with data-binary-ieee754
 - rerebase # conflicts with base


### PR DESCRIPTION
The conflicting module was removed in v0.6.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
