### PR TITLE
Remove upper bound on generic-random

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6683,9 +6683,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/6086
       - tasty-bench < 0.3
 
-      # https://github.com/commercialhaskell/stackage/issues/6107
-      - generic-random < 1.5.0.0
-
       # https://github.com/commercialhaskell/stackage/issues/6116
       - megaparsec < 9.1
       - megaparsec-tests < 9.1


### PR DESCRIPTION
Closes #6107. (dhall was revised to allow the newer version of generic-random)

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
