### PR TITLE
add nri-kafka and nri-postgreseql to nightlies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4543,8 +4543,10 @@ packages:
     "NoRedInk <haskell-open-source@noredink.com>":
         - nri-env-parser
         - nri-http
+        - nri-kafka
         - nri-observability
         - nri-prelude
+        - nri-postgresql
         - nri-redis
         - nri-test-encoding
 


### PR DESCRIPTION
nri-kafka is a suite of tools, built on top of hw-kafka-client, to help publish messages to kafka, and consume and process messages in kafka.
nri-postgreql is a handler library, built on top of postgresql-typed, to help use postgresql with nri-prelude.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
