### PR TITLE
verify-package: Don't include subdirs

### DIFF
--- a/verify-package
+++ b/verify-package
@@ -34,7 +34,7 @@ cd "$dir"
 stack unpack "$package"
 cd "$(ls | head -n 1)"
 rm -f stack.yaml
-stack init --resolver nightly
+stack init --resolver nightly --ignore-subdirs
 stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
 
 


### PR DESCRIPTION
See https://github.com/commercialhaskell/stackage/issues/5929

If sub-packages that are not intended for inclusion in stackage are present in sub directories, verify-package will verify too many things.
