### PR TITLE
Add fakedata-quickcheck and enable tests for fakedata

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -862,6 +862,7 @@ packages:
         - persistent-redis
         - fakedata
         - fakedata-parser
+        - fakedata-quickcheck
         - streamly-bytestring
 
     "haskell-openal":
@@ -7567,7 +7568,6 @@ expected-test-failures:
     - character-cases # https://github.com/aiya000/hs-character-cases/issues/3
     - lz4-frame-conduit # https://github.com/nh2/lz4-frame-conduit/issues/3
     - dhall-yaml # https://github.com/commercialhaskell/stackage/issues/5640
-    - fakedata # random 1.2
 
     # Assertion failures due to module name ambiguity
     # (These _should_ be fixed by using the `hide` section of this file)


### PR DESCRIPTION
A new version of fakedata has been released which fixes the tests.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
