### PR TITLE
Disable tests for int-cast since bounds on QuickCheck are outdated

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4317,7 +4317,7 @@ packages:
         # - msgpack-rpc # https://github.com/commercialhaskell/stackage/pull/4471
         # - msgpack-idl # https://github.com/commercialhaskell/stackage/pull/4471
         - msgpack-aeson < 0 # via msgpack
-        - int-cast < 0 # ghc 8.10
+        - int-cast
 
     "Akihito Kirisaki <kirisaki@klaraworks.net> @kirisaki":
         - caster < 0 # via fast-builder
@@ -7137,6 +7137,7 @@ skipped-tests:
     - hashable # via test-framework
     - haskey-btree # via test-framework
     - hmatrix-morpheus # via test-framework
+    - int-cast # via QuickCheck constraint
     - irc # via test-framework
     - language-c-quote # via test-framework
     - largeword # via test-framework


### PR DESCRIPTION
`int-cast` has outdated bounds. I am not having my hopes up that @hvr would fix 'em anytime soon, so I'll ping @2mol since he is listed as the owner.

Disabling the test suite makes it buildable with ghc-8.10, I am not so hopeful about ghc-9.0

Feel free to close this PR if you think it's not worth it, I was just trying to help out @Mikolaj with LambdaHack/LmbdaHack#244

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
