### PR TITLE
Unblock persistent

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -684,7 +684,7 @@ packages:
         - mime-mail-ses
         - mime-types
         - network-conduit-tls
-        - persistent < 2.12.0.0 || > 2.12.0.0
+        - persistent 
         - persistent-mysql
         - persistent-postgresql
         - persistent-sqlite


### PR DESCRIPTION
In #5968 it should be the case that all dependencies on `persistent` have allowed 2.12.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
