### PR TITLE
Fix aeson-schemas test

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6034,8 +6034,6 @@ expected-benchmark-failures:
     - mmark-ext
     # https://github.com/mmark-md/mmark/issues/76
     - mmark
-    # https://github.com/LeapYear/aeson-schemas/issues/65
-    - aeson-schemas
     # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
     - hspec-expectations-pretty-diff
 


### PR DESCRIPTION
FYI @juhp this should probably have gone into `expected-test-failures`, not `expected-benchmark-failures`?