### PR TITLE
Enable DBFunctor package after removing indirect dependency with random < 1.2 via MissingH

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4245,7 +4245,7 @@ packages:
         - ghci-hexcalc
 
     "Nikos Karagianndis <nkarag@gmail.com> @nkarag":
-        - DBFunctor < 0 # random 1.2
+        - DBFunctor
 
     "Marat Khafizov <xafizoff@gmail.com> @xafizoff":
         - n2o


### PR DESCRIPTION
Checklist:
- [X ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ X] At least 30 minutes have passed since uploading to Hackage
- [ X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
