### PR TITLE
Re-enabled gi-gdk, gi-gtk & gi-gtk-hs but only for major version 3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3265,14 +3265,14 @@ packages:
         - gi-cairo
         - gi-dbusmenu
         - gi-dbusmenugtk3
-        - gi-gdk
+        - gi-gdk == 3.* # https://github.com/commercialhaskell/stackage/issues/6317
         - gi-gdkpixbuf
         - gi-gdkx11
         - gi-gio
         - gi-glib
         - gi-gobject
         - gi-graphene
-        - gi-gtk
+        - gi-gtk == 3.* # https://github.com/commercialhaskell/stackage/issues/6317
         - gi-gtk-hs
         - gi-gmodule
         - gi-pango
@@ -5338,7 +5338,6 @@ packages:
         - eventsource-store-specs < 0
         - exinst < 0
         - ftp-client-conduit < 0 # 0.5.0.5
-        - gi-gdk < 0
         - ginger < 0 # 0.10.2.0
         - giphy-api < 0 # https://github.com/passy/giphy-api/pull/19
         - groundhog-th < 0 # 0.11
@@ -5900,9 +5899,6 @@ packages:
         - gi-dbusmenugtk3 < 0 # tried gi-dbusmenugtk3-0.4.11, but its *library* requires the disabled package: gi-gdk
         - gi-gdkx11 < 0 # tried gi-gdkx11-4.0.4, but its *library* requires the disabled package: gi-gdk
         - gi-gsk < 0 # tried gi-gsk-4.0.4, but its *library* requires the disabled package: gi-gdk
-        - gi-gtk < 0 # tried gi-gtk-4.0.5, but its *library* requires the disabled package: gi-gdk
-        - gi-gtk-hs < 0 # tried gi-gtk-hs-0.3.11, but its *library* does not support: gi-gtk-4.0.5
-        - gi-gtk-hs < 0 # tried gi-gtk-hs-0.3.11, but its *library* requires the disabled package: gi-gdk
         - gi-gtksource < 0 # tried gi-gtksource-3.0.25, but its *library* does not support: gi-gtk-4.0.5
         - gi-gtksource < 0 # tried gi-gtksource-3.0.25, but its *library* requires the disabled package: gi-gdk
         - gi-vte < 0 # tried gi-vte-2.91.29, but its *library* does not support: gi-gtk-4.0.5


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
