### PR TITLE
Remove upper bounds for tidal - fixes #5848

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5111,9 +5111,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/5846
       - dbus < 1.2.18
 
-      # https://github.com/commercialhaskell/stackage/issues/5848
-      - tidal < 1.7
-
       # https://github.com/commercialhaskell/stackage/issues/5849
       - cryptonite < 0.28
 


### PR DESCRIPTION
The new Tidal 1.7.1 release resolves the issue with stack.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
