### PR TITLE
Re-enable hedgehog-classes

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2318,7 +2318,7 @@ packages:
         - chronos
         - refined
         - these-skinny
-        - hedgehog-classes < 0 # #5816/closed
+        - hedgehog-classes
 
     "Kostiantyn Rybnikov <k-bx@k-bx.com> @k-bx":
         - SHA


### PR DESCRIPTION
Originally disabled per #5816; the bound has been bumped in hedgehog-classes-0.2.5.2 and it now properly builds.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version
