### PR TITLE
Fix sandwich-quickcheck and sandwich-slack on GHC 9

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6428,8 +6428,6 @@ packages:
         - rvar < 0 # tried rvar-0.2.0.6, but its *library* requires the disabled package: random-source
         - safe-tensor < 0 # tried safe-tensor-0.2.1.1, but its *library* does not support: singletons-3.0
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* does not support: tomland-1.3.3.0
-        - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.5, but its *library* does not support: base-4.15.0.0
-        - sandwich-slack < 0 # tried sandwich-slack-0.1.0.4, but its *library* does not support: base-4.15.0.0
         - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.0.6, but its *library* requires the disabled package: webdriver
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* does not support: containers-0.6.4.1
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* does not support: aeson-1.5.6.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [N/A] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

The latest versions on Hackage should work on GHC 9, hopefully removing these lines is the only change needed.