### PR TITLE
[ fix #5826 ] reenable Agda

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -25,7 +25,7 @@ packages:
     "Andreas Abel <andreas.abel@gu.se> @andreasabel":
         - BNFC
         - STMonadTrans
-        - Agda < 0  # https://github.com/commercialhaskell/stackage/issues/5826
+        - Agda
         - agda2lagda
         - ListLike
         - haskell-src


### PR DESCRIPTION
Agda-2.6.1.3 was just released and builds with nightly-2021-02-06.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version
