### PR TITLE
Update people responsible/notified for X11, xmonad, xmonad-contrib

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1725,7 +1725,6 @@ packages:
         - darcs
         - idris
         - libffi
-        - xmonad-contrib
         - cairo
         - glib
         - gio
@@ -2697,8 +2696,6 @@ packages:
         - streamproc
         - stringsearch # for cgi
         - titlecase
-        - X11
-        - xmonad
 
     "Mark Fine <mark.fine@gmail.com> @markfine":
         - postgresql-schema
@@ -4649,6 +4646,11 @@ packages:
 
     "Grzegorz Milka <grzegorzmilka@gmail.com> @gregorias":
         - trimdent
+
+    "xmonad <xmonad@haskell.org>":
+        - X11
+        - xmonad
+        - xmonad-contrib
 
     "Grandfathered dependencies":
         - snappy
@@ -7805,6 +7807,13 @@ github-users:
         - bazel-runfiles
     network-multicast:
         - audreyt
+    xmonad:
+        - byorgey
+        - dmwit
+        - geekosaur
+        - liskin
+        - psibi
+        - slotThe
 
 # end of github-users
 


### PR DESCRIPTION
Updated to match https://github.com/xmonad/xmonad/blob/master/MAINTAINERS.md

---

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- n/a (not adding new package) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks