### PR TITLE
Reenable MissingH and its reverse dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5450,7 +5450,6 @@ packages:
         - Chart-cairo < 0 # tried Chart-cairo-1.9.3, but its *library* requires the disabled package: operational
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.3, but its *library* does not support: SVGFonts-1.8.0.1
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.3, but its *library* requires the disabled package: operational
-        - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires the disabled package: MissingH
         - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: biocore
         - FPretty < 0 # tried FPretty-1.1, but its *library* does not support: base-4.15.0.0
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* does not support: linear-1.21.8
@@ -5471,7 +5470,6 @@ packages:
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: monadloc
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: pwstore-fast
         - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* does not support: base-4.15.0.0
-        - MissingH < 0 # tried MissingH-1.4.3.0, but its *library* does not support: random-1.2.1
         - Network-NineP < 0 # tried Network-NineP-0.4.7.1, but its *library* requires the disabled package: mstate
         - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* does not support: base-4.15.0.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseBlast-0.3.3.0
@@ -5710,7 +5708,6 @@ packages:
         - brittany < 0 # tried brittany-0.13.1.2, but its *library* does not support: ghc-9.0.1
         - brittany < 0 # tried brittany-0.13.1.2, but its *library* does not support: ghc-boot-th-9.0.1
         - broadcast-chan < 0 # tried broadcast-chan-0.2.1.1, but its *library* does not support: base-4.15.0.0
-        - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: MissingH
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - butcher < 0 # tried butcher-1.3.3.2, but its *library* does not support: base-4.15.0.0
@@ -5769,7 +5766,6 @@ packages:
         - cql-io < 0 # tried cql-io-1.1.1, but its *library* requires the disabled package: cql
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
-        - cryptocompare < 0 # tried cryptocompare-0.1.2, but its *library* requires the disabled package: MissingH
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: QuickCheck-2.14.2
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: attoparsec-0.14.1
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: simple-vec3-0.6.0.1
@@ -5871,7 +5867,6 @@ packages:
         - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.4, but its *library* does not support: template-haskell-2.17.0.0
         - fasta < 0 # tried fasta-0.10.4.2, but its *library* requires the disabled package: pipes-text
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
-        - file-modules < 0 # tried file-modules-0.1.2.4, but its *library* requires the disabled package: MissingH
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires the disabled package: strict-base-types
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: BiobaseNewick
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: hierarchical-clustering
@@ -6032,7 +6027,6 @@ packages:
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmpfr < 0 # tried hmpfr-0.4.4, but its *library* does not support: integer-gmp-1.1
-        - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires the disabled package: MissingH
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.6, but its *executable* requires the disabled package: ixset-typed
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: aeson-1.5.6.0
@@ -7197,7 +7191,6 @@ skipped-tests:
     - oset # tried oset-0.4.0.1, but its *test-suite* does not support: hspec-2.8.5
     - oset # tried oset-0.4.0.1, but its *test-suite* does not support: hspec-discover-2.8.5
     - partial-semigroup # tried partial-semigroup-0.5.1.12, but its *test-suite* does not support: doctest-0.18.2
-    - pipes-csv # tried pipes-csv-1.4.3, but its *test-suite* requires the disabled package: MissingH
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
     - postgrest # tried postgrest-8.0.0, but its *test-suite* does not support: hspec-2.8.5
     - proto3-wire # tried proto3-wire-1.2.2, but its *test-suite* does not support: doctest-0.18.2
@@ -7813,7 +7806,6 @@ skipped-benchmarks:
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* does not support: criterion-1.5.11.0
     - elynx-tree # tried elynx-tree-0.6.1.0, but its *benchmarks* requires the disabled package: elynx-tools
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
-    - glob-posix # tried glob-posix-0.2.0.1, but its *benchmarks* requires the disabled package: MissingH
     - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* does not support: aeson-1.5.6.0
     - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* does not support: time-1.9.3
     - hip # tried hip-1.5.6.0, but its *benchmarks* requires the disabled package: repa-algorithms


### PR DESCRIPTION
libraries:
- MissingH  (Note: its test-suite does not build!)
- ConfigFile
- cryptocompare
- file-modules
- hocon

tests:
- pipes-csv

benchmarks:
- glob-posix

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following commands:

       stack unpack MissingH
       stack build --resolver nightly-2021-11-28 MissingH-1.4.3.0
