### PR TITLE
adding language-dot (requires maintainer approval)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1283,6 +1283,7 @@ packages:
     "Ben Gamari <ben@smart-cactus.org> @bgamari":
         - vector-fftw < 0 # GHC 8.4 via base-4.11.0.0
         - cborg-json
+        - language-dot
 
     "Roman Cheplyaka <roma@ro-che.info> @feuerbach":
         - action-permutations


### PR DESCRIPTION
@bgamari Since your language-dot repo has issue-tracking disabled, this is the easiest way I see to request that you add language-dot to Stackage.

I've been using it in Cubix for a while, and now wish to use it in another project. A very cursory glance suggests that language-dot is superior to dot.

This awaits only your approval.

(This is a follow-up to https://github.com/commercialhaskell/stackage/pull/6070 , since recreating the PR was easier than altering the old one to accommodate changes to Stackage.)

---------------------------------

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
