### PR TITLE
Update to GHC 9.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fpco/pid1:18.04
 
 ENV HOME /home/stackage
 ENV LANG en_US.UTF-8
-ENV GHCVER 9.0.1
+ENV GHCVER 9.0.2
 
 # NOTE: also update debian-bootstrap.sh when cuda version changes
 ENV PATH /home/stackage/.stack/programs/x86_64-linux/ghc-$GHCVER/bin:/usr/local/cuda-10.0/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1,6 +1,6 @@
 ghc-major-version: "9.0"
 # new curator is supposed to use exact GHC version
-ghc-version: "9.0.1"
+ghc-version: "9.0.2"
 
 # This affects which version of the Cabal file format we allow. We
 # should ensure that this is always no greater than the version
@@ -5416,11 +5416,11 @@ packages:
         - Chart-cairo < 0 # tried Chart-cairo-1.9.3, but its *library* requires the disabled package: cairo
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.3, but its *library* does not support: SVGFonts-1.8.0.1
         - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: biocore
-        - FPretty < 0 # tried FPretty-1.1, but its *library* does not support: base-4.15.0.0
+        - FPretty < 0 # tried FPretty-1.1, but its *library* does not support: base-4.15.1.0
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* does not support: linear-1.21.8
         - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
         - H < 0 # tried H-0.9.0.1, but its *executable* requires the disabled package: inline-r
-        - HaskellNet < 0 # tried HaskellNet-0.6, but its *library* does not support: base-4.15.0.0
+        - HaskellNet < 0 # tried HaskellNet-0.6, but its *library* does not support: base-4.15.1.0
         - HaskellNet-SSL < 0 # tried HaskellNet-SSL-0.3.4.4, but its *library* requires the disabled package: HaskellNet
         - Hoed < 0 # tried Hoed-0.5.1, but its *library* requires the disabled package: regex-tdfa-text
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *executable* does not support: fast-logger-3.1.0
@@ -5435,9 +5435,9 @@ packages:
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: Workflow
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: monadloc
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: pwstore-fast
-        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* does not support: base-4.15.0.0
+        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* does not support: base-4.15.1.0
         - Network-NineP < 0 # tried Network-NineP-0.4.7.1, but its *library* requires the disabled package: mstate
-        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* does not support: base-4.15.0.0
+        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* does not support: base-4.15.1.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseBlast-0.3.3.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseFasta-0.4.0.1
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseHTTP-1.2.0
@@ -5449,11 +5449,11 @@ packages:
         - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-lucid < 0 # tried Spock-lucid-0.4.0.1, but its *library* requires the disabled package: Spock
         - Spock-worker < 0 # tried Spock-worker-0.3.1.0, but its *library* requires the disabled package: Spock
-        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* does not support: base-4.15.0.0
-        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* does not support: base-4.15.0.0
+        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* does not support: base-4.15.1.0
+        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* does not support: base-4.15.1.0
         - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* does not support: lens-5.0.1
         - YampaSynth < 0 # tried YampaSynth-0.2, but its *executable* requires the disabled package: Yampa
-        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* does not support: base-4.15.0.0
+        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* does not support: base-4.15.1.0
         - accelerate-arithmetic < 0 # tried accelerate-arithmetic-1.0.0.1, but its *library* does not support: accelerate-1.3.0.0
         - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate
         - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm
@@ -5481,7 +5481,7 @@ packages:
         - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* does not support: accelerate-1.3.0.0
-        - aeson-diff < 0 # tried aeson-diff-1.1.0.9, but its *library* does not support: base-4.15.0.0
+        - aeson-diff < 0 # tried aeson-diff-1.1.0.9, but its *library* does not support: base-4.15.1.0
         - aeson-injector < 0 # tried aeson-injector-1.1.5.0, but its *library* does not support: lens-5.0.1
         - aeson-picker < 0 # tried aeson-picker-0.1.0.5, but its *library* does not support: lens-5.0.1
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: base64-bytestring-1.2.1.0
@@ -5581,7 +5581,7 @@ packages:
         - amazonka-workspaces < 0 # tried amazonka-workspaces-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-xray < 0 # tried amazonka-xray-1.6.1, but its *library* requires the disabled package: amazonka-core
         - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* does not support: ansi-terminal-0.11.1
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* does not support: base-4.15.0.0
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* does not support: base-4.15.1.0
         - antiope-core < 0 # tried antiope-core-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-core < 0 # tried antiope-core-7.5.3, but its *library* requires the disabled package: amazonka-core
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka
@@ -5603,7 +5603,7 @@ packages:
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* does not support: unliftio-core-0.2.0.1
         - atom-conduit < 0 # tried atom-conduit-0.9.0.1, but its *library* requires the disabled package: refined
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: attoparsec-0.14.3
-        - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: base-4.15.0.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: base-4.15.1.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: cryptonite-0.29
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: memory-0.16.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: template-haskell-2.17.0.0
@@ -5611,7 +5611,7 @@ packages:
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: avers
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* does not support: lens-5.0.1
         - aws-xray-client-wai < 0 # tried aws-xray-client-wai-0.1.0.1, but its *library* requires the disabled package: aws-xray-client
-        - axel < 0 # tried axel-0.0.12, but its *library* does not support: base-4.15.0.0
+        - axel < 0 # tried axel-0.0.12, but its *library* does not support: base-4.15.1.0
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient-universe
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: aeson-1.5.6.0
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: hspec-2.8.5
@@ -5619,7 +5619,7 @@ packages:
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: shake-0.19.6
         - b9 < 0 # tried b9-3.2.0, but its *library* requires the disabled package: posix-pty
         - b9 < 0 # tried b9-3.2.0, but its *library* requires the disabled package: template
-        - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* does not support: base-4.15.0.0
+        - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* does not support: base-4.15.1.0
         - bcp47 < 0 # tried bcp47-0.2.0.5, but its *library* requires the disabled package: country
         - bcp47-orphans < 0 # tried bcp47-orphans-0.1.0.4, but its *library* requires the disabled package: bcp47
         - beam-core < 0 # tried beam-core-0.9.1.0, but its *library* does not support: dlist-1.0
@@ -5636,20 +5636,20 @@ packages:
         - bench-show < 0 # tried bench-show-0.3.1, but its *library* requires the disabled package: Chart-diagrams
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: brick-0.65
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: bytestring-0.10.12.1
-        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: directory-1.3.6.1
+        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: directory-1.3.6.2
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: filepath-1.4.2.1
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: lens-5.0.1
-        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: process-1.6.11.0
+        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: process-1.6.13.2
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: protolude-0.3.0
-        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: text-1.2.4.1
+        - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: text-1.2.5.0
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: time-1.9.3
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: typed-process-0.2.8.0
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: vector-0.12.3.1
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: vty-5.33
-        - binary-bits < 0 # tried binary-bits-0.5, but its *library* does not support: base-4.15.0.0
+        - binary-bits < 0 # tried binary-bits-0.5, but its *library* does not support: base-4.15.1.0
         - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
         - bioalign < 0 # tried bioalign-0.0.5, but its *library* requires the disabled package: biocore
-        - biocore < 0 # tried biocore-0.3.1, but its *library* does not support: base-4.15.0.0
+        - biocore < 0 # tried biocore-0.3.1, but its *library* does not support: base-4.15.1.0
         - biocore < 0 # tried biocore-0.3.1, but its *library* requires the disabled package: stringable
         - biofasta < 0 # tried biofasta-0.0.3, but its *library* requires the disabled package: biocore
         - biofastq < 0 # tried biofastq-0.1, but its *library* requires the disabled package: biocore
@@ -5665,18 +5665,17 @@ packages:
         - bitcoin-types < 0 # tried bitcoin-types-0.9.2, but its *library* requires the disabled package: hexstring
         - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
         - blosum < 0 # tried blosum-0.1.1.4, but its *executable* requires the disabled package: pipes-text
-        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* does not support: base-4.15.0.0
+        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* does not support: base-4.15.1.0
         - boundingboxes < 0 # tried boundingboxes-0.2.3, but its *library* does not support: lens-5.0.1
         - brittany < 0 # tried brittany-0.14.0.0, but its *library* does not support: aeson-1.5.6.0
-        - brittany < 0 # tried brittany-0.14.0.0, but its *library* does not support: text-1.2.4.1
-        - broadcast-chan < 0 # tried broadcast-chan-0.2.1.1, but its *library* does not support: base-4.15.0.0
+        - broadcast-chan < 0 # tried broadcast-chan-0.2.1.1, but its *library* does not support: base-4.15.1.0
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
-        - butcher < 0 # tried butcher-1.3.3.2, but its *library* does not support: base-4.15.0.0
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* does not support: base-4.15.1.0
         - cabal-file < 0 # tried cabal-file-0.1.1, but its *library* requires the disabled package: hackage-security
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: Cabal-3.4.0.0
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: base-4.15.0.0
-        - cairo < 0 # tried cairo-0.13.8.1, but its *library* does not support: Cabal-3.4.0.0
+        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: Cabal-3.4.1.0
+        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: base-4.15.1.0
+        - cairo < 0 # tried cairo-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
         - cereal-time < 0 # tried cereal-time-0.1.0.0, but its *library* does not support: time-1.9.3
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: aeson-1.5.6.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: aeson-casing-0.2.0.0
@@ -5688,8 +5687,11 @@ packages:
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: byteslice
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: bytesmith
         - chronos-bench < 0 # tried chronos-bench-0.2.0.2, but its *library* requires the disabled package: chronos
-        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* does not support: base-4.15.0.0
-        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* does not support: base-4.15.0.0
+        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* does not support: base-4.15.1.0
+        - clash-ghc < 0 # tried clash-ghc-1.4.6, but its *library* does not support: ghc-bignum-1.1
+        - clash-lib < 0 # tried clash-lib-1.4.6, but its *library* does not support: ghc-bignum-1.1
+        - clash-prelude < 0 # tried clash-prelude-1.4.6, but its *library* does not support: ghc-bignum-1.1
+        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* does not support: base-4.15.1.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* does not support: template-haskell-2.17.0.0
         - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* does not support: clock-0.8.2
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* does not support: cmark-0.6
@@ -5719,10 +5721,10 @@ packages:
         - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* does not support: hspec-core-2.8.5
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* does not support: conferer-1.1.0.0
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires the disabled package: snap-server
-        - configurator-pg < 0 # tried configurator-pg-0.2.5, but its *library* does not support: base-4.15.0.0
+        - configurator-pg < 0 # tried configurator-pg-0.2.5, but its *library* does not support: base-4.15.1.0
         - configurator-pg < 0 # tried configurator-pg-0.2.5, but its *library* does not support: megaparsec-9.2.0
         - country < 0 # tried country-0.2.1, but its *library* does not support: attoparsec-0.14.3
-        - country < 0 # tried country-0.2.1, but its *library* does not support: base-4.15.0.0
+        - country < 0 # tried country-0.2.1, but its *library* does not support: base-4.15.1.0
         - cql-io < 0 # tried cql-io-1.1.1, but its *library* requires the disabled package: cql
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
@@ -5730,19 +5732,19 @@ packages:
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: attoparsec-0.14.3
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: simple-vec3-0.6.0.1
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: strict-0.4.0.1
-        - css-syntax < 0 # tried css-syntax-0.1.0.0, but its *library* does not support: base-4.15.0.0
-        - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: Cabal-3.4.0.0
+        - css-syntax < 0 # tried css-syntax-0.1.0.0, but its *library* does not support: base-4.15.1.0
+        - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: Cabal-3.4.1.0
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: attoparsec-0.14.3
-        - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: base-4.15.0.0
+        - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: base-4.15.1.0
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: constraints-0.13.2
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: cryptonite-0.29
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: memory-0.16.0
         - darcs < 0 # tried darcs-2.16.4, but its *library* requires the disabled package: regex-compat-tdfa
         - data-accessor-template < 0 # tried data-accessor-template-0.2.1.16, but its *library* does not support: template-haskell-2.17.0.0
-        - data-compat < 0 # tried data-compat-0.1.0.3, but its *library* does not support: base-4.15.0.0
-        - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* does not support: base-4.15.0.0
+        - data-compat < 0 # tried data-compat-0.1.0.3, but its *library* does not support: base-4.15.1.0
+        - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* does not support: base-4.15.1.0
         - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
-        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* does not support: base-4.15.0.0
+        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* does not support: base-4.15.1.0
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.0.17, but its *library* requires the disabled package: haskell-lsp
         - dhall-nix < 0 # tried dhall-nix-1.1.23, but its *library* requires the disabled package: hnix
         - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires the disabled package: haskell-src-exts-simple
@@ -5750,7 +5752,7 @@ packages:
         - diagrams-canvas < 0 # tried diagrams-canvas-1.4.1, but its *library* requires the disabled package: blank-canvas
         - diagrams-canvas < 0 # tried diagrams-canvas-1.4.1, but its *library* requires the disabled package: statestack
         - diagrams-gtk < 0 # tried diagrams-gtk-1.4, but its *library* requires the disabled package: gtk
-        - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* does not support: base-4.15.0.0
+        - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* does not support: base-4.15.1.0
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* does not support: containers-0.6.4.1
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* does not support: diagrams-core-1.5.0
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* does not support: lens-5.0.1
@@ -5758,15 +5760,15 @@ packages:
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* requires the disabled package: statestack
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* requires the disabled package: static-canvas
         - diagrams-postscript < 0 # tried diagrams-postscript-1.5.1, but its *library* requires the disabled package: statestack
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* does not support: base-4.15.0.0
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* does not support: base-4.15.1.0
         - dice < 0 # tried dice-0.1.0.1, but its *library* requires the disabled package: random-fu
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* does not support: criterion-1.5.12.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: attoparsec-0.14.3
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: base-4.15.0.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: base-4.15.1.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: containers-0.6.4.1
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: exceptions-0.10.4
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* does not support: time-1.9.3
-        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* does not support: Cabal-3.4.0.0
+        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* does not support: Cabal-3.4.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* does not support: containers-0.6.4.1
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* does not support: hashable-1.3.5.0
@@ -5788,26 +5790,27 @@ packages:
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* does not support: language-docker-10.4.0
         - dom-parser < 0 # tried dom-parser-3.1.0, but its *library* requires the disabled package: xml-lens
         - drawille < 0 # tried drawille-0.1.2.0, but its *library* does not support: containers-0.6.4.1
-        - earcut < 0 # tried earcut-0.1.0.4, but its *library* does not support: base-4.15.0.0
+        - earcut < 0 # tried earcut-0.1.0.4, but its *library* does not support: base-4.15.1.0
         - easytest < 0 # tried easytest-0.3, but its *library* does not support: hedgehog-1.0.5
         - ed25519 < 0 # tried ed25519-0.0.5.0, but its *library* does not support: ghc-prim-0.7.0
         - edit < 0 # tried edit-1.0.1.0, but its *library* does not support: QuickCheck-2.14.2
-        - edit < 0 # tried edit-1.0.1.0, but its *library* does not support: base-4.15.0.0
+        - edit < 0 # tried edit-1.0.1.0, but its *library* does not support: base-4.15.1.0
         - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* does not support: free-5.1.7
         - egison < 0 # tried egison-4.1.3, but its *library* requires the disabled package: sweet-egison
         - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* does not support: parser-combinators-1.3.0
         - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* does not support: template-haskell-2.17.0.0
-        - ekg < 0 # tried ekg-0.4.0.15, but its *library* does not support: base-4.15.0.0
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* does not support: base-4.15.1.0
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires the disabled package: snap-server
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: amazonka
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: amazonka-core
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: ekg-core
-        - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* does not support: base-4.15.0.0
+        - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* does not support: base-4.15.1.0
         - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* does not support: ghc-prim-0.7.0
-        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* does not support: base-4.15.0.0
-        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* does not support: base-4.15.0.0
+        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* does not support: base-4.15.1.0
+        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* does not support: base-4.15.1.0
         - ekg-wai < 0 # tried ekg-wai-0.1.0.3, but its *library* does not support: time-1.9.3
-        - elm-street < 0 # tried elm-street-0.1.0.4, but its *library* does not support: base-4.15.0.0
+        - elm-street < 0 # tried elm-street-0.1.0.4, but its *library* does not support: base-4.15.1.0
+        - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: ghc-typelits-natnormalise
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
         - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
         - event < 0 # tried event-0.1.4, but its *library* does not support: containers-0.6.4.1
@@ -5827,21 +5830,24 @@ packages:
         - friday < 0 # tried friday-0.2.3.1, but its *library* does not support: containers-0.6.4.1
         - friday < 0 # tried friday-0.2.3.1, but its *library* requires the disabled package: ratio-int
         - friday-juicypixels < 0 # tried friday-juicypixels-0.1.2.4, but its *library* requires the disabled package: friday
-        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* does not support: base-4.15.0.0
+        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* does not support: base-4.15.1.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* does not support: haskeline-0.8.2
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: poly-0.5.0.0
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: protolude-0.3.0
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
-        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: base-4.15.0.0
+        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: base-4.15.1.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: generic-deriving-1.14.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: dhall-1.40.2
-        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: ghc-9.0.1
-        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* does not support: ghc-9.0.1
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: ghc-9.0.2
+        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* does not support: ghc-9.0.2
+        - ghc-typelits-extra < 0 # tried ghc-typelits-extra-0.4.3, but its *library* does not support: ghc-bignum-1.1
+        - ghc-typelits-knownnat < 0 # tried ghc-typelits-knownnat-0.7.6, but its *library* requires the disabled package: ghc-typelits-natnormalise
+        - ghc-typelits-natnormalise < 0 # tried ghc-typelits-natnormalise-0.7.6, but its *library* does not support: ghc-bignum-1.1
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires the disabled package: ghcjs-dom-jsaddle
         - gi-gsk < 0 # tried gi-gsk-4.0.4, but its *library* does not support: gi-gdk-3.0.25
         - gi-webkit2 < 0 # tried gi-webkit2-4.0.28, but its *library* requires the disabled package: gi-soup
         - gingersnap < 0 # tried gingersnap-0.3.1.0, but its *library* requires the disabled package: snap-core
-        - gio < 0 # tried gio-0.13.8.1, but its *library* does not support: Cabal-3.4.0.0
+        - gio < 0 # tried gio-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
         - git-annex < 0 # tried git-annex-8.20211231, but its *executable* requires the disabled package: IfElse
         - git-annex < 0 # tried git-annex-8.20211231, but its *executable* requires the disabled package: aws
         - git-annex < 0 # tried git-annex-8.20211231, but its *executable* requires the disabled package: bloomfilter
@@ -5852,15 +5858,15 @@ packages:
         - git-annex < 0 # tried git-annex-8.20211231, but its *executable* requires the disabled package: sandi
         - git-annex < 0 # tried git-annex-8.20211231, but its *executable* requires the disabled package: torrent
         - git-vogue < 0 # tried git-vogue-0.3.0.2, but its *executable* requires the disabled package: stylish-haskell
-        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* does not support: base-4.15.0.0
-        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* does not support: base-4.15.0.0
+        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* does not support: base-4.15.1.0
+        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* does not support: base-4.15.1.0
         - gitlib-libgit2 < 0 # tried gitlib-libgit2-3.1.2.1, but its *library* requires the disabled package: gitlib
         - glaze < 0 # tried glaze-0.3.0.1, but its *library* does not support: lens-5.0.1
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: glazier
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
-        - glib < 0 # tried glib-0.13.8.1, but its *library* does not support: Cabal-3.4.0.0
+        - glib < 0 # tried glib-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: linear-accelerate
         - gloss-examples < 0 # tried gloss-examples-1.13.0.3, but its *executable* does not support: random-1.2.1
@@ -5961,7 +5967,7 @@ packages:
         - gogol-youtube < 0 # tried gogol-youtube-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-analytics < 0 # tried gogol-youtube-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-reporting < 0 # tried gogol-youtube-reporting-0.5.0, but its *library* requires the disabled package: gogol-core
-        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* does not support: base-4.15.0.0
+        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* does not support: base-4.15.1.0
         - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* does not support: base64-bytestring-1.2.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* does not support: http-api-data-0.4.3
         - google-translate < 0 # tried google-translate-0.5, but its *library* does not support: http-client-0.7.9
@@ -5969,8 +5975,8 @@ packages:
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* does not support: groundhog-0.12.0
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires the disabled package: groundhog-th
         - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* does not support: mysql-0.2.1
-        - grouped-list < 0 # tried grouped-list-0.2.2.1, but its *library* does not support: base-4.15.0.0
-        - gtk3 < 0 # tried gtk3-0.15.6, but its *library* does not support: Cabal-3.4.0.0
+        - grouped-list < 0 # tried grouped-list-0.2.2.1, but its *library* does not support: base-4.15.1.0
+        - gtk3 < 0 # tried gtk3-0.15.6, but its *library* does not support: Cabal-3.4.1.0
         - hOpenPGP < 0 # tried hOpenPGP-2.9.7, but its *library* requires the disabled package: ixset-typed
         - hackage-security < 0 # tried hackage-security-0.6.0.1, but its *library* does not support: template-haskell-2.17.0.0
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: http-client-0.7.9
@@ -5979,59 +5985,60 @@ packages:
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* does not support: deepseq-1.4.5.0
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* requires the disabled package: colourista
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* requires the disabled package: spdx
+        - hamilton < 0 # tried hamilton-0.1.0.3, but its *executable* requires the disabled package: ghc-typelits-knownnat
         - hapistrano < 0 # tried hapistrano-0.4.3.0, but its *library* does not support: path-0.9.2
         - happstack-hsp < 0 # tried happstack-hsp-7.3.7.5, but its *library* requires the disabled package: harp
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *executable* does not support: base-4.15.0.0
+        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *executable* does not support: base-4.15.1.0
         - haskell-lsp-client < 0 # tried haskell-lsp-client-1.0.0.1, but its *library* requires the disabled package: haskell-lsp
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: ghc-9.0.1
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: ghc-boot-th-9.0.1
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: ghc-9.0.2
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: ghc-boot-th-9.0.2
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* does not support: Glob-0.10.2
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* does not support: optparse-applicative-0.16.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* does not support: strict-0.4.0.1
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: haskell-tools-builtin-refactorings
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: Cabal-3.4.0.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: Cabal-3.4.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: Diff-0.4.1
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: network-3.1.2.5
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: optparse-applicative-0.16.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: strict-0.4.0.1
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: haskell-tools-builtin-refactorings
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: haskell-tools-builtin-refactorings
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: warp-3.3.18
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: haskell-tools-builtin-refactorings
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: Cabal-3.4.0.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: Cabal-3.4.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* does not support: base-4.15.0.0
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* does not support: ghc-9.0.1
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* does not support: base-4.15.1.0
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
         - haskey < 0 # tried haskey-0.3.1.0, but its *library* does not support: stm-containers-1.2
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* does not support: monad-control-1.0.3.1
@@ -6042,7 +6049,7 @@ packages:
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: haxl
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: aeson-1.5.6.0
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: attoparsec-0.14.3
-        - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: base-4.15.0.0
+        - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: base-4.15.1.0
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: dlist-1.0
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: ansi-terminal-0.11.1
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: brick-0.65
@@ -6051,10 +6058,10 @@ packages:
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: vty-5.33
         - hgeometry < 0 # tried hgeometry-0.13, but its *library* requires the disabled package: vector-circular
         - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.13, but its *library* requires the disabled package: vector-circular
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: base-4.15.0.0
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: base-4.15.1.0
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: template-haskell-2.17.0.0
-        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* does not support: base-4.15.0.0
-        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* does not support: base-4.15.0.0
+        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* does not support: base-4.15.1.0
+        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* does not support: base-4.15.1.0
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: swagger2
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: swagger2
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart-diagrams
@@ -6082,7 +6089,7 @@ packages:
         - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-quickcheck < 0 # tried hschema-quickcheck-0.0.1.1, but its *library* requires the disabled package: hschema
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: attoparsec-0.14.3
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: ghc-boot-9.0.1
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: ghc-boot-9.0.2
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: ghc-lib-parser-9.0.2.20211226
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: hlint-3.3.6
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: http-client-0.7.9
@@ -6090,24 +6097,24 @@ packages:
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: optparse-applicative-0.16.1.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: template-haskell-2.17.0.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires the disabled package: text-region
-        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* does not support: base-4.15.0.0
+        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* does not support: base-4.15.1.0
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* does not support: hspec-core-2.8.5
         - hspec-wai-json < 0 # tried hspec-wai-json-0.11.0, but its *library* does not support: hspec-wai-0.11.1
         - hspec-webdriver < 0 # tried hspec-webdriver-1.2.0, but its *library* requires the disabled package: webdriver
         - hsx2hs < 0 # tried hsx2hs-0.14.1.8, but its *library* does not support: template-haskell-2.17.0.0
         - hw-hspec-hedgehog < 0 # tried hw-hspec-hedgehog-0.1.1.0, but its *library* does not support: hspec-2.8.5
-        - hyraxAbif < 0 # tried hyraxAbif-0.2.3.27, but its *library* requires the disabled package: protolude
-        - idris < 0 # tried idris-1.3.4, but its *library* does not support: Cabal-3.4.0.0
+        - hyraxAbif < 0 # tried hyraxAbif-0.2.3.27, but its *library* does not support: text-1.2.5.0
+        - idris < 0 # tried idris-1.3.4, but its *library* does not support: Cabal-3.4.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* does not support: network-3.1.2.5
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: hse-cpp
-        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* does not support: base-4.15.0.0
-        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* does not support: base-4.15.0.0
-        - inline-java < 0 # tried inline-java-0.10.0, but its *library* does not support: ghc-9.0.1
+        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* does not support: base-4.15.1.0
+        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* does not support: base-4.15.1.0
+        - inline-java < 0 # tried inline-java-0.10.0, but its *library* does not support: ghc-9.0.2
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
         - inline-r < 0 # tried inline-r-0.10.5, but its *library* does not support: singletons-3.0.1
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - io-streams-haproxy < 0 # tried io-streams-haproxy-1.0.1.0, but its *library* does not support: attoparsec-0.14.3
-        - io-streams-haproxy < 0 # tried io-streams-haproxy-1.0.1.0, but its *library* does not support: base-4.15.0.0
+        - io-streams-haproxy < 0 # tried io-streams-haproxy-1.0.1.0, but its *library* does not support: base-4.15.1.0
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* does not support: attoparsec-0.14.3
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* does not support: network-3.1.2.5
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* does not support: path-0.9.2
@@ -6127,8 +6134,8 @@ packages:
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* does not support: smallcheck-1.2.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires the disabled package: run-haskell-module
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: aeson-1.5.6.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: base-4.15.0.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* does not support: base-4.15.0.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: base-4.15.1.0
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* does not support: base-4.15.1.0
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: distributed-closure
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: distributed-closure
@@ -6142,7 +6149,7 @@ packages:
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: time-1.9.3
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: aeson-1.5.6.0
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: katip-0.8.7.0
-        - kraken < 0 # tried kraken-0.1.0, but its *library* does not support: base-4.15.0.0
+        - kraken < 0 # tried kraken-0.1.0, but its *library* does not support: base-4.15.1.0
         - lambdabot-core < 0 # tried lambdabot-core-5.3.0.2, but its *library* requires the disabled package: random-fu
         - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.0.2, but its *library* requires the disabled package: lambdabot-core
         - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* does not support: template-haskell-2.17.0.0
@@ -6159,13 +6166,14 @@ packages:
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* does not support: lens-family-2.1.1
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* does not support: lens-family-core-2.1.0
         - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires the disabled package: hs-functors
-        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* does not support: base-4.15.0.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* does not support: base-4.15.0.0
+        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* does not support: base-4.15.1.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* does not support: base-4.15.1.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* does not support: text-1.2.5.0
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg-core
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: protolude
-        - licensor < 0 # tried licensor-0.5.0, but its *library* does not support: Cabal-3.4.0.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* does not support: base-4.15.0.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* does not support: Cabal-3.4.1.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* does not support: base-4.15.1.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* does not support: lens-5.0.1
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* does not support: containers-0.6.4.1
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* does not support: megaparsec-9.2.0
@@ -6173,21 +6181,21 @@ packages:
         - list-witnesses < 0 # tried list-witnesses-0.1.3.2, but its *library* requires the disabled package: functor-products
         - little-logger < 0 # tried little-logger-0.3.2, but its *library* requires the disabled package: co-log
         - little-logger < 0 # tried little-logger-0.3.2, but its *library* requires the disabled package: co-log-core
-        - loc < 0 # tried loc-0.1.3.10, but its *library* does not support: base-4.15.0.0
+        - loc < 0 # tried loc-0.1.3.10, but its *library* does not support: base-4.15.1.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: aeson-1.5.6.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: o-clock-1.2.1
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: universum-1.7.2
         - logger-thread < 0 # tried logger-thread-0.1.0.2, but its *library* requires the disabled package: protolude
-        - logging-effect-extra < 0 # tried logging-effect-extra-2.0.0, but its *library* does not support: base-4.15.0.0
+        - logging-effect-extra < 0 # tried logging-effect-extra-2.0.0, but its *library* does not support: base-4.15.1.0
         - logging-effect-extra < 0 # tried logging-effect-extra-2.0.0, but its *library* does not support: prettyprinter-1.7.1
         - logging-effect-extra < 0 # tried logging-effect-extra-2.0.0, but its *library* requires the disabled package: logging-effect
-        - logging-effect-extra-file < 0 # tried logging-effect-extra-file-2.0.1, but its *library* does not support: base-4.15.0.0
+        - logging-effect-extra-file < 0 # tried logging-effect-extra-file-2.0.1, but its *library* does not support: base-4.15.1.0
         - logging-effect-extra-file < 0 # tried logging-effect-extra-file-2.0.1, but its *library* does not support: prettyprinter-1.7.1
         - logging-effect-extra-file < 0 # tried logging-effect-extra-file-2.0.1, but its *library* requires the disabled package: logging-effect
-        - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* does not support: base-4.15.0.0
+        - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* does not support: base-4.15.1.0
         - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* does not support: prettyprinter-1.7.1
         - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* requires the disabled package: logging-effect
-        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* does not support: ghc-9.0.1
+        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* does not support: ghc-9.0.2
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: network-3.1.2.5
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-0.18.3
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-client-0.18.3
@@ -6198,12 +6206,13 @@ packages:
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* does not support: attoparsec-0.14.3
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* does not support: megaparsec-9.2.0
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires the disabled package: Interpolation
-        - map-syntax < 0 # tried map-syntax-0.3, but its *library* does not support: base-4.15.0.0
+        - map-syntax < 0 # tried map-syntax-0.3, but its *library* does not support: base-4.15.1.0
         - markup < 0 # tried markup-4.2.0, but its *library* requires the disabled package: attoparsec-uri
         - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: aeson-1.5.6.0
         - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: http-client-0.7.9
         - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: lens-5.0.1
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires the disabled package: marvin-interpolate
+        - matrix-static < 0 # tried matrix-static-0.3, but its *library* requires the disabled package: ghc-typelits-natnormalise
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: extra-1.7.10
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: formatting-7.1.3
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: http-client-0.7.9
@@ -6233,14 +6242,15 @@ packages:
         - misfortune < 0 # tried misfortune-0.1.1.2, but its *library* requires the disabled package: random-fu
         - miso < 0 # tried miso-1.8.1.0, but its *library* requires the disabled package: jsaddle
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *executable* requires the disabled package: pipes-text
-        - mole < 0 # tried mole-0.0.7, but its *executable* does not support: base-4.15.0.0
+        - modular < 0 # tried modular-0.1.0.8, but its *library* requires the disabled package: ghc-typelits-knownnat
+        - mole < 0 # tried mole-0.0.7, but its *executable* does not support: base-4.15.1.0
         - mole < 0 # tried mole-0.0.7, but its *executable* requires the disabled package: snap-server
-        - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: base-4.15.0.0
+        - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: base-4.15.1.0
         - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: mwc-random-0.15.0.2
         - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires the disabled package: ekg-core
         - monad-mock < 0 # tried monad-mock-0.2.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
-        - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* does not support: base-4.15.0.0
+        - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* does not support: base-4.15.1.0
         - msgpack-aeson < 0 # tried msgpack-aeson-0.1.0.0, but its *library* requires the disabled package: msgpack
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* does not support: blaze-builder-0.4.2.2
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* does not support: filepath-1.4.2.1
@@ -6248,26 +6258,26 @@ packages:
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* does not support: template-haskell-2.17.0.0
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires the disabled package: peggy
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires the disabled package: shakespeare-text
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: base-4.15.0.0
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: base-4.15.1.0
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: binary-conduit-1.3.1
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: conduit-1.3.4.2
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: conduit-extra-1.3.5
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: network-3.1.2.5
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: random-1.2.1
-        - multistate < 0 # tried multistate-0.8.0.3, but its *library* does not support: base-4.15.0.0
+        - multistate < 0 # tried multistate-0.8.0.3, but its *library* does not support: base-4.15.1.0
         - mwc-random-accelerate < 0 # tried mwc-random-accelerate-0.2.0.0, but its *library* requires the disabled package: accelerate
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* does not support: memory-0.16.0
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires the disabled package: word24
         - mysql-haskell-nem < 0 # tried mysql-haskell-nem-0.1.0.0, but its *library* requires the disabled package: mysql-haskell
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: mysql-haskell
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: tcp-streams-openssl
-        - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* does not support: base-4.15.0.0
+        - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* does not support: base-4.15.1.0
         - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* does not support: singletons-3.0.1
         - n2o-web < 0 # tried n2o-web-0.11.2, but its *library* requires the disabled package: n2o-protocols
         - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires the disabled package: async-timer
-        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* does not support: base-4.15.0.0
+        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* does not support: base-4.15.1.0
         - net-mqtt-lens < 0 # tried net-mqtt-lens-0.1.1.0, but its *library* requires the disabled package: net-mqtt
-        - netrc < 0 # tried netrc-0.2.0.0, but its *library* does not support: base-4.15.0.0
+        - netrc < 0 # tried netrc-0.2.0.0, but its *library* does not support: base-4.15.1.0
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: hexstring
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: network-attoparsec
         - network-msgpack-rpc < 0 # tried network-msgpack-rpc-0.0.6, but its *library* does not support: network-3.1.2.5
@@ -6277,23 +6287,23 @@ packages:
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* does not support: numhask-0.8.1.0
         - nvim-hs-ghcid < 0 # tried nvim-hs-ghcid-2.0.0.0, but its *library* requires the disabled package: nvim-hs-contrib
         - oblivious-transfer < 0 # tried oblivious-transfer-0.1.0, but its *library* requires the disabled package: protolude
-        - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: Cabal-3.4.0.0
-        - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: base-4.15.0.0
+        - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: Cabal-3.4.1.0
+        - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: base-4.15.1.0
         - om-elm < 0 # tried om-elm-2.0.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - opml-conduit < 0 # tried opml-conduit-0.9.0.0, but its *library* requires the disabled package: refined
-        - oset < 0 # tried oset-0.4.0.1, but its *library* does not support: base-4.15.0.0
-        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* does not support: Cabal-3.4.0.0
+        - oset < 0 # tried oset-0.4.0.1, but its *library* does not support: base-4.15.1.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* does not support: Cabal-3.4.1.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* does not support: groups-0.5.3
         - pairing < 0 # tried pairing-1.1.0, but its *library* does not support: protolude-0.3.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires the disabled package: elliptic-curve
-        - pango < 0 # tried pango-0.13.8.1, but its *library* does not support: Cabal-3.4.0.0
+        - pango < 0 # tried pango-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
         - pantry < 0 # tried pantry-0.5.3, but its *library* requires the disabled package: hackage-security
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* does not support: template-haskell-2.17.0.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* does not support: parser-combinators-1.3.0
         - path-text-utf8 < 0 # tried path-text-utf8-0.0.1.8, but its *library* does not support: path-0.9.2
         - pcf-font-embed < 0 # tried pcf-font-embed-0.1.2.0, but its *library* requires the disabled package: pcf-font
         - pedersen-commitment < 0 # tried pedersen-commitment-0.2.0, but its *library* requires the disabled package: protolude
-        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* does not support: base-4.15.0.0
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* does not support: base-4.15.1.0
         - persistable-record < 0 # tried persistable-record-0.6.0.5, but its *library* requires the disabled package: th-data-compat
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: persistable-record
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query-HDBC
@@ -6303,16 +6313,16 @@ packages:
         - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* does not support: JuicyPixels-3.3.6
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* does not support: hmatrix-0.20.2
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: Cabal-3.4.0.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: Cabal-3.4.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: aeson-1.5.6.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: base-4.15.0.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: base-4.15.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: binary-orphans-1.0.2
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: containers-0.6.4.1
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: hashable-1.3.5.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: shake-0.19.6
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: yaml-0.11.7.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: Cabal-3.4.0.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: base-4.15.0.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: Cabal-3.4.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: base64-bytestring-1.2.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: containers-0.6.4.1
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: hashable-1.3.5.0
@@ -6325,12 +6335,12 @@ packages:
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: cairo
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* does not support: base-4.15.0.0
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* does not support: base-4.15.1.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires the disabled package: haskell-src-exts-simple
         - polysemy-zoo < 0 # tried polysemy-zoo-0.7.0.2, but its *library* does not support: constraints-0.13.2
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* does not support: base-4.15.0.0
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* does not support: base-4.15.1.0
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* does not support: ghc-prim-0.7.0
-        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: base-4.15.0.0
+        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: base-4.15.1.0
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: hasql-1.5.0.1
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: retry-0.9.0.0
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: swagger2-2.7
@@ -6342,10 +6352,10 @@ packages:
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* does not support: containers-0.6.4.1
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* does not support: lens-5.0.1
         - product-isomorphic < 0 # tried product-isomorphic-0.0.3.3, but its *library* requires the disabled package: th-data-compat
-        - protolude < 0 # tried protolude-0.3.0, but its *library* does not support: base-4.15.0.0
+        - protolude < 0 # tried protolude-0.3.0, but its *library* does not support: base-4.15.1.0
         - protolude < 0 # tried protolude-0.3.0, but its *library* does not support: ghc-prim-0.7.0
-        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* does not support: base-4.15.0.0
-        - pure-io < 0 # tried pure-io-0.2.1, but its *library* does not support: base-4.15.0.0
+        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* does not support: base-4.15.1.0
+        - pure-io < 0 # tried pure-io-0.2.1, but its *library* does not support: base-4.15.1.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* does not support: optparse-applicative-0.16.1.0
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* does not support: ansi-terminal-0.11.1
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
@@ -6365,7 +6375,7 @@ packages:
         - rdf < 0 # tried rdf-0.1.0.5, but its *library* does not support: attoparsec-0.14.3
         - reanimate < 0 # tried reanimate-1.1.4.0, but its *library* requires the disabled package: hgeometry
         - reanimate < 0 # tried reanimate-1.1.4.0, but its *library* requires the disabled package: hgeometry-combinatorial
-        - refined < 0 # tried refined-0.6.2, but its *library* does not support: base-4.15.0.0
+        - refined < 0 # tried refined-0.6.2, but its *library* does not support: base-4.15.1.0
         - refined < 0 # tried refined-0.6.2, but its *library* does not support: template-haskell-2.17.0.0
         - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires the disabled package: hsx2hs
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* does not support: regex-base-0.94.0.2
@@ -6380,11 +6390,11 @@ packages:
         - relational-record < 0 # tried relational-record-0.2.2.0, but its *library* requires the disabled package: product-isomorphic
         - relational-record < 0 # tried relational-record-0.2.2.0, but its *library* requires the disabled package: relational-query-HDBC
         - relational-schemas < 0 # tried relational-schemas-0.1.8.0, but its *library* requires the disabled package: relational-query
-        - repa-algorithms < 0 # tried repa-algorithms-3.4.1.4, but its *library* does not support: base-4.15.0.0
+        - repa-algorithms < 0 # tried repa-algorithms-3.4.1.4, but its *library* does not support: base-4.15.1.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* does not support: aeson-1.5.6.0
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* does not support: base-4.15.0.0
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* does not support: base-4.15.1.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* does not support: req-3.9.2
-        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* does not support: base-4.15.0.0
+        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* does not support: base-4.15.1.0
         - rhine-gloss < 0 # tried rhine-gloss-0.7.0, but its *library* requires the disabled package: rhine
         - riak < 0 # tried riak-1.2.0.0, but its *library* does not support: attoparsec-0.14.3
         - riak < 0 # tried riak-1.2.0.0, but its *library* does not support: network-3.1.2.5
@@ -6400,14 +6410,14 @@ packages:
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* does not support: aeson-1.5.6.0
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: hjsonschema
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: validationt
-        - sendgrid-v3 < 0 # tried sendgrid-v3-0.3.0.0, but its *library* does not support: base-4.15.0.0
+        - sendgrid-v3 < 0 # tried sendgrid-v3-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: aeson-1.5.6.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: base-4.15.0.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: base-4.15.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: http-client-0.7.9
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: lens-5.0.1
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: optparse-applicative-0.16.1.0
         - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
-        - sequence-formats < 0 # tried sequence-formats-1.6.1, but its *library* does not support: base-4.15.0.0
+        - sequence-formats < 0 # tried sequence-formats-1.6.1, but its *library* does not support: base-4.15.1.0
         - sequenceTools < 0 # tried sequenceTools-1.5.0, but its *library* requires the disabled package: sequence-formats
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: blaze-builder-0.4.2.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: cryptonite-0.29
@@ -6418,10 +6428,10 @@ packages:
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-0.18.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-server-0.18.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: time-1.9.3
-        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* does not support: base-4.15.0.0
+        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* does not support: base-4.15.1.0
         - servant-auth-server < 0 # tried servant-auth-server-0.4.6.0, but its *library* does not support: base64-bytestring-1.2.1.0
         - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* does not support: swagger2-2.7
-        - servant-errors < 0 # tried servant-errors-0.1.6.0, but its *library* does not support: base-4.15.0.0
+        - servant-errors < 0 # tried servant-errors-0.1.6.0, but its *library* does not support: base-4.15.1.0
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* does not support: aeson-1.5.6.0
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: containers-0.6.4.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: formatting-7.1.3
@@ -6429,27 +6439,27 @@ packages:
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: servant-0.18.3
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: time-1.9.3
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: QuickCheck-2.14.2
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: base-4.15.0.0
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: base-4.15.1.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: http-media-0.8.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: lens-5.0.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: pandoc-types-1.22.1
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: base-4.15.0.0
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: base-4.15.1.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: hspec-2.8.5
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: base-4.15.0.0
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: servant-0.18.3
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: base-4.15.0.0
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: http-media-0.8.0.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-0.18.3
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-client-core-0.18.3
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: base-4.15.0.0
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: http-media-0.8.0.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: servant-server-0.18.3
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires the disabled package: streaming-wai
-        - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: Cabal-3.4.0.0
-        - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: base-4.15.0.0
+        - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: Cabal-3.4.1.0
+        - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: base-4.15.1.0
         - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: lens-5.0.1
         - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* does not support: swagger2-2.7
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: base-4.15.0.0
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: base-4.15.1.0
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: servant-0.18.3
         - serverless-haskell < 0 # tried serverless-haskell-0.12.6, but its *library* requires the disabled package: amazonka-core
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-1.0.5, but its *library* does not support: base64-bytestring-1.2.1.0
@@ -6457,26 +6467,28 @@ packages:
         - serversession-frontend-yesod < 0 # tried serversession-frontend-yesod-1.0, but its *library* does not support: yesod-core-1.6.21.0
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* does not support: exceptions-0.10.4
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
-        - sexpr-parser < 0 # tried sexpr-parser-0.2.0.0, but its *library* does not support: base-4.15.0.0
+        - sexpr-parser < 0 # tried sexpr-parser-0.2.0.0, but its *library* does not support: base-4.15.1.0
         - sexpr-parser < 0 # tried sexpr-parser-0.2.0.0, but its *library* does not support: megaparsec-9.2.0
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* does not support: trifecta-2.1.2
-        - shower < 0 # tried shower-0.2.0.2, but its *library* does not support: base-4.15.0.0
+        - shower < 0 # tried shower-0.2.0.2, but its *library* does not support: base-4.15.1.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* does not support: template-haskell-2.17.0.0
         - size-based < 0 # tried size-based-0.1.2.0, but its *library* does not support: template-haskell-2.17.0.0
+        - sized < 0 # tried sized-1.0.0.0, but its *library* requires the disabled package: ghc-typelits-knownnat
+        - sized < 0 # tried sized-1.0.0.0, but its *library* requires the disabled package: type-natural
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: aeson-1.5.6.0
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: base-4.15.0.0
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: base-4.15.1.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: constraints-0.13.2
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: lens-5.0.1
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: random-1.2.1
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
-        - slack-web < 0 # tried slack-web-0.3.0.1, but its *library* does not support: base-4.15.0.0
+        - slack-web < 0 # tried slack-web-0.3.0.1, but its *library* does not support: base-4.15.1.0
         - slack-web < 0 # tried slack-web-0.3.0.1, but its *library* does not support: http-client-0.7.9
-        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* does not support: base-4.15.0.0
+        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* does not support: base-4.15.1.0
         - smash-lens < 0 # tried smash-lens-0.1.0.1, but its *library* does not support: lens-5.0.1
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: aeson-1.5.6.0
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: attoparsec-0.14.3
-        - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: base-4.15.0.0
+        - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: base-4.15.1.0
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: dlist-1.0
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: lens-5.0.1
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: mwc-random-0.15.0.2
@@ -6491,23 +6503,23 @@ packages:
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: jni
         - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* does not support: ad-4.5
         - speculation < 0 # tried speculation-1.5.0.3, but its *library* does not support: stm-2.5.0.0
-        - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* does not support: text-1.2.4.1
+        - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* does not support: text-1.2.5.0
         - stack < 0 # tried stack-2.7.3, but its *library* requires the disabled package: hackage-security
-        - streamproc < 0 # tried streamproc-1.6.2, but its *library* does not support: base-4.15.0.0
+        - streamproc < 0 # tried streamproc-1.6.2, but its *library* does not support: base-4.15.1.0
         - strict-base-types < 0 # tried strict-base-types-0.7, but its *library* requires the disabled package: strict-lens
-        - strict-tuple < 0 # tried strict-tuple-0.1.4, but its *library* does not support: base-4.15.0.0
+        - strict-tuple < 0 # tried strict-tuple-0.1.4, but its *library* does not support: base-4.15.1.0
         - strict-tuple-lens < 0 # tried strict-tuple-lens-0.2, but its *library* requires the disabled package: strict-tuple
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: hspec-2.8.5
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: hspec-core-2.8.5
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: random-1.2.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* does not support: haskell-src-exts-1.23.1
-        - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: Cabal-3.4.0.0
+        - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: Cabal-3.4.1.0
         - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: ghc-lib-parser-9.0.2.20211226
         - sv < 0 # tried sv-1.4.0.1, but its *library* does not support: attoparsec-0.14.3
-        - sv < 0 # tried sv-1.4.0.1, but its *library* does not support: base-4.15.0.0
+        - sv < 0 # tried sv-1.4.0.1, but its *library* does not support: base-4.15.1.0
         - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* does not support: attoparsec-0.14.3
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: attoparsec-0.14.3
-        - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: base-4.15.0.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: base-4.15.1.0
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: lens-5.0.1
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: profunctors-5.6.2
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: containers-0.6.4.1
@@ -6524,64 +6536,65 @@ packages:
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* does not support: tasty-1.4.2.1
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* does not support: time-1.9.3
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* does not support: network-3.1.2.5
-        - termbox < 0 # tried termbox-0.3.0, but its *library* does not support: base-4.15.0.0
+        - termbox < 0 # tried termbox-0.3.0, but its *library* does not support: base-4.15.1.0
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - termonad < 0 # tried termonad-4.2.0.0, but its *library* requires the disabled package: xml-html-qq
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract
         - testing-feat < 0 # tried testing-feat-1.1.0.0, but its *library* requires the disabled package: size-based
-        - text-all < 0 # tried text-all-0.4.2, but its *library* does not support: text-1.2.4.1
+        - text-all < 0 # tried text-all-0.4.2, but its *library* does not support: text-1.2.5.0
         - text-all < 0 # tried text-all-0.4.2, but its *library* does not support: text-format-0.3.2
-        - text-format < 0 # tried text-format-0.3.2, but its *library* does not support: base-4.15.0.0
+        - text-format < 0 # tried text-format-0.3.2, but its *library* does not support: base-4.15.1.0
         - text-generic-pretty < 0 # tried text-generic-pretty-1.2.1, but its *library* does not support: wl-pprint-text-1.2.0.1
         - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* does not support: template-haskell-2.17.0.0
-        - these-skinny < 0 # tried these-skinny-0.7.4, but its *library* does not support: base-4.15.0.0
+        - these-skinny < 0 # tried these-skinny-0.7.4, but its *library* does not support: base-4.15.1.0
         - threepenny-gui < 0 # tried threepenny-gui-0.9.1.0, but its *library* requires the disabled package: snap-server
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: threepenny-gui
         - thumbnail-plus < 0 # tried thumbnail-plus-1.0.5, but its *library* does not support: either-5.0.1.1
-        - token-bucket < 0 # tried token-bucket-0.1.0.1, but its *library* does not support: base-4.15.0.0
-        - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* does not support: base-4.15.0.0
-        - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* does not support: base-4.15.0.0
-        - tonatona < 0 # tried tonatona-0.1.2.1, but its *library* does not support: base-4.15.0.0
-        - tonatona-logger < 0 # tried tonatona-logger-0.2.0.2, but its *library* does not support: base-4.15.0.0
-        - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* does not support: base-4.15.0.0
+        - token-bucket < 0 # tried token-bucket-0.1.0.1, but its *library* does not support: base-4.15.1.0
+        - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* does not support: base-4.15.1.0
+        - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* does not support: base-4.15.1.0
+        - tonatona < 0 # tried tonatona-0.1.2.1, but its *library* does not support: base-4.15.1.0
+        - tonatona-logger < 0 # tried tonatona-logger-0.2.0.2, but its *library* does not support: base-4.15.1.0
+        - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* does not support: base-4.15.1.0
         - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* does not support: persistent-2.13.2.1
         - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* does not support: persistent-postgresql-2.13.2.1
-        - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: base-4.15.0.0
+        - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: base-4.15.1.0
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: persistent-2.13.2.1
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: persistent-sqlite-2.13.0.3
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: base-4.15.0.0
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: base-4.15.1.0
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-0.18.3
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-server-0.18.3
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: wai-extra-3.1.8
-        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: base-4.15.0.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: base-4.15.1.0
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: writer-cps-transformers-0.5.6.1
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* does not support: network-3.1.2.5
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
         - true-name < 0 # tried true-name-0.1.0.3, but its *library* does not support: template-haskell-2.17.0.0
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
+        - type-natural < 0 # tried type-natural-1.1.0.1, but its *library* requires the disabled package: ghc-typelits-natnormalise
         - tz < 0 # tried tz-0.1.3.5, but its *library* does not support: template-haskell-2.17.0.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: aeson-1.5.6.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: attoparsec-0.14.3
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: base-4.15.0.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: base-4.15.1.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: cryptonite-0.29
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: parser-combinators-1.3.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: aeson-1.5.6.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: base-4.15.0.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: base-4.15.1.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: base64-bytestring-1.2.1.0
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* does not support: attoparsec-0.14.3
         - uri-templater < 0 # tried uri-templater-0.3.1.0, but its *library* does not support: trifecta-2.1.2
         - urlpath < 0 # tried urlpath-9.0.1, but its *library* requires the disabled package: attoparsec-uri
-        - userid < 0 # tried userid-0.1.3.6, but its *library* does not support: base-4.15.0.0
+        - userid < 0 # tried userid-0.1.3.6, but its *library* does not support: base-4.15.1.0
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* does not support: text-short-0.1.5
         - vado < 0 # tried vado-0.0.13, but its *library* does not support: attoparsec-0.14.3
-        - vado < 0 # tried vado-0.0.13, but its *library* does not support: base-4.15.0.0
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* does not support: base-4.15.0.0
+        - vado < 0 # tried vado-0.0.13, but its *library* does not support: base-4.15.1.0
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* does not support: base-4.15.1.0
         - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* does not support: containers-0.6.4.1
         - vector-circular < 0 # tried vector-circular-0.1.3, but its *library* does not support: template-haskell-2.17.0.0
-        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* does not support: base-4.15.0.0
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: base-4.15.0.0
+        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* does not support: base-4.15.1.0
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: base-4.15.1.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: brick-0.65
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: lens-5.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: vty-5.33
@@ -6594,13 +6607,13 @@ packages:
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* does not support: attoparsec-0.14.3
-        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* does not support: base-4.15.0.0
+        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* does not support: base-4.15.1.0
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* does not support: dlist-1.0
         - web-routes-th < 0 # tried web-routes-th-0.22.6.6, but its *library* does not support: template-haskell-2.17.0.0
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: OneTuple-0.3.1
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: aeson-1.5.6.0
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: attoparsec-0.14.3
-        - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: base-4.15.0.0
+        - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: base-4.15.1.0
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: cryptonite-0.29
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: hspec-2.8.5
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: http-client-0.7.9
@@ -6610,7 +6623,7 @@ packages:
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - web3 < 0 # tried web3-0.9.1.0, but its *library* does not support: vinyl-0.13.3
         - webby < 0 # tried webby-1.0.1, but its *library* does not support: formatting-7.1.3
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* does not support: base-4.15.0.0
+        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* does not support: base-4.15.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* does not support: language-javascript-0.7.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* does not support: webdriver-0.9.0.1
         - websockets-snap < 0 # tried websockets-snap-0.10.3.1, but its *library* requires the disabled package: snap-server
@@ -6647,7 +6660,7 @@ packages:
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: containers-0.6.4.1
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: flat-0.4.4
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: model-0.5
-        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* does not support: base-4.15.0.0
+        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* does not support: base-4.15.1.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* does not support: storable-record-0.0.6
     # End of Library and exe bounds failures
 
@@ -7066,7 +7079,7 @@ skipped-tests:
     - drawille # tried drawille-0.1.2.0, but its *test-suite* does not support: hspec-2.8.5
     - dual-tree # tried dual-tree-0.2.3.0, but its *test-suite* requires the disabled package: testing-feat
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* does not support: QuickCheck-2.14.2
-    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* does not support: directory-1.3.6.1
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* does not support: directory-1.3.6.2
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* does not support: doctest-0.18.2
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* does not support: hlint-3.3.6
     - edit # tried edit-1.0.1.0, but its *test-suite* does not support: doctest-0.18.2
@@ -7110,9 +7123,10 @@ skipped-tests:
     - hasmin # tried hasmin-1.0.3, but its *test-suite* does not support: doctest-0.18.2
     - heist # tried heist-1.1.0.1, but its *test-suite* does not support: lens-5.0.1
     - hidden-char # tried hidden-char-0.1.0.2, but its *test-suite* does not support: hspec-2.8.5
+    - hmatrix-vector-sized # tried hmatrix-vector-sized-0.1.3.0, but its *test-suite* requires the disabled package: ghc-typelits-knownnat
     - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* does not support: hspec-2.8.5
     - http-media # tried http-media-0.8.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
-    - http-media # tried http-media-0.8.0.0, but its *test-suite* does not support: base-4.15.0.0
+    - http-media # tried http-media-0.8.0.0, but its *test-suite* does not support: base-4.15.1.0
     - http-streams # tried http-streams-0.8.9.4, but its *test-suite* requires the disabled package: snap-server
     - hw-balancedparens # tried hw-balancedparens-0.4.1.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-bits # tried hw-bits-0.7.2.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
@@ -7148,7 +7162,7 @@ skipped-tests:
     - lrucaching # tried lrucaching-0.3.3, but its *test-suite* does not support: hspec-2.8.5
     - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: Glob-0.10.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
-    - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: base-4.15.0.0
+    - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: base-4.15.1.0
     - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: doctest-0.18.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: tasty-1.4.2.1
     - makefile # tried makefile-1.1.0.0, but its *test-suite* does not support: tasty-hunit-0.10.0.3
@@ -7183,7 +7197,7 @@ skipped-tests:
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-th
     - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* does not support: QuickCheck-2.14.2
     - scalendar # tried scalendar-1.2.0, but its *test-suite* requires the disabled package: SCalendar
-    - schematic # tried schematic-0.5.1.0, but its *test-suite* does not support: base-4.15.0.0
+    - schematic # tried schematic-0.5.1.0, but its *test-suite* does not support: base-4.15.1.0
     - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* does not support: hspec-discover-2.8.5
     - servant-auth-server # tried servant-auth-server-0.4.6.0, but its *test-suite* does not support: hspec-2.8.5
     - servant-auth-server # tried servant-auth-server-0.4.6.0, but its *test-suite* does not support: hspec-discover-2.8.5
@@ -7230,6 +7244,7 @@ skipped-tests:
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* does not support: tasty-1.4.2.1
     - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
     - transient # tried transient-0.7.0.0, but its *test-suite* does not support: random-1.2.1
+    - typerep-map # tried typerep-map-0.4.0.0, but its *test-suite* requires the disabled package: ghc-typelits-knownnat
     - tzdata # tried tzdata-0.2.20201021.0, but its *test-suite* requires the disabled package: test-framework-th
     - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
     - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* does not support: generic-random-1.5.0.1
@@ -7797,6 +7812,7 @@ skipped-benchmarks:
     - superbuffer # tried superbuffer-0.3.1.1, but its *benchmarks* does not support: criterion-1.5.12.0
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: criterion-plus
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: stm-stats
+    - typerep-map # tried typerep-map-0.4.0.0, but its *benchmarks* requires the disabled package: ghc-typelits-knownnat
     - tz # tried tz-0.1.3.5, but its *benchmarks* requires the disabled package: thyme
     - unicode-transforms # tried unicode-transforms-0.4.0, but its *benchmarks* does not support: path-0.9.2
     - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: xxhash


### PR DESCRIPTION
Current bounds issues:

```
        - unicode-transforms < 0 # tried unicode-transforms-0.3.8, but its *library* does not support: text-1.2.5.0
        - clash-ghc < 0 # tried clash-ghc-1.4.6, but its *library* does not support: ghc-bignum-1.1
        - clash-lib < 0 # tried clash-lib-1.4.6, but its *library* does not support: ghc-bignum-1.1
        - clash-prelude < 0 # tried clash-prelude-1.4.6, but its *library* does not support: ghc-bignum-1.1
        - ghc-typelits-extra < 0 # tried ghc-typelits-extra-0.4.3, but its *library* does not support: ghc-bignum-1.1
        - ghc-typelits-natnormalise < 0 # tried ghc-typelits-natnormalise-0.7.6, but its *library* does not support: ghc-bignum-1.1
        - hashable < 0 # tried hashable-1.3.5.0, but its *library* does not support: ghc-bignum-1.1
 ```
 
We should wait for hashable (https://github.com/haskell-unordered-containers/hashable/pull/239). May need to close #6268, ~#6337~, ~#6313~.

Ping  @martijnbastiaan
