### PR TITLE
Re-enable cabal2nix which now works with GHC 9.0.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -16,6 +16,11 @@ packages:
         - gopher-proxy
         - filepath-bytestring
         - download-curl
+        - cabal2nix
+        - distribution-nixpkgs
+        - hackage-db
+        - language-nix
+        - jailbreak-cabal
 
     "Profpatsch <mail@profpatsch.de> @Profpatsch":
         - error

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5275,7 +5275,6 @@ packages:
         - bv-little < 0
         - cabal-debian < 0
         - cabal-toolkit < 0
-        - cabal2nix < 0
         - chaselev-deque < 0
         - compdata < 0
         - courier < 0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
