### PR TITLE
Re-enabled generic-lens-core, generic-lens & generic-optics

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5331,7 +5331,6 @@ packages:
         - eventsource-store-specs < 0
         - exinst < 0
         - ftp-client-conduit < 0 # 0.5.0.5
-        - generic-lens-core < 0 # 2.1.0.0
         - gi-gdk < 0
         - ginger < 0 # 0.10.2.0
         - giphy-api < 0 # https://github.com/passy/giphy-api/pull/19
@@ -5902,8 +5901,6 @@ packages:
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: poly-0.5.0.0
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: protolude-0.3.0
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
-        - generic-lens < 0 # tried generic-lens-2.2.0.0, but its *library* requires the disabled package: generic-lens-core
-        - generic-optics < 0 # tried generic-optics-2.2.0.0, but its *library* requires the disabled package: generic-lens-core
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: base-4.15.0.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: generic-deriving-1.14.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: dhall-1.40.1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
