### PR TITLE
Replace language-fortran with fortran-src

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3409,7 +3409,7 @@ packages:
     "Dominic Orchard <dom.orchard@gmail.com> @dorchard":
         - array-memoize
         - codo-notation < 0 # MonadFail
-        - language-fortran
+        - fortran-src
 
     "Cheng Shao <astrohavoc@gmail.com> @TerrorJack":
         - binaryen


### PR DESCRIPTION
language-fortran was deprecated by fortran-src some years ago.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
