### PR TITLE
Add captcha-core, captcha-2captcha, captcha-capmonster

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7008,6 +7008,9 @@ skipped-tests:
     - hpqtypes-extras # needs a running postgres database
     # norfairking
     - autodocodec # runs doctest
+    - captcha-core
+    - captcha-2captcha
+    - captcha-capmonster
 
     # Uses Cabal's "library internal" stanza feature
     - s3-signer

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4730,6 +4730,11 @@ packages:
     "Ghais Issa <0x47@0x49.dev> @ghais":
         - LetsBeRational
 
+    "Edward Yang <qwbarch@gmail.com> @qwbarch":
+        - captcha-core
+        - captcha-2captcha
+        - captcha-capmonster
+
     "Grandfathered dependencies":
         - Boolean
         - Decimal

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4734,6 +4734,7 @@ packages:
         - captcha-core
         - captcha-2captcha
         - captcha-capmonster
+        - data-default-extras
 
     "Grandfathered dependencies":
         - Boolean

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4734,7 +4734,7 @@ packages:
         - captcha-core
         - captcha-2captcha
         - captcha-capmonster
-        - data-default-extras
+        - data-default-extra
 
     "Grandfathered dependencies":
         - Boolean

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4735,6 +4735,13 @@ packages:
         - captcha-2captcha
         - captcha-capmonster
         - data-default-extra
+        - data-default-instances-base
+        - data-default-instances-bytestring
+        - data-default-instances-case-insensitive
+        - data-default-instances-new-base
+        - data-default-instances-text
+        - data-default-instances-unordered-containers
+        - data-default-instances-vector
 
     "Grandfathered dependencies":
         - Boolean


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

These packages relies on the [data-default-extra](https://hackage.haskell.org/package/data-default-extra) package.  
The ``MAINTAINERS.md`` instructions mentions to add non-stackage dependencies to the ``build-constraints.yaml``, which I've done.  
Not sure if it'll be fine as the ``verify-package`` script fails due to ``data-default-extra`` not being on stackage.  
The packages otherwise builds fine against ``stack-nightly-2022-01-06``.