### PR TITLE
Add new package `doctest-parallel`. Allow haddock failure (due to #5014)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2190,6 +2190,7 @@ packages:
 
     "Martijn Bastiaan <martijn@hmbastiaan.nl> @martijnbastiaan":
         - aeson-pretty
+        - doctest-parallel
 
     "Athan Clark <athan.clark@gmail.com> @athanclark":
         - aeson-attoparsec
@@ -7649,6 +7650,7 @@ expected-haddock-failures:
     - hw-ip # https://github.com/commercialhaskell/stackage/issues/5014
     - hw-json # https://github.com/commercialhaskell/stackage/issues/5014
     - hw-rankselect
+    - doctest-parallel # https://github.com/commercialhaskell/stackage/issues/5014
 
 # end of expected-haddock-failures
 


### PR DESCRIPTION
This is an extremely useful package, since it works much better than `doctest`. However ran into a known issue #5014 thus allowed haddock failure:

```
doctest-parallel    > Documentation created:
doctest-parallel    > .stack-work/dist/x86_64-linux-tinfo6/Cabal-3.4.0.0/doc/html/doctest-parallel/index.html,
doctest-parallel    > Cabal-simple_mPHDZzAJ_3.4.0.0_ghc-9.0.1: internal error when calculating
doctest-parallel    > .stack-work/dist/x86_64-linux-tinfo6/Cabal-3.4.0.0/doc/html/doctest-parallel/doctest-parallel.txt
doctest-parallel    > transitive package dependencies.
doctest-parallel    > Preprocessing test suite 'doctests' for doctest-parallel-0.2..
doctest-parallel    > Debug info: []
```

@martijnbastiaan I hope you don't mind me adding your package to stackage, I was waiting for somebody to finally fix the buggy `doctest`, so thank you for getting it done. Let me know if you'd like me to add it under your name instead, which means you'll be pinged if there are any compatibility issues with `doctest-parallel` and other packages on stackage in the future.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
