### PR TITLE
Correct the flag setting for `mintty` to match the shipped `Win32-2.10`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6874,8 +6874,12 @@ package-flags:
     functor-classes-compat:
         containers: true
 
+    # 2021-11-14
+    # Since we are shipping Win32-2.10 (thus not 2.13.1), this flag needs to be set to 'false'.
+    # https://github.com/RyanGlScott/mintty/issues/4#issuecomment-968329124
+    # TODO: revisit when Win32 is bumped
     mintty:
-        win32-2-13-1: true
+        win32-2-13-1: false
 
     cassava:
         bytestring--lt-0_10_4: false


### PR DESCRIPTION
Fixes this compilation problem:
```
$ stack build --stack-yaml=stack-9.0.1.yaml --test
WARNING: Ignoring mintty's bounds on Win32 (>=2.13.1); using Win32-2.10.0.0.
Reason: trusting snapshot over cabal file dependency information.
mintty              > Configuring mintty-0.1.3...
mintty              > Building library for mintty-0.1.3..
mintty              > [1 of 1] Compiling System.Console.MinTTY
mintty              >
mintty              > src\System\Console\MinTTY.hs:31:1: error:
mintty              >     Could not find module `System.Console.MinTTY.Win32'
mintty              >     Use -v (or `:set -v` in ghci) to see a list of the files searched for.
mintty              >    |
mintty              > 31 | import qualified System.Console.MinTTY.Win32 as Win32 (isMinTTY, isMinTTYHandle)
```
Further reading: https://github.com/RyanGlScott/mintty/issues/4