### PR TITLE
ghc-9: Re-enable cdar-mBound and aern2-mp

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5212,7 +5212,6 @@ packages:
         - butcher < 0 # -1.3.3.2 (>=4.11 && < 4.15). Lennart Spitzner <hexagoxel@hexagoxel.de> @lspitzner. @lspitzner. Used by: library
         - bzlib < 0 # -0.5.1.0 (>=4.3 && < 4.15). Grandfathered dependencies. @hackage-trustees. Used by: library
         - cabal-plan < 0 # -0.7.2.0 ((>=4.6 && < 4.10) || ^>=4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14). Henning Thielemann <stackage@henning-thielemann.de> @thielema. @hvr. Used by: library
-        - cdar-mBound < 0 # -0.1.0.2 (>=4.7 && < 4.15). Michal Konecny <mikkonecny@gmail.com> @michalkonecny. @michalkonecny. Used by: library
         - circular < 0 # -0.3.1.1 (>=4.14.1.0 && < 4.15). Dominik Schrempf <dominik.schrempf@gmail.com> @dschrempf. @dschrempf. Used by: library
         - co-log-core < 0 # -0.2.1.1 (>=4.10.1.0 && < 4.15). Grandfathered dependencies. @kowainik. Used by: library
         - configurator-pg < 0 # -0.2.5 (>=4.9 && < 4.15). Robert Vollmert <rob@vllmrt.net> @robx. @robx. Used by: library
@@ -5434,8 +5433,6 @@ packages:
         - salak < 0 # -0.3.6 (>=0.8.0 && < 0.9). Daniel YU <leptonyu@gmail.com>. @leptonyu. Used by: library
         # ghc-prof (GHC 9, Grandfathered dependencies) (not present) depended on by:
         - profiterole < 0 # -0.1 (-any). Neil Mitchell <ndmitchell@gmail.com> @ndmitchell. @ndmitchell. Used by: executable
-        # cdar-mBound (GHC 9, Michal Konecny <mikkonecny@gmail.com> @michalkonecny) (not present) depended on by:
-        - aern2-mp < 0 # -0.2.6.0 (>=0.1.0.0). Michal Konecny <mikkonecny@gmail.com> @michalkonecny. @michalkonecny. Used by: library
         # network-bsd (GHC 9, Grandfathered dependencies) (not present) depended on by:
         - bson < 0 # -0.4.0.1 (>=2.7 && < 2.9). Victor Denisov <denisovenator@gmail.com> @VictorDenisov. @mongodb-haskell. Used by: library
         - happstack-server < 0 # -7.7.1 (>=2.8.1 && < 2.9). Jeremy Shaw <jeremy@n-heptane.com> @stepcut. @stepcut. Used by: library


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage

Relaxed upper bound on base in cdar-mBound.  This should unblock also aern2-mp.