### PR TITLE
Re-enable bound's tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5530,7 +5530,6 @@ skipped-tests:
     - cron # Could not deduce (SOP.All (SOP.All Arbitrary) xss) arising from a use of ‘SOP.hcpure’
     - config-ini # https://github.com/aisamanra/config-ini/issues/22
     - dhall # https://github.com/dhall-lang/dhall-haskell/issues/1985
-    - bound # https://github.com/commercialhaskell/stackage/pull/5854
 
     # Runtime issues
     - blank-canvas # Never finishes https://github.com/ku-fpg/blank-canvas/issues/73


### PR DESCRIPTION
These can be re-enabled with the resolution of ekmett/bound#81.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
