### PR TITLE
Re-enabled th-extras

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5410,7 +5410,6 @@ packages:
         - sydtest-persistent-sqlite < 0
         - text-region < 0
         - th-data-compat < 0
-        - th-extras < 0
         - throttle-io-stream < 0
         - throwable-exceptions < 0
         - thyme < 0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
