### PR TITLE
Remove upper bounds on `massiv` rev dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6702,13 +6702,6 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/6122
       - mmorph < 1.2
 
-      # https://github.com/commercialhaskell/stackage/issues/6144
-      - scheduler < 2.0.0 # https://github.com/commercialhaskell/stackage/issues/6144
-      - massiv < 1.0.0.0
-      - massiv-io < 1.0.0.0
-      - massiv-persist < 1.0.0.0
-      - massiv-serialise < 1.0.0.0
-      - massiv-test < 1.0.0.0
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
massiv and its reverse dependencies have been fixed to support scheduler-2.0

Fixes #6144 CC @cdornan 

Once `aura` has had its bounds updated this PR can be merged, I think.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
