### PR TITLE
Re-enable prometheus-metrics-ghc & wai-middleware-prometheus

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2101,10 +2101,10 @@ packages:
 
     "Will Coster <willcoster@gmail.com> @fimad":
         - prometheus-client
-        - prometheus-metrics-ghc < 0 # Build failure: https://github.com/fimad/prometheus-haskell/issues/39
+        - prometheus-metrics-ghc
         - scalpel
         - scalpel-core
-        - wai-middleware-prometheus < 0 # GHC 8.4 via prometheus-client
+        - wai-middleware-prometheus
 
     "William Casarin <bill@casarin.me> @jb55":
         - bson-lens < 0 # via bson


### PR DESCRIPTION
These two libraries were disabled referencing fimad/prometheus-haskell#39 which was fixed in 2018. It looks like they were never re-enabled in stackage.

I also just ran tests for both of these packages using lts-17.14 and nightly-2021-06-01, both compile and tests pass with no issues.

Fixes fimad/prometheus-haskell#61

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

```
      ./verify-package prometheus-metrics-ghc
      ./verify-package wai-middleware-prometheus
```

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
