### PR TITLE
Revert "Preserves snapshot-incomplete with NOPLAN=1"

### DIFF
--- a/automated/build.sh
+++ b/automated/build.sh
@@ -108,7 +108,7 @@ then
         docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator update && curator constraints --target $TARGET && curator snapshot-incomplete --target $TARGET && curator snapshot"
     fi
 else
-    docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator snapshot"
+    docker run $ARGS_PREBUILD $IMAGE /bin/bash -c "curator snapshot-incomplete --target $TARGET && curator snapshot"
 fi
 
 


### PR DESCRIPTION
Reverts commercialhaskell/stackage#5815.

It looks as if this situation isn't nearly as straightforward as the e160b7aa3e763192c9b689e3c04c6ec223361de0 commit message made it seem.

I'm still not 100% sure what the path forwards is for allowing us to tweak version bounds more easily, but after trying this out for a few months I think we're probably better off with the old behavior.