### PR TITLE
Remove `clash-*` from bound failure list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5706,9 +5706,6 @@ packages:
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: bytesmith
         - chronos-bench < 0 # tried chronos-bench-0.2.0.2, but its *library* requires the disabled package: chronos
         - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* does not support: base-4.15.1.0
-        - clash-ghc < 0 # tried clash-ghc-1.4.6, but its *library* does not support: ghc-bignum-1.1
-        - clash-lib < 0 # tried clash-lib-1.4.6, but its *library* does not support: ghc-bignum-1.1
-        - clash-prelude < 0 # tried clash-prelude-1.4.6, but its *library* does not support: ghc-bignum-1.1
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* does not support: base-4.15.1.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* does not support: template-haskell-2.17.0.0
         - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* does not support: clock-0.8.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5853,7 +5853,6 @@ packages:
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: dhall-1.40.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: ghc-9.0.2
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* does not support: ghc-9.0.2
-        - ghc-typelits-extra < 0 # tried ghc-typelits-extra-0.4.3, but its *library* does not support: ghc-bignum-1.1
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires the disabled package: ghcjs-dom-jsaddle
         - gi-gsk < 0 # tried gi-gsk-4.0.4, but its *library* does not support: gi-gdk-3.0.25
         - gi-webkit2 < 0 # tried gi-webkit2-4.0.28, but its *library* requires the disabled package: gi-soup


### PR DESCRIPTION
v1.4.7 supports up-to-date `ghc-bignum`s

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

I've run the last command, but it complains about `ghc-typelits-extra`, which should be fixed by the second commit in this PR.