### PR TITLE
Re-enabled gtk-strut

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5932,7 +5932,6 @@ packages:
         - groundhog-mysql < 0 # tried groundhog-mysql-0.11, but its *library* does not support: mysql-0.2.1
         - grouped-list < 0 # tried grouped-list-0.2.2.1, but its *library* does not support: base-4.15.0.0
         - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.0, but its *library* requires the disabled package: gi-gdk
-        - gtk-strut < 0 # tried gtk-strut-0.1.3.0, but its *library* requires the disabled package: gi-gdk
         - gtk3 < 0 # tried gtk3-0.15.6, but its *library* does not support: Cabal-3.4.0.0
         - hOpenPGP < 0 # tried hOpenPGP-2.9.7, but its *library* requires the disabled package: ixset-typed
         - hackage-security < 0 # tried hackage-security-0.6.0.1, but its *library* does not support: template-haskell-2.17.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
