### PR TITLE
Add place-cursor-at

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3877,6 +3877,7 @@ packages:
         - stripe-wreq < 0 # via wreq
 
     "Viacheslav Lotsmanov <lotsmanov89@gmail.com> @unclechu":
+        - place-cursor-at
         - qm-interpolated-string
 
     "Douglas Burke <dburke.gw@gmail.com> @DougBurke":


### PR DESCRIPTION
This package is maintained by me, Viacheslav Lotsmanov.

~~The `verify-package` fails on building `X11` package even though I provided the necessary libraries. Probably Nix setup has to be tuned to make it work. *See the details below in the comments.*~~ (It’s solved now)

It builds successfully on Hackage Matrix Builder:  
https://matrix.hackage.haskell.org/#/package/place-cursor-at

I’ve also built it locally with Stack:  
https://github.com/unclechu/place-cursor-at/blob/7d9242df472bb7ee1d4a1dc414e9d325799e10a0/stack.yaml

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
