### PR TITLE
Re-enable invertible-grammar and sexp-grammar

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6084,7 +6084,6 @@ packages:
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - invertible < 0 # tried invertible-0.2.0.7, but its *library* requires the disabled package: partial-isomorphisms
-        - invertible-grammar < 0 # tried invertible-grammar-0.1.3, but its *library* does not support: template-haskell-2.17.0.0
         - io-streams-haproxy < 0 # tried io-streams-haproxy-1.0.1.0, but its *library* does not support: base-4.15.0.0
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* does not support: network-3.1.2.2
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* does not support: path-0.9.0
@@ -6510,7 +6509,6 @@ packages:
         - serversession-backend-redis < 0 # tried serversession-backend-redis-1.0.4, but its *library* does not support: hedis-0.14.4
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* does not support: exceptions-0.10.4
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
-        - sexp-grammar < 0 # tried sexp-grammar-2.3.1, but its *library* requires the disabled package: invertible-grammar
         - sexpr-parser < 0 # tried sexpr-parser-0.2.0.0, but its *library* does not support: base-4.15.0.0
         - sexpr-parser < 0 # tried sexpr-parser-0.2.0.0, but its *library* does not support: megaparsec-9.0.1
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
