### PR TITLE
Remove `freckle-app` from `skipped-tests`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6931,9 +6931,6 @@ skipped-tests:
     # Uses Cabal's "library internal" stanza feature
     - s3-signer
 
-    # Missing package.yaml
-    - freckle-app # https://github.com/commercialhaskell/stackage/pull/6173#issuecomment-903228985
-
     # Due to cycles, which are actually just limitations in Stack right now.
     - HUnit
     - attoparsec


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
