### PR TITLE
Remove myself as a maintainer of packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2641,27 +2641,6 @@ packages:
     "Franklin Chen <franklinchen@franklinchen.com> @FranklinChen":
         - Ebnf2ps
 
-    "Dmitry Ivanov <ethercrow@gmail.com> @ethercrow":
-        - charsetdetect-ae
-        - compiler-warnings
-        - docopt
-        - dynamic-state
-        - io-storage
-        - oo-prototypes
-        - opentelemetry
-        - opentelemetry-extra
-        - opentelemetry-wai
-        - opentelemetry-lightstep
-        - planb-token-introspection
-        - pointedlist
-        - unordered-intmap
-        - word-trie
-        - xdg-basedir
-        - yi-rope
-        # needed for opentelemetry
-        - ghc-trace-events  # @maoe
-        - numeric-limits # Lennart Augustsson
-
     "Tobias Bexelius <tobias_bexelius@hotmail.com> @tobbebex":
         - GPipe
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package`
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
