### PR TITLE
Re-enable pbrisbin and Freckle packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1068,16 +1068,16 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2 < 0.6.2  # https://github.com/commercialhaskell/stackage/issues/5825
-        - yesod-markdown < 0 # pandoc
+        - yesod-auth-oauth2
+        - yesod-markdown
         - yesod-paginator
 
         # Freckle packages I'm maintaining for us
-        - bcp47 < 0 # aeson, megaparsec, text
-        - bcp47-orphans < 0 # esqueleto, text
-        - faktory < 0 # megaparsec
-        - graphula < 0 # aeson, base, bytestring, generics-eot, unliftio-core
-        - hspec-expectations-json < 0 # aeson, text
+        - bcp47
+        - bcp47-orphans
+        - faktory
+        - graphula < 0 # generics-eot
+        - hspec-expectations-json
         - yesod-page-cursor
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":


### PR DESCRIPTION
- The issue with yesod-auth-oauth2 is fixed.
- yesod-markdown, bcp47*, faktory, and hspec-expectations-json have all
  had releases with relaxed upper bounds

We're watching https://packdeps.haskellers.com/ more closely now, so
hopefully these will break less.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully [verified things]