### PR TITLE
re-enable quickbench after 1.0.1 release

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6363,7 +6363,6 @@ packages:
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* does not support: optparse-applicative-0.16.1.0
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* does not support: ansi-terminal-0.11
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
-        - quickbench < 0 # tried quickbench-1.0, but its *library* requires the disabled package: docopt
         - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* does not support: template-haskell-2.17.0.0
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.5, but its *library* requires the disabled package: unfoldable-restricted
         - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.1, but its *library* requires the disabled package: markov-chain-usage-model


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
