### PR TITLE
Add lzma-clib

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4839,6 +4839,7 @@ packages:
         - lukko
         - lz4
         - lzma
+        - lzma-clib
         - managed
         - math-functions
         - membrain


### PR DESCRIPTION
In contrast to other packages, which bundle C sources into the main package, `lzma`, which is already present in Stackage snapshots, needs a companion package `lzma-clib` to be built on Windows. This package is buildable only on Windows, so it was added to `skipped-builds` (but not to `packages` section!) in #3877:

https://github.com/commercialhaskell/stackage/blob/ae49439fbb8f20bd6c821fb6e7dc834e80a7018c/build-constraints.yaml#L6828-L6831

I put `lzma-clib` into grandfathered dependencies, but happy to move it under my own section, if it's more acceptable. 

Could this patch please be backported to LTS 18 series? Otherwise the existing `lzma` package from LTS 18.1 remains broken and unbuildable under Windows.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
