### PR TITLE
add nri-observability

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4481,8 +4481,9 @@ packages:
         - derive-topdown
 
     "NoRedInk <haskell-open-source@noredink.com>":
-        - nri-prelude
         - nri-env-parser
+        - nri-observability
+        - nri-prelude
 
     "Behrang Norouzinia <behrangn@gmail.com> @behrang":
         - jalaali


### PR DESCRIPTION
we recently released nri-observability, which consumes nri-prelude's `log` abstraction and reports to, logs, BugSnag. When we have it a little more mature, we'll also release a Honeycomb and perhaps NewRelic.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] ⏰At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
