### PR TITLE
Re-enable req-conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5279,7 +5279,6 @@ packages:
         - raaz < 0
         - rawfilepath < 0
         - regex-compat-tdfa < 0
-        - req-conduit < 0 # https://github.com/mrkkrp/req-conduit/issues/12
         - rhine < 0
         - rose-trees < 0 # compilation seems to hang?
         - safe-money < 0


### PR DESCRIPTION
I have published the version 1.0.1 which is compatible with the current
nightly snapshots.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
