### PR TITLE
Enable all of tz and tzdata

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6571,7 +6571,6 @@ packages:
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
         - true-name < 0 # tried true-name-0.1.0.3, but its *library* does not support: template-haskell-2.17.0.0
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
-        - tz < 0 # tried tz-0.1.3.5, but its *library* does not support: template-haskell-2.17.0.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: aeson-1.5.6.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: attoparsec-0.14.4
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: base-4.15.1.0
@@ -7254,7 +7253,6 @@ skipped-tests:
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* does not support: tasty-1.4.2.1
     - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
     - transient # tried transient-0.7.0.0, but its *test-suite* does not support: random-1.2.1
-    - tzdata # tried tzdata-0.2.20201021.0, but its *test-suite* requires the disabled package: test-framework-th
     - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
     - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* does not support: generic-random-1.5.0.1
     - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* does not support: hspec-2.8.5


### PR DESCRIPTION
New releases are available for these packages and the reasons mentioned in these comments no longer apply for the newest versions.

EDIT: The CI failure seems unrelated to these packages.