### PR TITLE
Add swish to ghc-9 nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5665,7 +5665,6 @@ packages:
         - swagger2 < 0 # tried swagger2-2.6, but its *library* does not support: template-haskell-2.17.0.0
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires the disabled package: egison-pattern-src
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires the disabled package: egison-pattern-src-th-mode
-        - swish < 0 # tried swish-0.10.0.4, but its *library* does not support: base-4.15.0.0
         - sydtest < 0 # tried sydtest-0.2.0.0, but its *library* requires the disabled package: path
         - sydtest-discover < 0 # tried sydtest-discover-0.0.0.0, but its *library* requires the disabled package: path
         - sydtest-persistent-sqlite < 0 # tried sydtest-persistent-sqlite-0.1.0.0, but its *library* requires the disabled package: sydtest


### PR DESCRIPTION
I haven't checked the constraint list to note if any of the needed packages are currently disabled, but I was able to build and test swish 0.10.0.5 against ghc 9 locally.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
