### PR TITLE
Add linear-base

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4571,6 +4571,9 @@ packages:
     "David A Roberts <d@vidr.cc> @davidar":
         - streamt
 
+    "Arnaud Spiwack <arnaud.spiwack@tweag.io> @aspiwack":
+        - linear-base
+
     "Grandfathered dependencies":
         - Boolean
         - Decimal


### PR DESCRIPTION
We were waiting for a GHC 9 nightly to submit `linear-base` to Stackage, so here it is :).

@aspiwack is the Hackage maintainer and aware of also becoming the Stackage maintainer.

This _should_ also unblock `one-liner`, however I do not know whether I should unblock it on this PR. Let me know if I need to do anything about it.

```
        - one-liner < 0 # tried one-liner-2.0, but its *library* requires the disabled package: linear-base
```