### PR TITLE
unrestrict hsshellscript version from 3.5.0 again (#5817)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -501,7 +501,7 @@ packages:
         - cabal-plan
         - topograph
         - ix-shapable
-        - hsshellscript < 3.5.0 # https://github.com/commercialhaskell/stackage/issues/5817
+        - hsshellscript
         - hyper
         - storable-endian
 


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (replace `$package` with the name of the package that is submitted, and `$version` with the version of the package you want to get into Stackage):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version  # $version is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks