### PR TITLE
init covariance and glasso

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4556,18 +4556,20 @@ packages:
         - cabal-appimage
 
     "Dominik Schrempf <dominik.schrempf@gmail.com> @dschrempf":
-        - pava
-        - elynx-nexus
+        - circular
+        - covariance
+        - dirichlet
+        - elynx
         - elynx-markov
+        - elynx-nexus
         - elynx-seq
         - elynx-tools
         - elynx-tree
+        - glasso
+        - mcmc
+        - pava
         - slynx
         - tlynx
-        - elynx
-        - mcmc
-        - dirichlet
-        - circular
 
     "Eric Rochester <erochest@gmail.com> @erochest":
         - text-regex-replace
@@ -6718,9 +6720,6 @@ packages:
 
       # https://github.com/commercialhaskell/stackage/issues/6195
       - miso < 1.8
-
-      # https://github.com/commercialhaskell/stackage/issues/6196
-      - mcmc < 0.6.1
 
 # end of packages
 


### PR DESCRIPTION
- 'glasso' is method to estimate sparse covariance/precision matrices from
  sample data. I am not the author of 'glasso', but in agreement with the author
  I add this package. The author may take ownership at a later time.
  See https://github.com/kaizhang/glasso/issues/1.

- 'covariance' provides shrinkage based estimators for the same problem and also
   a wrapper around 'glasso'.

This solves issue https://github.com/commercialhaskell/stackage/issues/6196.

I also sorted the packages I maintain.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
