### PR TITLE
Re-activate `geniplate-mirror`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5271,7 +5271,6 @@ packages:
         - fourmolu < 0 # tried fourmolu-0.3.0.0, but its *library* does not support: ghc-lib-parser-9.0.1.20210324
         - freer-simple < 0 # tried freer-simple-1.2.1.1, but its *library* does not support: template-haskell-2.17.0.0
         - generic-monoid < 0 # tried generic-monoid-0.1.0.1, but its *library* does not support: base-4.15.0.0
-        - geniplate-mirror < 0 # tried geniplate-mirror-0.7.7, but its *library* does not support: template-haskell-2.17.0.0
         - genvalidity-path < 0 # tried genvalidity-path-0.3.0.4, but its *library* requires the disabled package: path
         - genvalidity-sydtest < 0 # tried genvalidity-sydtest-0.0.0.0, but its *library* requires the disabled package: sydtest
         - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-0.0.0.0, but its *library* requires the disabled package: sydtest


### PR DESCRIPTION
`geniplate-mirror` 0.7.8 has been updated for GHC 9.0.1, see https://hackage.haskell.org/package/geniplate-mirror-0.7.8 and CI results https://github.com/danr/geniplate/runs/2855322960?check_suite_focus=true.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
