### PR TITLE
Re-enable compilation of sexp-grammar (including its benchmark)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7284,7 +7284,6 @@ expected-test-failures:
     - require # compilation failure https://github.com/commercialhaskell/stackage/issues/6093
     - secp256k1-haskell # #5948/closed
     - servant-static-th # Tasty issue: https://github.com/commercialhaskell/stackage/issues/6090
-    - sexp-grammar # https://github.com/esmolanka/sexp-grammar/issues/21
     - snap-core # random 1.2
     - string-random # https://github.com/hiratara/hs-string-random/issues/16
     - text-icu # https://github.com/bos/text-icu/issues/32
@@ -7519,7 +7518,6 @@ expected-benchmark-failures:
     - incremental-parser # 0.5.0.2
     - lz4 # https://github.com/fpco/stackage/issues/3510
     - raaz # https://github.com/commercialhaskell/stackage/issues/4766
-    - sexp-grammar # https://github.com/esmolanka/sexp-grammar/issues/21
     - thyme
     - universum
     - xmlgen # https://github.com/skogsbaer/xmlgen/issues/6


### PR DESCRIPTION
Re-enabling as discussed in https://github.com/esmolanka/sexp-grammar/issues/21

----

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
