### PR TITLE
Reenable xmonad

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5424,7 +5424,6 @@ packages:
         - xls < 0
         - xml-conduit-parse < 0
         - xml-lens < 0
-        - xmonad < 0
         - xturtle < 0
         - yeshql-hdbc < 0
         - yesod-auth < 0 # 1.6.10.3
@@ -6704,8 +6703,6 @@ packages:
         - xdg-desktop-entry < 0 # tried xdg-desktop-entry-0.1.1.1, but its *library* requires the disabled package: ConfigFile
         - xml-html-qq < 0 # tried xml-html-qq-0.1.0.1, but its *library* requires the disabled package: heterocephalus
         - xml-isogen < 0 # tried xml-isogen-0.3.0, but its *library* requires the disabled package: dom-parser
-        - xmonad-contrib < 0 # tried xmonad-contrib-0.16, but its *library* requires the disabled package: xmonad
-        - xmonad-extras < 0 # tried xmonad-extras-0.15.3, but its *library* requires the disabled package: xmonad
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* does not support: yeshql-core-4.2.0.0
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* does not support: persistent-2.13.2.1


### PR DESCRIPTION
0.17.0 was uploaded to Hackage yesterday, fixing the build.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
