### PR TITLE
Add freckle engineering stanza and include a few packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1094,6 +1094,7 @@ packages:
         - yesod-page-cursor < 0 # https://github.com/commercialhaskell/stackage/issues/5948
         - nonempty-zipper
         - sendgrid-v3
+        - yesod-auth-oauth2
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
         - fb

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1085,7 +1085,7 @@ packages:
         - yesod-markdown
         - yesod-paginator
 
-    "Freckle Engineering <freckle-engineering@renaissance.com> github.com/freckle":
+    "Freckle Engineering <freckle-engineering@renaissance.com> @freckle":
         - bcp47
         - bcp47-orphans
         - faktory

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1085,17 +1085,15 @@ packages:
         - yesod-markdown
         - yesod-paginator
 
-        # Freckle packages I'm maintaining for us
+    "Freckle Engineering <freckle-engineering@renaissance.com> github.com/freckle":
         - bcp47
         - bcp47-orphans
         - faktory
         - graphula
         - hspec-expectations-json
         - yesod-page-cursor < 0 # https://github.com/commercialhaskell/stackage/issues/5948
-
-    "Michael Gilliland @mjgpy3":
-        # Freckle packages I'm maintaining for us
         - nonempty-zipper
+        - sendgrid-v3
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
         - fb

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1085,7 +1085,7 @@ packages:
         - yesod-markdown
         - yesod-paginator
 
-    "Freckle Engineering <freckle-engineering@renaissance.com> @freckle":
+    "Freckle Engineering <freckle-engineering@renaissance.com> @pbrisbin @halogenandtoast @mjgpy3":
         - bcp47
         - bcp47-orphans
         - faktory

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1095,6 +1095,7 @@ packages:
         - nonempty-zipper
         - sendgrid-v3
         - yesod-auth-oauth2
+        - hspec-junit-formatter
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
         - fb


### PR DESCRIPTION
This is probably a little unconventional in a few ways. This attempts to add
packages maintained by the freckle engineering team to its own stanza.

It also takes "stackage ownership" of `sendgrid-v3`, originally requested here
  https://github.com/marcelbuesing/sendgrid-v3/issues/13

Ping @pbrisbin since I moved your Freckle packages and @marcelbuesing since
`sendgrid-v3` is your package.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

**Note:** `verify-package` failed locally due to `sendgrid-v3` tests needing environment variables to actually call out to sendgrid. Running the same `stack build` without `--test` passed.

I also added `yesod-auth-oauth2` per discussion with @pbrisbin. This package passes in `verify-package`

Added `hspec-junit-formatter` as well. Which passes `verify-package` and I just added to hackage 35min ago.