### PR TITLE
Re-enable with-utf8 and th-env

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5403,7 +5403,6 @@ packages:
         - sydtest-persistent-sqlite < 0
         - text-region < 0
         - th-data-compat < 0
-        - th-env < 0
         - th-extras < 0
         - throttle-io-stream < 0
         - throwable-exceptions < 0
@@ -6694,8 +6693,6 @@ packages:
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires the disabled package: webdriver
         - websockets-snap < 0 # tried websockets-snap-0.10.3.1, but its *library* requires the disabled package: snap-core
         - websockets-snap < 0 # tried websockets-snap-0.10.3.1, but its *library* requires the disabled package: snap-server
-        - with-utf8 < 0 # tried with-utf8-1.0.2.2, but its *executable* requires the disabled package: th-env
-        - with-utf8 < 0 # tried with-utf8-1.0.2.2, but its *library* does not support: base-4.15.0.0
         - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* does not support: containers-0.6.4.1
         - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* does not support: containers-0.6.4.1
         - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: next-ref


### PR DESCRIPTION
* The latest version of with-utf8 works with GHC up to and including 9.2.1.
* The latest version of th-env has been fixed to work with GHC 9.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
