### PR TITLE
Enable zenacy-html for GHC 9

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5399,7 +5399,6 @@ packages:
         - xmonad < 0
         - yeshql-hdbc < 0
         - yesod-auth < 0 # 1.6.10.3
-        - zenacy-html < 0
 
     "GHC 9 bounds issues":
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* does not support: network-3.1.2.2


### PR DESCRIPTION
Re-enable zenacy-html

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
