### PR TITLE
Re-enable hakyll

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -821,7 +821,7 @@ packages:
         - psqueues
         - websockets
         - websockets-snap
-        - hakyll < 0 # via pandoc-citeproc
+        - hakyll
 
     "Sibi Prabakaran <sibi@psibi.in> @psibi":
         - download


### PR DESCRIPTION
The incompatibility has been fixed in https://github.com/jaspervdj/hakyll/pull/826 which is released as part of hakyll-4.14.0.0.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
