### PR TITLE
Revert "add curly-expander"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -101,9 +101,6 @@ packages:
 
     "Tobias Reinhart <tobi.reinhart@fau.de> @TobiReinhart":
         - sparse-tensor
-     
-    "Přemysl Šťastný <p-w@stty.cz> @stastnypremysl":
-        - curly-expander
 
     "Stephan Schiffels <stephan_schiffels@mac.com> @stschiff":
         - sequence-formats


### PR DESCRIPTION
Reverts commercialhaskell/stackage#5887.

The Stackage curator is currently unable to parse Cabal files that are at specification version 3.0 or higher; we only support v2.4 and below at the moment.

That is, when trying to run the curator for this package we receive the following error:
```
curator: Unable to parse cabal file from package curly-expander-0.2.0.3@sha256:926f10c8421f0b7051fe4f1ee9bbf4ecceb42801e0fa7e8b66d705f229d65fd5,1468 (from Hackage)

- 0:0: Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899.
```