### PR TITLE
Fix #6294: reinstitute happy < 1.21

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6751,6 +6751,11 @@ packages:
       - lucid < 2.9.13
       - mmark < 0.0.7.4
 
+      # happy-1.21.0 is deprecated an unbuildable
+      # https://github.com/commercialhaskell/stackage/issues/6294
+      # see also https://github.com/commercialhaskell/stackage/issues/6242
+      - happy < 1.21
+
       # https://github.com/commercialhaskell/stackage/issues/6243
       - jose < 0.9
 


### PR DESCRIPTION
Fix #6294: reinstitute happy < 1.21

Reason: `happy-1.21.0` is deprecated and unbuildable

This PR includes a reversion of commit e0daffc17db906e1f13a521dc801704316d8b00d.

  "Remove bounds for #6242 and fix #6242"
