### PR TITLE
Add hex-text

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3914,6 +3914,7 @@ packages:
         - aws-cloudfront-signed-cookies
         - data-ascii
         - d10
+        - hex-text
         - stripe-concepts
         - stripe-signature
         - stripe-scotty


### PR DESCRIPTION
It was previously done in https://github.com/commercialhaskell/stackage/pull/5719. And then reverted in https://github.com/commercialhaskell/stackage/pull/5732 due to incompatibility with the latest `base16-bytestring`. Now this incompatibility is resolved.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
