### PR TITLE
add comfort-array-shape remove upper bound on comfort-array, lapack

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -445,6 +445,7 @@ packages:
         - combinatorial
         - comfort-graph
         - comfort-array
+        - comfort-array-shape
         - concurrent-split
         - cutter
         - data-accessor
@@ -6701,10 +6702,6 @@ packages:
 
       # https://github.com/commercialhaskell/stackage/issues/6122
       - mmorph < 1.2
-
-      # https://github.com/commercialhaskell/stackage/issues/6153
-      - comfort-array < 0.5
-      - lapack < 0.4
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks