### PR TITLE
commenter: Find disabled packages that may need newer dependencies

### DIFF
--- a/etc/commenter/Cargo.lock
+++ b/etc/commenter/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "commenter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy-regex",
  "regex",

--- a/etc/commenter/latest-version/LICENSE
+++ b/etc/commenter/latest-version/LICENSE
@@ -1,0 +1,30 @@
+Copyright Adam Bergmark (c) 2021
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/etc/commenter/latest-version/README.md
+++ b/etc/commenter/latest-version/README.md
@@ -1,0 +1,1 @@
+# latest-version

--- a/etc/commenter/latest-version/Setup.hs
+++ b/etc/commenter/latest-version/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/etc/commenter/latest-version/cabal.project
+++ b/etc/commenter/latest-version/cabal.project
@@ -1,0 +1,6 @@
+source-repository-package
+  type: git
+  location: git://github.com/commercialhaskell/pantry.git
+
+packages: ./latest-version.cabal
+with-compiler: ghc-8.10.7

--- a/etc/commenter/latest-version/latest-version.cabal
+++ b/etc/commenter/latest-version/latest-version.cabal
@@ -1,0 +1,23 @@
+name:                latest-version
+version:             0.1.0.0
+homepage:            https://github.com/githubuser/latest-version#readme
+license:             BSD3
+license-file:        LICENSE
+author:              Adam Bergmark
+maintainer:          adam@bergmark.nl
+copyright:           2021 Adam Bergmark
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+extra-source-files:  README.md
+
+executable latest-version
+  ghc-options:         -Wall
+  hs-source-dirs:      src
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:       base >= 4.7 && < 5
+                     , pantry
+                     , Cabal
+                     , rio
+                     , containers

--- a/etc/commenter/latest-version/src/Main.hs
+++ b/etc/commenter/latest-version/src/Main.hs
@@ -1,0 +1,18 @@
+module Main where
+
+import Data.List
+import Distribution.Types.PackageName
+import Distribution.Types.Version
+import Pantry
+import RIO
+import System.Environment
+import qualified Data.Map as Map
+
+main :: IO ()
+main =
+  runPantryApp $
+    liftIO . putStrLn
+    . intercalate "." . map show . versionNumbers
+    . fst . head . Map.toDescList
+    =<< getHackagePackageVersions YesRequireHackageIndex IgnorePreferredVersions
+    . mkPackageName =<< head <$> liftIO getArgs

--- a/etc/commenter/latest-version/stack.yaml
+++ b/etc/commenter/latest-version/stack.yaml
@@ -1,0 +1,4 @@
+resolver:
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
+packages:
+- .

--- a/etc/commenter/src/main.rs
+++ b/etc/commenter/src/main.rs
@@ -21,6 +21,7 @@ enum Header {
 enum Opt {
     Clear,
     Add,
+    Outdated,
 }
 
 fn main() {
@@ -28,11 +29,16 @@ fn main() {
     match opt {
         Opt::Clear => clear(),
         Opt::Add => add(),
+        Opt::Outdated => outdated(),
     }
 }
 
 fn clear() {
     commenter::clear();
+}
+
+fn outdated() {
+    commenter::outdated();
 }
 
 fn add() {


### PR DESCRIPTION
This adds `commenter outdated` which looks at the versions of disabled packages and their dependencies. It can give hints on whether lifting the constraints would help. It only works on the commenter generated sections of build-constraints.

Part of the output from an earlier commit on the ghc-9.2 branch (73b45485):

```
ghc-exactprint mismatch, snapshot: 0.6.4, hackage: 1.3.0
saltine mismatch, snapshot: 0.1.1.1, hackage: 0.2.0.0
stack mismatch, snapshot: 2.7.3, hackage: 9.9.9
unicode-data mismatch, snapshot: 0.1.0.1, hackage: 0.2.0, dependents: unicode-transforms-0.4.0
```

Looking into those, I noticed that ghc-exactprint needed to be upgraded to be in the snapshot at all, and upgrading unicode-data enabled unicode-transforms. The others still need the upper bound.

