### PR TITLE
Re-enable graphula

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1076,7 +1076,7 @@ packages:
         - bcp47
         - bcp47-orphans
         - faktory
-        - graphula < 0 # generics-eot
+        - graphula
         - hspec-expectations-json
         - yesod-page-cursor
 


### PR DESCRIPTION
This was waiting on generics-eot, recently re-enabled.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully _verified the package