### PR TITLE
Re-enable gopher-proxy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -13,7 +13,7 @@ packages:
     "Lukas Epple <sternenseemann@systemli.org> @sternenseemann":
         - socket
         - spacecookie
-        - gopher-proxy < 0 # compile fail attoparsec 0.14
+        - gopher-proxy
         - filepath-bytestring
         - download-curl
         - cabal2nix


### PR DESCRIPTION
attoparsec failure has been resolved in the latest release on hackage,
released earlier today.

See <https://github.com/commercialhaskell/stackage/issues/5959#issuecomment-951245525>

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
