### PR TITLE
addressed wai-middleware-auth compilation issues

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5327,7 +5327,6 @@ packages:
         - uncertain < 0
         - unordered-intmap < 0
         - users-persistent < 0
-        - wai-middleware-auth < 0
         - wai-predicates < 0
         - webdriver < 0
         - webex-teams-pipes < 0


### PR DESCRIPTION
Will turn this into a non-draft PR in ~ 30 minutes!
---

The latest hackage release 0.2.5.1 is compatible with GHC 9:
https://github.com/fpco/wai-middleware-auth/pull/27

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
