### PR TITLE
Re-enable Hakyll

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -873,6 +873,8 @@ packages:
         - psqueues
         - websockets
         - websockets-snap
+
+    "Jasper Van der Jeugt @jaspervdj & Alexander Batischev <eual.jp@gmail.com> @Minoru":
         - hakyll
 
     "Sibi Prabakaran <sibi@psibi.in> @psibi":
@@ -5905,12 +5907,6 @@ packages:
         - hadolint < 0 # tried hadolint-2.7.0, but its *library* does not support: deepseq-1.4.5.0
         - hadolint < 0 # tried hadolint-2.7.0, but its *library* requires the disabled package: colourista
         - hadolint < 0 # tried hadolint-2.7.0, but its *library* requires the disabled package: spdx
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: cryptonite-0.29
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: file-embed-0.0.15.0
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: memory-0.16.0
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: optparse-applicative-0.16.1.0
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: pandoc-2.14.2
-        - hakyll < 0 # tried hakyll-4.14.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - hamilton < 0 # tried hamilton-0.1.0.3, but its *library* requires the disabled package: typelits-witnesses
         - hapistrano < 0 # tried hapistrano-0.4.2.0, but its *library* does not support: path-0.9.0
         - happstack-hsp < 0 # tried happstack-hsp-7.3.7.5, but its *library* requires the disabled package: harp


### PR DESCRIPTION
Also add myself to the list of users to ping about Hakyll.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Some dependencies are not allowed still:
* binary-0.10.0.0, network-uri-2.7.0.0 — these are yanked from Hackage
* time-1.12 — only exists on Hackage, isn't shipped with any GHC (not even HEAD), so I can't test with it
* bytestring 0.11.1.0 ­— not all of my transitive dependencies support it, so I can't allow it either (I'm working on that)