### PR TITLE
Fix nvim-hs test suite failure

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7667,8 +7667,6 @@ expected-test-failures:
     - threads # https://github.com/basvandijk/threads/issues/10
     - tmp-postgres # https://github.com/jfischoff/tmp-postgres/issues/1
     - yesod-core # https://github.com/yesodweb/yesod/issues/1711
-    
-    - nvim-hs # https://github.com/commercialhaskell/stackage/issues/6425
 
     # Please review the sections above before adding packages to a new section or to Misc.
 


### PR DESCRIPTION
Fixes #6425 

Version 2.2.0.1 of nvim-hs doesn't fail tests if nvim isn't installed. I've also added a comment in that test file, so that this is less likely to happen in the future. https://github.com/neovimhaskell/nvim-hs/commit/1e6bafbab5d69605e564c52e1d7549970b440200

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # with and without nvim executable on path
