### PR TITLE
Add through-text to GHC 9 nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5273,7 +5273,6 @@ packages:
         - termbox < 0 # -0.3.0 (^>=4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14). Mitchell Rosen <mitchellwrosen@gmail.com> @mitchellwrosen. @mitchellwrosen. Used by: library
         - text-format < 0 # -0.3.2 (>=4.3 && < 4.15). Dan Burton <danburton.email@gmail.com> @DanBurton. @bos @hackage-trustees. Used by: library
         - these-skinny < 0 # -0.7.4 (>=4.10 && < 4.15). Daniel Cartwright <chessai1996@gmail.com> @chessai. @chessai. Used by: library
-        - through-text < 0 # -0.1.0.0 (>=4.3 && < 4.15). Adam Bergmark <adam@bergmark.nl> @bergmark. @bergmark. Used by: library
         - tonalude < 0 # -0.1.1.1 (>=4.7 && < 4.15). Kadzuya Okamoto <arow.okamoto@gmail.com> @arowM. @tonatona-project. Used by: library
         - type-errors-pretty < 0 # -0.0.1.1 (>=4.10.1.0 && < 4.15). Grandfathered dependencies. @chshersh. Used by: library
         - typerep-map < 0 # -0.3.3.0 (>=4.10 && < 4.15). Grandfathered dependencies. @kowainik. Used by: library


### PR DESCRIPTION
Example PR to get a package into the initial GHC 9 nightly

Using the ghc-9 branch as base:
<img width="844" alt="Screenshot 2021-05-29 at 18 26 06" src="https://user-images.githubusercontent.com/100681/120077578-569cf680-c0ab-11eb-9f47-ca54a3b4aa05.png">
