### PR TITLE
Re-enable ttrie

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2881,7 +2881,7 @@ packages:
 
     "Michael Schröder <mc.schroeder@gmail.com> @mcschroeder":
         - ctrie
-        - ttrie < 0 # compile fail against primitive https://github.com/commercialhaskell/stackage/issues/6259
+        - ttrie
 
     "Stefan Kersten <kaoskorobase@gmail.com> @kaoskorobase":
         - hsndfile


### PR DESCRIPTION
Running verify-package gives me a resolver error for two packages that are solely used in the benchmarks for the library. I don't know how to fix this. The benchmarks aren't needed to use the library, so I don't think they should impede the library's inclusion in stackage. (This hasn't been an issue previously, but it's been a while since my last release.)

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

