### PR TITLE
Re-enable testing of mmark and mmark-ext

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7830,12 +7830,6 @@ expected-test-failures:
     # https://github.com/commercialhaskell/stackage/issues/5841
     - dbus
 
-    # https://github.com/mmark-md/mmark-ext/issues/20
-    - mmark-ext
-
-    # https://github.com/mmark-md/mmark/issues/76
-    - mmark
-
     # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
     - hspec-expectations-pretty-diff
 


### PR DESCRIPTION
I believe I have fixed the test suites. New versions of the packages have
been released.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

(Re the last point, I'm pretty sure it works, but I'm on NixOS where `ghc8104` is not available and I don't want to move the pin just yet.)