### PR TITLE
Add wordpress-auth & servant-auth-wordpress

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4267,8 +4267,8 @@ packages:
 
     "Pavan Rikhi <pavan.rikhi@gmail.com> @prikhi":
         - hs-php-session
-        - wordpress-auth < 0 # via http-types
-        - servant-auth-wordpress < 0 # via servant-server
+        - wordpress-auth
+        - servant-auth-wordpress
         - ca-province-codes
         - mx-state-codes
         - sitemap-gen


### PR DESCRIPTION
Add these back as I've made the latest versions compile successfully
with the nightly LTS. 

Never received a ping that these were being removed...

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
