### PR TITLE
Remove `retry` From GHC 9 Compilation Failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5226,7 +5226,6 @@ packages:
         - rawfilepath < 0
         - record-wrangler < 0
         - regex-compat-tdfa < 0
-        - retry < 0
         - rhine < 0
         - rose-trees < 0 # compilation seems to hang?
         - safe-money < 0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
