### PR TITLE
Re-enable `identicon` and tests for `forma`, `mmark`, `mmark-ext`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6025,7 +6025,6 @@ expected-test-failures:
     - distributed-process-task
     - fft # test-fft:  exited with: ExitFailure (-11)
     - foldl-statistics # https://github.com/data61/foldl-statistics/issues/2
-    - forma
     - fsnotify # Often runs out of inotify handles
     - hastache
     - idris # https://github.com/fpco/stackage/issues/1382
@@ -6341,11 +6340,6 @@ expected-test-failures:
     # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
     - hspec-expectations-pretty-diff
 
-    # https://github.com/commercialhaskell/stackage/issues/5878
-    # ordering because of hashable
-    - mmark
-    - mmark-ext
-
     # https://github.com/kcsongor/generic-lens/issues/133
     - generic-optics
 
@@ -6520,8 +6514,6 @@ skipped-benchmarks:
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
     - hgeometry # tried hgeometry-0.12.0.4, but its *benchmarks* requires the disabled package: deepseq-generics
     - hw-eliasfano # tried hw-eliasfano-0.1.2.0, but its *benchmarks* requires the disabled package: hw-hspec-hedgehog
-    - identicon # tried identicon-0.2.2, but its *benchmarks* does not support: criterion-1.5.9.0
-    - identicon # tried identicon-0.2.2, but its *benchmarks* does not support: random-1.2.0
     - lsp-test # tried lsp-test-0.14.0.0, but its *benchmarks* does not support: base-4.15.0.0
     - lsp-test # tried lsp-test-0.14.0.0, but its *benchmarks* requires the disabled package: lsp
     - o-clock # tried o-clock-1.2.1, but its *benchmarks* requires the disabled package: tiempo


### PR DESCRIPTION
Even though this removes `mmark` and `mmark-ext` from the list of packages
with failing test suites, `mmark` and its dependent packages are still
blocked on `email-validate`:

https://github.com/Porges/email-validate-hs/issues/58

However, when `mmark` is re-enabled its test suite should pass.
