### PR TITLE
Add HaskellNet package.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1655,7 +1655,7 @@ packages:
         - snowflake
 
     "Leza M. Lutonda <lemol-c@hotmail.com> @lemol":
-        - HaskellNet < 0 # mime-mail-0.5
+        # - HaskellNet < 0 # mime-mail-0.5
         - HaskellNet-SSL < 0 # mime-mail-0.5 via HaskellNet
 
     "Jens Petersen <juhpetersen@gmail.com> @juhp":


### PR DESCRIPTION
HaskellNet is maintained by @qnikst and is buildable in the stackage nighly so removing constraint that blocks it.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
