### PR TITLE
Re-enabled flexible-defaults & random-source

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5877,7 +5877,6 @@ packages:
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires the disabled package: strict-base-types
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: BiobaseNewick
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: hierarchical-clustering
-        - flexible-defaults < 0 # tried flexible-defaults-0.0.3, but its *library* requires the disabled package: th-extras
         - freer-simple < 0 # tried freer-simple-1.2.1.1, but its *library* does not support: template-haskell-2.17.0.0
         - friday < 0 # tried friday-0.2.3.1, but its *library* does not support: containers-0.6.4.1
         - friday < 0 # tried friday-0.2.3.1, but its *library* requires the disabled package: ratio-int
@@ -6351,7 +6350,6 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: req-3.9.2
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires the disabled package: extensible
         - random-fu < 0 # tried random-fu-0.2.7.7, but its *library* requires the disabled package: random-source
-        - random-source < 0 # tried random-source-0.3.0.11, but its *library* requires the disabled package: th-extras
         - ranged-list < 0 # tried ranged-list-0.1.0.0, but its *library* requires the disabled package: typecheck-plugin-nat-simple
         - rank-product < 0 # tried rank-product-0.2.2.0, but its *library* requires the disabled package: random-fu
         - reanimate < 0 # tried reanimate-1.1.4.0, but its *library* requires the disabled package: hgeometry


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
