### PR TITLE
expected failures: remove FitSpec and Speculate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5992,7 +5992,6 @@ expected-test-failures:
     - async-timer # https://github.com/mtesseract/async-timer/issues/8
     - commutative # https://github.com/athanclark/commutative/issues/4
     - conduit-throttle # https://github.com/mtesseract/conduit-throttle/issues/12
-    - fitspec # https://github.com/commercialhaskell/stackage/issues/6026
     - haddock
     - haskell-tools-builtin-refactorings
     - hweblib # https://github.com/aycanirican/hweblib/issues/3
@@ -6153,8 +6152,6 @@ expected-test-failures:
     - servant-elm
 
     - sbv
-
-    - speculate
 
 # end of expected-test-failures
 


### PR DESCRIPTION
Tests of FitSpec (v0.4.10) and Speculate (v0.4.8) no longer fail to build.
They have been updated to be compatible with LeanCheck v0.9.6.

This PR removes both packages from the `expected-test-failures` list in `build-constraints.yaml`.

Fixes stackage issue #6026 -- https://github.com/commercialhaskell/stackage/issues/6026