### PR TITLE
Re-enable Ormolu

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6243,7 +6243,6 @@ packages:
         - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - operational-class < 0 # tried operational-class-0.3.0.0, but its *library* requires the disabled package: operational
         - opml-conduit < 0 # tried opml-conduit-0.9.0.0, but its *library* requires the disabled package: refined
-        - ormolu < 0 # tried ormolu-0.1.4.1, but its *library* does not support: ghc-lib-parser-9.0.1.20210324
         - oset < 0 # tried oset-0.4.0.1, but its *library* does not support: base-4.15.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* does not support: Cabal-3.4.0.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* does not support: groups-0.5.3
@@ -7096,7 +7095,6 @@ skipped-tests:
     - numhask-prelude # tried numhask-prelude-0.5.0, but its *test-suite* does not support: doctest-0.18.1
     - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell
     - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell-quickcheck
-    - ormolu # tried ormolu-0.1.4.1, but its *test-suite* does not support: path-0.9.0
     - oset # tried oset-0.4.0.1, but its *test-suite* does not support: hspec-2.8.2
     - oset # tried oset-0.4.0.1, but its *test-suite* does not support: hspec-discover-2.8.2
     - partial-semigroup # tried partial-semigroup-0.5.1.12, but its *test-suite* does not support: doctest-0.18.1


### PR DESCRIPTION
Ormolu 0.2.0.0 is fully compatible with the current nightly snapshots.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
