### PR TITLE
Please re-enable stackcollapse-ghc in nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6555,7 +6555,6 @@ packages:
         - sqlite-simple < 0 # tried sqlite-simple-0.4.18.0, but its *library* requires the disabled package: blaze-textual
         - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* does not support: text-1.2.4.1
         - stack < 0 # tried stack-2.7.3, but its *library* requires the disabled package: mustache
-        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* does not support: base-4.15.0.0
         - store-streaming < 0 # tried store-streaming-0.2.0.3, but its *library* requires the disabled package: store
         - streamproc < 0 # tried streamproc-1.6.2, but its *library* does not support: base-4.15.0.0
         - strict-base-types < 0 # tried strict-base-types-0.7, but its *library* requires the disabled package: strict-lens


### PR DESCRIPTION
GHC 9.0.1 is now supported, starting from revision 1 of 0.0.1.4 on Hackage

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
