### PR TITLE
Re-enabled gi-dbusmenugtk3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5887,8 +5887,6 @@ packages:
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: ghc-9.0.1
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* does not support: ghc-9.0.1
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.4.0, but its *library* requires the disabled package: ghcjs-dom-jsaddle
-        - gi-dbusmenugtk3 < 0 # tried gi-dbusmenugtk3-0.4.11, but its *library* does not support: gi-gtk-4.0.5
-        - gi-dbusmenugtk3 < 0 # tried gi-dbusmenugtk3-0.4.11, but its *library* requires the disabled package: gi-gdk
         - gi-gdkx11 < 0 # tried gi-gdkx11-4.0.4, but its *library* requires the disabled package: gi-gdk
         - gi-gsk < 0 # tried gi-gsk-4.0.4, but its *library* requires the disabled package: gi-gdk
         - gi-gtksource < 0 # tried gi-gtksource-3.0.25, but its *library* does not support: gi-gtk-4.0.5


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
