### PR TITLE
Reenable xlsx as GHC9 support added in xlsx-0.8.4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5203,7 +5203,6 @@ packages:
         - webdriver < 0
         - webex-teams-pipes < 0
         - word24 < 0
-        - xlsx < 0
         - xml-lens < 0
         - xmonad < 0
         - yesod-core < 0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package xlsx-0.8.4