### PR TITLE
Revert "Upgrade to aeson 2.0, closes #6217"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1670,15 +1670,15 @@ packages:
         - bank-holidays-england
 
     "Haskell Servant <haskell-servant-maintainers@googlegroups.com>":
-        - servant >= 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
+        - servant < 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
         - servant-blaze
         - servant-cassava
-        - servant-client >= 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
-        - servant-client-core >= 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
+        - servant-client < 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
+        - servant-client-core < 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
         - servant-conduit
         - servant-docs
         - servant-foreign
-        - servant-http-streams >= 0.18.4 # https://github.com/commercialhaskell/stackage/issues/6429
+        - servant-http-streams < 0.18.4 # https://github.com/commercialhaskell/stackage/issues/6429
         - servant-js
         - servant-lucid
         - servant-machines
@@ -1686,7 +1686,7 @@ packages:
         - servant-multipart
         - servant-multipart-api
         - servant-pipes
-        - servant-server >= 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
+        - servant-server < 0.19 # https://github.com/commercialhaskell/stackage/issues/6429
         - servant-swagger
         - servant-swagger-ui
         - servant-swagger-ui-core
@@ -3725,7 +3725,7 @@ packages:
         - wai-middleware-rollbar
 
     "Andrey Mokhov <andrey.mokhov@gmail.com> @snowleopard":
-        - algebraic-graphs
+        - algebraic-graphs < 0.6 # https://github.com/commercialhaskell/stackage/issues/6362
 
     "Albert Krewinkel <albert+stackage@zeitkraut.de> @tarleb":
         - hslua
@@ -5311,7 +5311,6 @@ packages:
         - xxhash < 0 # compile fail
         - universe-instances-base < 0 # deprecated
         - universe-instances-trans < 0 # deprecated
-        - 2captcha < 0 # deprecated
 
     "GHC upper bounds":
         # Need to always match the version shipped with GHC
@@ -5447,12 +5446,10 @@ packages:
     # verify if they have been fixeq.
     "Library and exe bounds failures":
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* does not support: network-3.1.2.7
-        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: Taxonomy
         - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* does not support: network-3.1.2.7
-        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseBlast
         - Chart-cairo < 0 # tried Chart-cairo-1.9.3, but its *library* requires the disabled package: cairo
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.3, but its *library* does not support: SVGFonts-1.8.0.1
-        - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
+        - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: biocore
         - FPretty < 0 # tried FPretty-1.1, but its *library* does not support: base-4.15.1.0
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* does not support: linear-1.21.8
         - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
@@ -5464,7 +5461,7 @@ packages:
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *executable* does not support: optparse-applicative-0.16.1.0
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *executable* does not support: wai-logger-2.4.0
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: IPv6Addr-2.0.4
-        - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: aeson-2.0.3.0
+        - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: aeson-1.5.6.0
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: attoparsec-0.14.4
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: hedis-0.15.1
         - IPv6DB < 0 # tried IPv6DB-0.3.2, but its *library* does not support: unordered-containers-0.2.16.0
@@ -5476,13 +5473,12 @@ packages:
         - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* does not support: base-4.15.1.0
         - Network-NineP < 0 # tried Network-NineP-0.4.7.1, but its *library* requires the disabled package: mstate
         - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* does not support: base-4.15.1.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseBlast-0.3.3.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseFasta-0.4.0.1
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseHTTP-1.2.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: BiobaseTypes-0.2.1.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: aeson-2.0.3.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: aeson-1.5.6.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* does not support: network-3.1.2.7
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: hierarchical-clustering
         - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
@@ -5520,14 +5516,9 @@ packages:
         - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* does not support: accelerate-1.3.0.0
-        - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.0, but its *library* does not support: aeson-2.0.3.0
-        - aeson-default < 0 # tried aeson-default-0.9.1.0, but its *library* does not support: aeson-2.0.3.0
         - aeson-diff < 0 # tried aeson-diff-1.1.0.9, but its *library* does not support: base-4.15.1.0
-        - aeson-injector < 0 # tried aeson-injector-1.1.5.0, but its *library* does not support: aeson-2.0.3.0
         - aeson-injector < 0 # tried aeson-injector-1.1.5.0, but its *library* does not support: lens-5.0.1
         - aeson-injector < 0 # tried aeson-injector-1.1.5.0, but its *library* does not support: servant-docs-0.12
-        - aeson-iproute < 0 # tried aeson-iproute-0.2.1, but its *library* does not support: aeson-2.0.3.0
-        - aeson-picker < 0 # tried aeson-picker-0.1.0.5, but its *library* does not support: aeson-2.0.3.0
         - aeson-picker < 0 # tried aeson-picker-0.1.0.5, but its *library* does not support: lens-5.0.1
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: base64-bytestring-1.2.1.0
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: bytestring-trie-0.2.6
@@ -5561,7 +5552,6 @@ packages:
         - amazonka-cognito-idp < 0 # tried amazonka-cognito-idp-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-cognito-sync < 0 # tried amazonka-cognito-sync-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-config < 0 # tried amazonka-config-1.6.1, but its *library* requires the disabled package: amazonka-core
-        - amazonka-core < 0 # tried amazonka-core-1.6.1, but its *library* does not support: aeson-2.0.3.0
         - amazonka-core < 0 # tried amazonka-core-1.6.1, but its *library* does not support: http-client-0.7.11
         - amazonka-datapipeline < 0 # tried amazonka-datapipeline-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-devicefarm < 0 # tried amazonka-devicefarm-1.6.1, but its *library* requires the disabled package: amazonka-core
@@ -5648,12 +5638,6 @@ packages:
         - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* does not support: template-haskell-2.17.0.0
         - asif < 0 # tried asif-6.0.4, but its *library* requires the disabled package: thyme
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* does not support: unliftio-core-0.2.0.1
-        - aura < 0 # tried aura-3.2.7, but its *library* does not support: hashable-1.3.5.0
-        - autodocodec-openapi3 < 0 # tried autodocodec-openapi3-0.1.0.0, but its *library* requires the disabled package: autodocodec
-        - autodocodec-schema < 0 # tried autodocodec-schema-0.1.0.0, but its *library* requires the disabled package: autodocodec
-        - autodocodec-schema < 0 # tried autodocodec-schema-0.1.0.0, but its *library* requires the disabled package: validity-aeson
-        - autodocodec-yaml < 0 # tried autodocodec-yaml-0.1.0.0, but its *library* requires the disabled package: autodocodec
-        - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: aeson-2.0.3.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: attoparsec-0.14.4
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: base-4.15.1.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* does not support: cryptonite-0.29
@@ -5665,7 +5649,7 @@ packages:
         - aws-xray-client-wai < 0 # tried aws-xray-client-wai-0.1.0.1, but its *library* requires the disabled package: aws-xray-client
         - axel < 0 # tried axel-0.0.12, but its *library* does not support: base-4.15.1.0
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient-universe
-        - b9 < 0 # tried b9-3.2.0, but its *library* does not support: aeson-2.0.3.0
+        - b9 < 0 # tried b9-3.2.0, but its *library* does not support: aeson-1.5.6.0
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: hspec-2.8.5
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: lens-5.0.1
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: shake-0.19.6
@@ -5674,7 +5658,7 @@ packages:
         - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* does not support: base-4.15.1.0
         - bcp47 < 0 # tried bcp47-0.2.0.5, but its *library* requires the disabled package: country
         - bcp47-orphans < 0 # tried bcp47-orphans-0.1.0.4, but its *library* requires the disabled package: bcp47
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: aeson-2.0.3.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: aeson-1.5.6.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: beam-core-0.9.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: hashable-1.3.5.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: mysql-0.2.1
@@ -5709,31 +5693,25 @@ packages:
         - bitcoin-tx < 0 # tried bitcoin-tx-0.13.1, but its *library* requires the disabled package: hexstring
         - bitcoin-types < 0 # tried bitcoin-types-0.9.2, but its *library* requires the disabled package: hexstring
         - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
-        - bloodhound < 0 # tried bloodhound-0.18.0.0, but its *library* does not support: aeson-2.0.3.0
         - blosum < 0 # tried blosum-0.1.1.4, but its *executable* requires the disabled package: pipes-text
         - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* does not support: base-4.15.1.0
         - boundingboxes < 0 # tried boundingboxes-0.2.3, but its *library* does not support: lens-5.0.1
-        - bower-json < 0 # tried bower-json-1.0.0.1, but its *library* requires the disabled package: aeson-better-errors
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires the disabled package: butcher
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires the disabled package: data-tree-print
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* does not support: aeson-1.5.6.0
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* does not support: yaml-0.11.6.0
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - butcher < 0 # tried butcher-1.3.3.2, but its *library* does not support: base-4.15.1.0
         - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: Cabal-3.4.1.0
         - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* does not support: base-4.15.1.0
         - cairo < 0 # tried cairo-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* does not support: aeson-2.0.3.0
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* does not support: aeson-2.0.3.0
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* does not support: aeson-2.0.3.0
         - category < 0 # tried category-0.2.5.0, but its *library* requires the disabled package: alg
         - cereal-time < 0 # tried cereal-time-0.1.0.0, but its *library* does not support: time-1.9.3
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: aeson-2.0.3.0
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: aeson-1.5.6.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: aeson-casing-0.2.0.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: connection-0.3.1
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: http-api-data-0.4.3
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: http-client-0.7.11
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* does not support: req-3.10.0
-        - chronos < 0 # tried chronos-1.1.3, but its *library* does not support: aeson-2.0.3.0
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: bytebuild
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: byteslice
         - chronos < 0 # tried chronos-1.1.3, but its *library* requires the disabled package: bytesmith
@@ -5746,14 +5724,11 @@ packages:
         - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires the disabled package: co-log-core
         - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
         - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
-        - composite-aeson < 0 # tried composite-aeson-0.7.5.0, but its *library* does not support: aeson-2.0.3.0
         - composite-aeson < 0 # tried composite-aeson-0.7.5.0, but its *library* does not support: generic-deriving-1.14.1
         - composite-aeson < 0 # tried composite-aeson-0.7.5.0, but its *library* does not support: profunctors-5.6.2
         - composite-aeson < 0 # tried composite-aeson-0.7.5.0, but its *library* does not support: template-haskell-2.17.0.0
         - composite-aeson-path < 0 # tried composite-aeson-path-0.7.5.0, but its *library* does not support: path-0.9.2
-        - composite-aeson-refined < 0 # tried composite-aeson-refined-0.7.5.0, but its *library* requires the disabled package: aeson-better-errors
         - composite-aeson-refined < 0 # tried composite-aeson-refined-0.7.5.0, but its *library* requires the disabled package: composite-aeson
-        - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: aeson-better-errors
         - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: composite-aeson
         - composite-base < 0 # tried composite-base-0.7.5.0, but its *library* does not support: profunctors-5.6.2
         - composite-base < 0 # tried composite-base-0.7.5.0, but its *library* does not support: template-haskell-2.17.0.0
@@ -5774,7 +5749,6 @@ packages:
         - configurator-pg < 0 # tried configurator-pg-0.2.5, but its *library* does not support: base-4.15.1.0
         - configurator-pg < 0 # tried configurator-pg-0.2.5, but its *library* does not support: megaparsec-9.2.0
         - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
-        - country < 0 # tried country-0.2.1, but its *library* does not support: aeson-2.0.3.0
         - country < 0 # tried country-0.2.1, but its *library* does not support: attoparsec-0.14.4
         - country < 0 # tried country-0.2.1, but its *library* does not support: base-4.15.1.0
         - cql-io < 0 # tried cql-io-1.1.1, but its *library* requires the disabled package: cql
@@ -5785,7 +5759,6 @@ packages:
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: simple-vec3-0.6.0.1
         - csg < 0 # tried csg-0.1.0.6, but its *library* does not support: strict-0.4.0.1
         - css-syntax < 0 # tried css-syntax-0.1.0.0, but its *library* does not support: base-4.15.1.0
-        - curl-runnings < 0 # tried curl-runnings-0.16.4, but its *library* does not support: aeson-2.0.3.0
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: Cabal-3.4.1.0
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: attoparsec-0.14.4
         - darcs < 0 # tried darcs-2.16.4, but its *library* does not support: base-4.15.1.0
@@ -5798,7 +5771,7 @@ packages:
         - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* does not support: base-4.15.1.0
         - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
         - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* does not support: base-4.15.1.0
-        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.0.17, but its *library* does not support: aeson-2.0.3.0
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.0.17, but its *library* requires the disabled package: haskell-lsp
         - dhall-nix < 0 # tried dhall-nix-1.1.23, but its *library* requires the disabled package: hnix
         - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires the disabled package: haskell-src-exts-simple
         - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires the disabled package: statestack
@@ -5813,7 +5786,6 @@ packages:
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* requires the disabled package: statestack
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.1, but its *library* requires the disabled package: static-canvas
         - diagrams-postscript < 0 # tried diagrams-postscript-1.5.1, but its *library* requires the disabled package: statestack
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* does not support: aeson-2.0.3.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* does not support: base-4.15.1.0
         - dice < 0 # tried dice-0.1.0.1, but its *library* requires the disabled package: random-fu
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* does not support: criterion-1.5.13.0
@@ -5840,21 +5812,18 @@ packages:
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* does not support: containers-0.6.4.1
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* does not support: random-1.2.1
         - diversity < 0 # tried diversity-0.8.1.0, but its *library* requires the disabled package: fasta
-        - docker < 0 # tried docker-0.6.0.6, but its *library* does not support: aeson-2.0.3.0
         - docker < 0 # tried docker-0.6.0.6, but its *library* does not support: unliftio-core-0.2.0.1
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* does not support: language-docker-10.4.0
         - dom-parser < 0 # tried dom-parser-3.1.0, but its *library* requires the disabled package: xml-lens
         - drawille < 0 # tried drawille-0.1.2.0, but its *library* does not support: containers-0.6.4.1
         - earcut < 0 # tried earcut-0.1.0.4, but its *library* does not support: base-4.15.1.0
         - easytest < 0 # tried easytest-0.3, but its *library* does not support: hedgehog-1.0.5
-        - ede < 0 # tried ede-0.3.2.0, but its *library* does not support: aeson-2.0.3.0
         - edit < 0 # tried edit-1.0.1.0, but its *library* does not support: QuickCheck-2.14.2
         - edit < 0 # tried edit-1.0.1.0, but its *library* does not support: base-4.15.1.0
         - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* does not support: free-5.1.7
         - egison < 0 # tried egison-4.1.3, but its *library* requires the disabled package: sweet-egison
         - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* does not support: parser-combinators-1.3.0
         - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* does not support: template-haskell-2.17.0.0
-        - ekg < 0 # tried ekg-0.4.0.15, but its *library* does not support: aeson-2.0.3.0
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* does not support: base-4.15.1.0
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires the disabled package: snap-server
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: amazonka
@@ -5862,12 +5831,9 @@ packages:
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: ekg-core
         - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* does not support: base-4.15.1.0
         - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* does not support: ghc-prim-0.7.0
-        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* does not support: aeson-2.0.3.0
         - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* does not support: base-4.15.1.0
         - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* does not support: base-4.15.1.0
         - ekg-wai < 0 # tried ekg-wai-0.1.0.3, but its *library* does not support: time-1.9.3
-        - elm-street < 0 # tried elm-street-0.1.0.4, but its *executable* does not support: servant-0.19
-        - elm-street < 0 # tried elm-street-0.1.0.4, but its *executable* does not support: servant-server-0.19
         - elm-street < 0 # tried elm-street-0.1.0.4, but its *library* does not support: base-4.15.1.0
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
         - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
@@ -5877,9 +5843,7 @@ packages:
         - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: eventful-sql-common
         - eventful-sql-common < 0 # tried eventful-sql-common-0.2.0, but its *library* does not support: persistent-template-2.12.0.0
         - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: eventful-sql-common
-        - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-api
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
-        - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
         - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.4, but its *library* does not support: template-haskell-2.17.0.0
         - fasta < 0 # tried fasta-0.10.4.2, but its *library* requires the disabled package: pipes-text
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
@@ -5887,7 +5851,6 @@ packages:
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: BiobaseNewick
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: hierarchical-clustering
         - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
-        - freckle-app < 0 # tried freckle-app-1.0.0.4, but its *library* requires the disabled package: datadog
         - friday < 0 # tried friday-0.2.3.1, but its *library* does not support: containers-0.6.4.1
         - friday < 0 # tried friday-0.2.3.1, but its *library* requires the disabled package: ratio-int
         - friday-juicypixels < 0 # tried friday-juicypixels-0.1.2.4, but its *library* requires the disabled package: friday
@@ -5898,14 +5861,6 @@ packages:
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: base-4.15.1.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: generic-deriving-1.14.1
-        - genvalidity-aeson < 0 # tried genvalidity-aeson-1.0.0.0, but its *library* requires the disabled package: validity-aeson
-        - genvalidity-mergeful < 0 # tried genvalidity-mergeful-0.3.0.0, but its *library* requires the disabled package: mergeful
-        - genvalidity-sydtest < 0 # tried genvalidity-sydtest-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-hashable < 0 # tried genvalidity-sydtest-hashable-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-lens < 0 # tried genvalidity-sydtest-lens-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-persistent < 0 # tried genvalidity-sydtest-persistent-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-typed-uuid < 0 # tried genvalidity-typed-uuid-0.1.0.1, but its *library* requires the disabled package: typed-uuid
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: dhall-1.40.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* does not support: ghc-9.0.2
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* does not support: ghc-9.0.2
@@ -5929,10 +5884,8 @@ packages:
         - gitlib-libgit2 < 0 # tried gitlib-libgit2-3.1.2.1, but its *library* requires the disabled package: gitlib
         - glaze < 0 # tried glaze-0.3.0.1, but its *library* does not support: lens-5.0.1
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
-        - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: glazier
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
-        - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
         - glib < 0 # tried glib-0.13.8.1, but its *library* does not support: Cabal-3.4.1.0
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
@@ -6040,29 +5993,22 @@ packages:
         - google-translate < 0 # tried google-translate-0.5, but its *library* does not support: http-api-data-0.4.3
         - google-translate < 0 # tried google-translate-0.5, but its *library* does not support: http-client-0.7.11
         - graphql-client < 0 # tried graphql-client-1.1.1, but its *executable* does not support: path-0.9.2
-        - graphql-client < 0 # tried graphql-client-1.1.1, but its *library* does not support: aeson-2.0.3.0
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* does not support: groundhog-0.12.0
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* does not support: groundhog-th-0.12
         - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* does not support: mysql-0.2.1
-        - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* does not support: aeson-2.0.3.0
         - grouped-list < 0 # tried grouped-list-0.2.2.1, but its *library* does not support: base-4.15.1.0
         - gtk3 < 0 # tried gtk3-0.15.6, but its *library* does not support: Cabal-3.4.1.0
         - hOpenPGP < 0 # tried hOpenPGP-2.9.7, but its *library* requires the disabled package: ixset-typed
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: http-client-0.7.11
-        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: servant-0.19
-        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: servant-client-0.19
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: servant-0.18.3
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* does not support: servant-client-0.18.3
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* does not support: deepseq-1.4.5.0
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* requires the disabled package: colourista
         - hadolint < 0 # tried hadolint-2.8.0, but its *library* requires the disabled package: spdx
-        - hal < 0 # tried hal-0.4.8, but its *library* does not support: aeson-2.0.3.0
-        - hapistrano < 0 # tried hapistrano-0.4.3.0, but its *library* does not support: aeson-2.0.3.0
         - hapistrano < 0 # tried hapistrano-0.4.3.0, but its *library* does not support: path-0.9.2
         - happstack-hsp < 0 # tried happstack-hsp-7.3.7.5, but its *library* requires the disabled package: harp
-        - happstack-jmacro < 0 # tried happstack-jmacro-7.0.12.3, but its *library* requires the disabled package: jmacro
         - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *executable* does not support: base-4.15.1.0
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* does not support: aeson-2.0.3.0
         - haskell-lsp-client < 0 # tried haskell-lsp-client-1.0.0.1, but its *library* requires the disabled package: haskell-lsp
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* does not support: aeson-2.0.3.0
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: base-4.15.1.0
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
@@ -6081,7 +6027,7 @@ packages:
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: Cabal-3.4.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: Diff-0.4.1
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: aeson-2.0.3.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: base-4.15.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* does not support: network-3.1.2.7
@@ -6095,7 +6041,7 @@ packages:
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: haskell-tools-builtin-refactorings
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: aeson-2.0.3.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: base-4.15.1.0
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* does not support: warp-3.3.19
@@ -6105,7 +6051,7 @@ packages:
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: Cabal-3.4.1.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: aeson-2.0.3.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: aeson-1.5.6.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: base-4.15.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: ghc-9.0.2
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* does not support: template-haskell-2.17.0.0
@@ -6120,8 +6066,7 @@ packages:
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* does not support: optparse-applicative-0.16.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* does not support: attoparsec-0.14.4
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: haxl
-        - headroom < 0 # tried headroom-0.4.3.0, but its *library* requires the disabled package: mustache
-        - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: aeson-2.0.3.0
+        - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: aeson-1.5.6.0
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: attoparsec-0.14.4
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: base-4.15.1.0
         - heist < 0 # tried heist-1.1.0.1, but its *library* does not support: dlist-1.0
@@ -6130,35 +6075,28 @@ packages:
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: optparse-applicative-0.16.1.0
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: semigroups-0.19.2
         - herms < 0 # tried herms-1.9.0.4, but its *executable* does not support: vty-5.33
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: aeson-2.0.3.0
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: base-4.15.1.0
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* does not support: template-haskell-2.17.0.0
         - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* does not support: base-4.15.1.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* does not support: base-4.15.1.0
-        - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
-        - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
+        - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: swagger2
+        - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: swagger2
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart-diagrams
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmpfr < 0 # tried hmpfr-0.4.4, but its *library* does not support: integer-gmp-1.1
-        - hnix-store-core < 0 # tried hnix-store-core-0.5.0.0, but its *library* does not support: algebraic-graphs-0.6
-        - hoauth2 < 0 # tried hoauth2-2.0.0, but its *library* does not support: aeson-2.0.3.0
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.6, but its *executable* requires the disabled package: ixset-typed
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: aeson-2.0.3.0
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: aeson-1.5.6.0
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: containers-0.6.4.1
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: retry-0.9.1.0
-        - hpc-lcov < 0 # tried hpc-lcov-1.0.1, but its *executable* does not support: aeson-2.0.3.0
         - hpc-lcov < 0 # tried hpc-lcov-1.0.1, but its *executable* does not support: path-0.9.2
         - hpio < 0 # tried hpio-0.9.0.7, but its *executable* does not support: optparse-applicative-0.16.1.0
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* does not support: QuickCheck-2.14.2
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* does not support: protolude-0.3.0
-        - hpqtypes < 0 # tried hpqtypes-1.9.2.1, but its *library* does not support: aeson-2.0.3.0
-        - hpqtypes-extras < 0 # tried hpqtypes-extras-1.14.1.0, but its *library* requires the disabled package: hpqtypes
-        - hpqtypes-extras < 0 # tried hpqtypes-extras-1.14.1.0, but its *library* requires the disabled package: log-base
         - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: containers-0.6.4.1
         - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: hmatrix-0.20.2
-        - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: statistics-0.16.0.1
+        - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: statistics-0.15.2.0
         - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: time-1.9.3
         - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* does not support: vector-algorithms-0.8.0.4
         - hquantlib < 0 # tried hquantlib-0.0.5.0, but its *library* requires the disabled package: hmatrix-special
@@ -6167,7 +6105,6 @@ packages:
         - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-quickcheck < 0 # tried hschema-quickcheck-0.0.1.1, but its *library* requires the disabled package: hschema
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: aeson-2.0.3.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: attoparsec-0.14.4
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: ghc-boot-9.0.2
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* does not support: ghc-lib-parser-9.0.2.20211226
@@ -6181,14 +6118,10 @@ packages:
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* does not support: hspec-core-2.8.5
         - hspec-wai-json < 0 # tried hspec-wai-json-0.11.0, but its *library* does not support: hspec-wai-0.11.1
         - hspec-webdriver < 0 # tried hspec-webdriver-1.2.0, but its *library* requires the disabled package: webdriver
-        - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.1, but its *library* requires the disabled package: jmacro
         - hsx2hs < 0 # tried hsx2hs-0.14.1.8, but its *library* does not support: template-haskell-2.17.0.0
-        - htoml < 0 # tried htoml-1.0.0.3, but its *library* does not support: aeson-2.0.3.0
         - hw-hspec-hedgehog < 0 # tried hw-hspec-hedgehog-0.1.1.0, but its *library* does not support: hspec-2.8.5
-        - hw-json < 0 # tried hw-json-1.3.2.2, but its *library* does not support: aeson-2.0.3.0
         - hyraxAbif < 0 # tried hyraxAbif-0.2.3.27, but its *library* does not support: text-1.2.5.0
         - idris < 0 # tried idris-1.3.4, but its *library* does not support: Cabal-3.4.1.0
-        - idris < 0 # tried idris-1.3.4, but its *library* does not support: aeson-2.0.3.0
         - idris < 0 # tried idris-1.3.4, but its *library* does not support: network-3.1.2.7
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: hse-cpp
         - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* does not support: base-4.15.1.0
@@ -6209,22 +6142,17 @@ packages:
         - ixset-typed-binary-instance < 0 # tried ixset-typed-binary-instance-0.1.0.2, but its *library* requires the disabled package: ixset-typed
         - ixset-typed-conversions < 0 # tried ixset-typed-conversions-0.1.2.0, but its *library* requires the disabled package: ixset-typed
         - ixset-typed-hashable-instance < 0 # tried ixset-typed-hashable-instance-0.1.0.2, but its *library* requires the disabled package: ixset-typed
-        - javascript-extras < 0 # tried javascript-extras-0.5.0.0, but its *library* requires the disabled package: ghcjs-base-stub
-        - jmacro-rpc < 0 # tried jmacro-rpc-0.3.3, but its *library* requires the disabled package: jmacro
-        - jmacro-rpc-happstack < 0 # tried jmacro-rpc-happstack-0.3.2, but its *library* requires the disabled package: jmacro
-        - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: jmacro
-        - jsaddle < 0 # tried jsaddle-0.9.8.1, but its *library* does not support: aeson-2.0.3.0
+        - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: snap-core
         - jsaddle < 0 # tried jsaddle-0.9.8.1, but its *library* does not support: attoparsec-0.14.4
         - jsaddle < 0 # tried jsaddle-0.9.8.1, but its *library* does not support: base64-bytestring-1.2.1.0
         - jsaddle < 0 # tried jsaddle-0.9.8.1, but its *library* does not support: ref-tf-0.5.0.1
-        - json-alt < 0 # tried json-alt-1.0.0, but its *library* does not support: aeson-2.0.3.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* does not support: aeson-2.0.3.0
+        - json-alt < 0 # tried json-alt-1.0.0, but its *library* does not support: aeson-1.5.6.0
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* does not support: aeson-1.5.6.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* does not support: lens-5.0.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* does not support: smallcheck-1.2.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires the disabled package: run-haskell-module
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: aeson-2.0.3.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: aeson-1.5.6.0
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* does not support: base-4.15.1.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* does not support: aeson-2.0.3.0
         - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* does not support: base-4.15.1.0
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: distributed-closure
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
@@ -6232,28 +6160,24 @@ packages:
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: distributed-closure
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: aeson-2.0.3.0
+        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: aeson-1.5.6.0
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: async-2.2.4
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: katip-0.8.7.0
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: rollbar-hs-0.3.1.0
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: time-1.9.3
-        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: aeson-2.0.3.0
+        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: aeson-1.5.6.0
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: katip-0.8.7.0
-        - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* does not support: aeson-2.0.3.0
         - kraken < 0 # tried kraken-0.1.0, but its *library* does not support: base-4.15.1.0
-        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* does not support: aeson-2.0.3.0
         - lambdabot-core < 0 # tried lambdabot-core-5.3.0.2, but its *library* requires the disabled package: random-fu
         - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.0.2, but its *library* requires the disabled package: lambdabot-core
         - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* does not support: template-haskell-2.17.0.0
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: aeson-2.0.3.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: base16-bytestring-1.0.2.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: formatting-7.1.3
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: hruby-0.5.0.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: lens-5.0.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: megaparsec-9.2.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: memory-0.16.0
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: servant-0.19
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: servant-client-0.19
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: servant-0.18.3
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* does not support: servant-client-0.18.3
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* does not support: template-haskell-2.17.0.0
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* does not support: lens-5.0.1
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* does not support: lens-5.0.1
@@ -6275,8 +6199,7 @@ packages:
         - list-witnesses < 0 # tried list-witnesses-0.1.3.2, but its *library* requires the disabled package: functor-products
         - little-logger < 0 # tried little-logger-0.3.2, but its *library* requires the disabled package: co-log
         - little-logger < 0 # tried little-logger-0.3.2, but its *library* requires the disabled package: co-log-core
-        - log-base < 0 # tried log-base-0.11.0.0, but its *library* does not support: aeson-2.0.3.0
-        - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: aeson-2.0.3.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: aeson-1.5.6.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: o-clock-1.2.1
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* does not support: universum-1.7.2
         - logger-thread < 0 # tried logger-thread-0.1.0.2, but its *library* requires the disabled package: protolude
@@ -6290,10 +6213,9 @@ packages:
         - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* does not support: prettyprinter-1.7.1
         - logging-effect-extra-handler < 0 # tried logging-effect-extra-handler-2.0.1, but its *library* requires the disabled package: logging-effect
         - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* does not support: ghc-9.0.2
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: aeson-2.0.3.0
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: network-3.1.2.7
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-0.19
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-client-0.19
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-0.18.3
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-client-0.18.3
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-core
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
@@ -6302,7 +6224,7 @@ packages:
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires the disabled package: Interpolation
         - map-syntax < 0 # tried map-syntax-0.3, but its *library* does not support: base-4.15.1.0
         - markup < 0 # tried markup-4.2.0, but its *library* requires the disabled package: attoparsec-uri
-        - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: aeson-2.0.3.0
+        - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: aeson-1.5.6.0
         - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: http-client-0.7.11
         - marvin < 0 # tried marvin-0.2.5, but its *library* does not support: lens-5.0.1
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires the disabled package: marvin-interpolate
@@ -6312,8 +6234,6 @@ packages:
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: optparse-applicative-0.16.1.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: scalpel-core-0.6.2
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: time-1.9.3
-        - medea < 0 # tried medea-1.2.0, but its *library* does not support: aeson-2.0.3.0
-        - medea < 0 # tried medea-1.2.0, but its *library* does not support: algebraic-graphs-0.6
         - menshen < 0 # tried menshen-0.0.3, but its *library* does not support: regex-tdfa-1.3.1.1
         - merkle-tree < 0 # tried merkle-tree-0.1.1, but its *library* requires the disabled package: protolude
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* does not support: containers-0.6.4.1
@@ -6321,8 +6241,8 @@ packages:
         - microformats2-parser < 0 # tried microformats2-parser-1.0.2.0, but its *library* requires the disabled package: xml-lens
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: http-client-0.7.11
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: http-media-0.8.0.0
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: servant-0.19
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: servant-client-0.19
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: servant-0.18.3
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: servant-client-0.18.3
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* does not support: time-1.9.3
         - midi-music-box < 0 # tried midi-music-box-0.0.1.2, but its *executable* requires the disabled package: diagrams-postscript
         - milena < 0 # tried milena-0.5.4.0, but its *library* does not support: lens-5.0.1
@@ -6335,22 +6255,14 @@ packages:
         - misfortune < 0 # tried misfortune-0.1.1.2, but its *library* requires the disabled package: knob
         - misfortune < 0 # tried misfortune-0.1.1.2, but its *library* requires the disabled package: random-fu
         - miso < 0 # tried miso-1.8.1.0, but its *library* requires the disabled package: jsaddle
-        - miso < 0 # tried miso-1.8.1.0, but its *library* requires the disabled package: servant-lucid
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *executable* requires the disabled package: pipes-text
         - mole < 0 # tried mole-0.0.7, but its *executable* does not support: base-4.15.1.0
         - mole < 0 # tried mole-0.0.7, but its *executable* requires the disabled package: snap-server
         - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: base-4.15.1.0
         - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: mwc-random-0.15.0.2
-        - monad-bayes < 0 # tried monad-bayes-0.1.1.0, but its *library* does not support: statistics-0.16.0.1
         - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires the disabled package: ekg-core
         - monad-mock < 0 # tried monad-mock-0.2.0.0, but its *library* does not support: template-haskell-2.17.0.0
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
-        - morpheus-graphql < 0 # tried morpheus-graphql-0.18.0, but its *library* does not support: aeson-2.0.3.0
-        - morpheus-graphql-app < 0 # tried morpheus-graphql-app-0.18.0, but its *library* does not support: aeson-2.0.3.0
-        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.18.0, but its *library* does not support: aeson-2.0.3.0
-        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.18.0, but its *library* requires the disabled package: morpheus-graphql-core
-        - morpheus-graphql-core < 0 # tried morpheus-graphql-core-0.18.0, but its *library* does not support: aeson-2.0.3.0
-        - morpheus-graphql-subscriptions < 0 # tried morpheus-graphql-subscriptions-0.18.0, but its *library* does not support: aeson-2.0.3.0
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* does not support: base-4.15.1.0
         - msgpack-aeson < 0 # tried msgpack-aeson-0.1.0.0, but its *library* requires the disabled package: msgpack
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* does not support: blaze-builder-0.4.2.2
@@ -6365,7 +6277,6 @@ packages:
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: conduit-extra-1.3.5
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: network-3.1.2.7
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* does not support: random-1.2.1
-        - mustache < 0 # tried mustache-2.3.2, but its *library* does not support: aeson-2.0.3.0
         - mwc-random-accelerate < 0 # tried mwc-random-accelerate-0.2.0.0, but its *library* requires the disabled package: accelerate
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* does not support: memory-0.16.0
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires the disabled package: word24
@@ -6384,15 +6295,6 @@ packages:
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: network-attoparsec
         - network-msgpack-rpc < 0 # tried network-msgpack-rpc-0.0.6, but its *library* does not support: network-3.1.2.7
         - network-transport-inmemory < 0 # tried network-transport-inmemory-0.5.2, but its *library* does not support: containers-0.6.4.1
-        - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires the disabled package: nri-prelude
-        - nri-http < 0 # tried nri-http-0.1.0.4, but its *library* requires the disabled package: nri-prelude
-        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires the disabled package: nri-prelude
-        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires the disabled package: nri-prelude
-        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires the disabled package: nri-prelude
-        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires the disabled package: nri-prelude
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.2, but its *library* does not support: servant-0.19
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.2, but its *library* does not support: servant-server-0.19
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.2, but its *library* requires the disabled package: nri-prelude
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* does not support: numhask-0.10.0.0
         - nvim-hs-ghcid < 0 # tried nvim-hs-ghcid-2.0.0.0, but its *library* requires the disabled package: nvim-hs-contrib
         - oblivious-transfer < 0 # tried oblivious-transfer-0.1.0, but its *library* requires the disabled package: protolude
@@ -6414,7 +6316,6 @@ packages:
         - persistable-record < 0 # tried persistable-record-0.6.0.5, but its *library* requires the disabled package: th-data-compat
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: persistable-record
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query-HDBC
-        - persistent-iproute < 0 # tried persistent-iproute-0.2.5, but its *library* requires the disabled package: aeson-iproute
         - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* does not support: tls-1.5.7
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* does not support: random-1.2.1
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* does not support: scotty-0.12
@@ -6422,13 +6323,13 @@ packages:
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* does not support: JuicyPixels-3.3.6
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* does not support: hmatrix-0.20.2
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: Cabal-3.4.1.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: aeson-2.0.3.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: aeson-1.5.6.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: base-4.15.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: binary-orphans-1.0.2
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: containers-0.6.4.1
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: hashable-1.3.5.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: shake-0.19.6
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: yaml-0.11.7.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* does not support: yaml-0.11.6.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: Cabal-3.4.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: base64-bytestring-1.2.1.0
@@ -6436,7 +6337,6 @@ packages:
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: hashable-1.3.5.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: http-client-0.7.11
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* does not support: shake-0.19.6
-        - pinboard < 0 # tried pinboard-0.10.2.0, but its *library* does not support: aeson-2.0.3.0
         - pinboard < 0 # tried pinboard-0.10.2.0, but its *library* does not support: http-client-0.7.11
         - pipes-category < 0 # tried pipes-category-0.3.0.0, but its *library* does not support: lens-5.0.1
         - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
@@ -6446,16 +6346,13 @@ packages:
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* does not support: base-4.15.1.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires the disabled package: haskell-src-exts-simple
-        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* does not support: aeson-2.0.3.0
         - polysemy-zoo < 0 # tried polysemy-zoo-0.7.0.2, but its *library* does not support: constraints-0.13.3
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* does not support: base-4.15.1.0
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* does not support: ghc-prim-0.7.0
-        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: aeson-2.0.3.0
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: base-4.15.1.0
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: hasql-1.5.0.1
-        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: jose-0.9
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: retry-0.9.1.0
-        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: swagger2-2.8.1
+        - postgrest < 0 # tried postgrest-8.0.0, but its *library* does not support: swagger2-2.8
         - postgrest < 0 # tried postgrest-8.0.0, but its *library* requires the disabled package: hasql-dynamic-statements
         - prairie < 0 # tried prairie-0.0.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - pred-set < 0 # tried pred-set-0.0.1, but its *library* requires the disabled package: HSet
@@ -6464,7 +6361,6 @@ packages:
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* does not support: containers-0.6.4.1
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* does not support: lens-5.0.1
         - product-isomorphic < 0 # tried product-isomorphic-0.0.3.3, but its *library* requires the disabled package: th-data-compat
-        - profiteur < 0 # tried profiteur-0.4.6.0, but its *executable* does not support: aeson-2.0.3.0
         - protolude < 0 # tried protolude-0.3.0, but its *library* does not support: base-4.15.1.0
         - protolude < 0 # tried protolude-0.3.0, but its *library* does not support: ghc-prim-0.7.0
         - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* does not support: base-4.15.1.0
@@ -6475,7 +6371,7 @@ packages:
         - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* does not support: template-haskell-2.17.0.0
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.5, but its *library* requires the disabled package: unfoldable-restricted
         - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.1, but its *library* requires the disabled package: markov-chain-usage-model
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: aeson-2.0.3.0
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: aeson-1.5.6.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: connection-0.3.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: constraints-0.13.3
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: http-api-data-0.4.3
@@ -6486,7 +6382,6 @@ packages:
         - ranged-list < 0 # tried ranged-list-0.1.0.0, but its *library* requires the disabled package: typecheck-plugin-nat-simple
         - rank-product < 0 # tried rank-product-0.2.2.0, but its *library* requires the disabled package: random-fu
         - rdf < 0 # tried rdf-0.1.0.5, but its *library* does not support: attoparsec-0.14.4
-        - reanimate < 0 # tried reanimate-1.1.5.0, but its *library* does not support: aeson-2.0.3.0
         - reanimate < 0 # tried reanimate-1.1.5.0, but its *library* requires the disabled package: hgeometry
         - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires the disabled package: hsx2hs
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* does not support: regex-base-0.94.0.2
@@ -6502,15 +6397,14 @@ packages:
         - relational-record < 0 # tried relational-record-0.2.2.0, but its *library* requires the disabled package: relational-query-HDBC
         - relational-schemas < 0 # tried relational-schemas-0.1.8.0, but its *library* requires the disabled package: relational-query
         - repa-algorithms < 0 # tried repa-algorithms-3.4.1.4, but its *library* does not support: base-4.15.1.0
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* does not support: aeson-2.0.3.0
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* does not support: aeson-1.5.6.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* does not support: base-4.15.1.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* does not support: req-3.10.0
         - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* does not support: base-4.15.1.0
         - rhine-gloss < 0 # tried rhine-gloss-0.7.0, but its *library* requires the disabled package: rhine
-        - riak < 0 # tried riak-1.2.0.0, but its *library* does not support: aeson-2.0.3.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* does not support: attoparsec-0.14.4
         - riak < 0 # tried riak-1.2.0.0, but its *library* does not support: network-3.1.2.7
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* does not support: aeson-2.0.3.0
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* does not support: aeson-1.5.6.0
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* does not support: http-client-0.7.11
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* does not support: network-3.1.2.7
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* does not support: time-1.9.3
@@ -6518,13 +6412,11 @@ packages:
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires the disabled package: tomland
         - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.0.6, but its *library* requires the disabled package: webdriver
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* does not support: containers-0.6.4.1
-        - schematic < 0 # tried schematic-0.5.1.0, but its *library* does not support: aeson-2.0.3.0
+        - schematic < 0 # tried schematic-0.5.1.0, but its *library* does not support: aeson-1.5.6.0
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: hjsonschema
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: validationt
-        - selda-json < 0 # tried selda-json-0.1.1.0, but its *library* does not support: aeson-2.0.3.0
-        - selda-postgresql < 0 # tried selda-postgresql-0.1.8.1, but its *library* requires the disabled package: selda-json
         - sendgrid-v3 < 0 # tried sendgrid-v3-0.3.0.0, but its *library* does not support: base-4.15.1.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: aeson-2.0.3.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: aeson-1.5.6.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: base-4.15.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: http-client-0.7.11
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* does not support: lens-5.0.1
@@ -6538,52 +6430,38 @@ packages:
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: http-api-data-0.4.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: http-types-0.12.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: memory-0.16.0
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-0.19
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-server-0.19
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-0.18.3
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: servant-server-0.18.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* does not support: time-1.9.3
-        - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* does not support: servant-server-0.19
-        - servant-cassava < 0 # tried servant-cassava-0.10.1, but its *library* does not support: servant-0.19
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* does not support: aeson-2.0.3.0
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* does not support: servant-0.19
+        - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* requires the disabled package: swagger2
         - servant-errors < 0 # tried servant-errors-0.1.6.0, but its *library* does not support: base-4.15.1.0
-        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* does not support: http-common-0.8.3.4
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* does not support: aeson-2.0.3.0
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* does not support: servant-0.19
+        - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* does not support: aeson-1.5.6.0
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: containers-0.6.4.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: formatting-7.1.3
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: lens-5.0.1
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: servant-0.19
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: servant-0.18.3
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* does not support: time-1.9.3
-        - servant-lucid < 0 # tried servant-lucid-0.9.0.4, but its *library* does not support: servant-0.19
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: QuickCheck-2.14.2
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: base-4.15.1.0
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: servant-0.19
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* does not support: servant-server-0.19
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: http-media-0.8.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: lens-5.0.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: pandoc-types-1.22.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* does not support: servant-docs-0.12
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: aeson-2.0.3.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: base-4.15.1.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: hspec-2.8.5
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: servant-0.19
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: servant-client-0.19
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* does not support: servant-server-0.19
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: base-4.15.1.0
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: servant-0.19
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* does not support: servant-0.18.3
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: http-media-0.8.0.0
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-0.19
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-client-core-0.19
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-0.18.3
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* does not support: servant-client-core-0.18.3
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: base-4.15.1.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: http-media-0.8.0.0
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: servant-server-0.19
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* does not support: servant-server-0.18.3
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires the disabled package: streaming-wai
-        - servant-swagger-ui < 0 # tried servant-swagger-ui-0.3.5.4.5.0, but its *library* does not support: aeson-2.0.3.0
-        - servant-swagger-ui-core < 0 # tried servant-swagger-ui-core-0.3.5, but its *library* does not support: aeson-2.0.3.0
-        - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* does not support: aeson-2.0.3.0
+        - servant-swagger < 0 # tried servant-swagger-1.1.10, but its *library* requires the disabled package: swagger2
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: base-4.15.1.0
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: servant-0.19
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* does not support: servant-0.18.3
         - serverless-haskell < 0 # tried serverless-haskell-0.12.6, but its *library* requires the disabled package: amazonka-core
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-1.0.5, but its *library* does not support: base64-bytestring-1.2.1.0
         - serversession-backend-redis < 0 # tried serversession-backend-redis-1.0.4, but its *library* does not support: hedis-0.15.1
@@ -6595,27 +6473,18 @@ packages:
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* does not support: trifecta-2.1.2
         - shower < 0 # tried shower-0.2.0.2, but its *library* does not support: base-4.15.1.0
-        - simple < 0 # tried simple-1.0.0, but its *library* requires the disabled package: simple-templates
-        - simple-session < 0 # tried simple-session-1.0.0, but its *library* requires the disabled package: simple
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* does not support: template-haskell-2.17.0.0
         - size-based < 0 # tried size-based-0.1.2.0, but its *library* does not support: template-haskell-2.17.0.0
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: aeson-2.0.3.0
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: aeson-1.5.6.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: base-4.15.1.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: constraints-0.13.3
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: lens-5.0.1
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* does not support: random-1.2.1
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
-        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* does not support: aeson-2.0.3.0
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* does not support: http-client-0.7.11
-        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* does not support: servant-0.19
-        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* does not support: servant-client-0.19
-        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* does not support: servant-client-core-0.19
-        - slick < 0 # tried slick-1.1.2.2, but its *library* requires the disabled package: mustache
         - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* does not support: base-4.15.1.0
-        - smash-aeson < 0 # tried smash-aeson-0.1.0.0, but its *library* does not support: aeson-2.0.3.0
         - smash-lens < 0 # tried smash-lens-0.1.0.1, but its *library* does not support: lens-5.0.1
-        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* does not support: aeson-2.0.3.0
-        - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: aeson-2.0.3.0
+        - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: aeson-1.5.6.0
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: attoparsec-0.14.4
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: base-4.15.1.0
         - snap < 0 # tried snap-1.1.3.1, but its *library* does not support: dlist-1.0
@@ -6635,18 +6504,11 @@ packages:
         - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* does not support: text-1.2.5.0
         - streamproc < 0 # tried streamproc-1.6.2, but its *library* does not support: base-4.15.1.0
         - strict-base-types < 0 # tried strict-base-types-0.7, but its *library* requires the disabled package: strict-lens
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* does not support: aeson-2.0.3.0
-        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-core
-        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-http-client
-        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* does not support: aeson-2.0.3.0
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: aeson-2.0.3.0
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: hspec-2.8.5
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: hspec-core-2.8.5
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* does not support: random-1.2.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* does not support: haskell-src-exts-1.23.1
-        - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
         - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: Cabal-3.4.1.0
-        - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: aeson-2.0.3.0
         - stylish-haskell < 0 # tried stylish-haskell-0.13.0.0, but its *library* does not support: ghc-lib-parser-9.0.2.20211226
         - sv < 0 # tried sv-1.4.0.1, but its *library* does not support: attoparsec-0.14.4
         - sv < 0 # tried sv-1.4.0.1, but its *library* does not support: base-4.15.1.0
@@ -6655,26 +6517,21 @@ packages:
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: base-4.15.1.0
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: lens-5.0.1
         - sv-core < 0 # tried sv-core-0.5, but its *library* does not support: profunctors-5.6.2
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: aeson-2.0.3.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: containers-0.6.4.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: http-api-data-0.4.3
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: http-client-0.7.11
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: http-media-0.8.0.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: katip-0.8.7.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* does not support: network-3.1.2.7
+        - swagger2 < 0 # tried swagger2-2.8, but its *library* does not support: aeson-1.5.6.0
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires the disabled package: egison-pattern-src
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires the disabled package: egison-pattern-src-th-mode
-        - sydtest < 0 # tried sydtest-0.7.0.1, but its *library* requires the disabled package: autodocodec
-        - sydtest-persistent < 0 # tried sydtest-persistent-0.0.0.0, but its *library* requires the disabled package: sydtest
-        - sydtest-servant < 0 # tried sydtest-servant-0.2.0.0, but its *library* requires the disabled package: sydtest
-        - sydtest-wai < 0 # tried sydtest-wai-0.2.0.0, but its *library* requires the disabled package: sydtest
-        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.0, but its *library* requires the disabled package: sydtest
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* does not support: containers-0.6.4.1
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* does not support: tasty-1.4.2.1
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* does not support: time-1.9.3
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* does not support: network-3.1.2.7
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
-        - termonad < 0 # tried termonad-4.2.0.0, but its *library* does not support: aeson-2.0.3.0
+        - termonad < 0 # tried termonad-4.2.0.0, but its *library* requires the disabled package: xml-html-qq
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* does not support: template-haskell-2.17.0.0
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract
         - testing-feat < 0 # tried testing-feat-1.1.0.0, but its *library* requires the disabled package: size-based
@@ -6698,8 +6555,8 @@ packages:
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: persistent-2.13.3.0
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* does not support: persistent-sqlite-2.13.1.0
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: base-4.15.1.0
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-0.19
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-server-0.19
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-0.18.3
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-server-0.18.3
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: wai-extra-3.1.8
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: base-4.15.1.0
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: writer-cps-transformers-0.5.6.1
@@ -6707,21 +6564,18 @@ packages:
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
         - true-name < 0 # tried true-name-0.1.0.3, but its *library* does not support: template-haskell-2.17.0.0
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
-        - typed-uuid < 0 # tried typed-uuid-0.2.0.0, but its *library* requires the disabled package: autodocodec
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: aeson-2.0.3.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: aeson-1.5.6.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: attoparsec-0.14.4
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: base-4.15.1.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: cryptonite-0.29
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* does not support: parser-combinators-1.3.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: aeson-2.0.3.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: aeson-1.5.6.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: base-4.15.1.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* does not support: base64-bytestring-1.2.1.0
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* does not support: attoparsec-0.14.4
-        - unjson < 0 # tried unjson-0.15.3, but its *library* does not support: aeson-2.0.3.0
         - uri-templater < 0 # tried uri-templater-0.3.1.0, but its *library* does not support: trifecta-2.1.2
         - urlpath < 0 # tried urlpath-9.0.1, but its *library* requires the disabled package: attoparsec-uri
-        - userid < 0 # tried userid-0.1.3.6, but its *library* does not support: aeson-2.0.3.0
         - userid < 0 # tried userid-0.1.3.6, but its *library* does not support: base-4.15.1.0
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* does not support: text-short-0.1.5
         - vado < 0 # tried vado-0.0.13, but its *library* does not support: attoparsec-0.14.4
@@ -6729,15 +6583,13 @@ packages:
         - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* does not support: base-4.15.1.0
         - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* does not support: containers-0.6.4.1
         - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* does not support: base-4.15.1.0
-        - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* does not support: aeson-2.0.3.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: base-4.15.1.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: brick-0.67
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: lens-5.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* does not support: vty-5.33
-        - wai-middleware-auth < 0 # tried wai-middleware-auth-0.2.5.1, but its *library* requires the disabled package: hoauth2
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* does not support: optparse-applicative-0.16.1.0
         - wai-middleware-metrics < 0 # tried wai-middleware-metrics-0.2.4, but its *library* requires the disabled package: ekg-core
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* does not support: aeson-2.0.3.0
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* does not support: aeson-1.5.6.0
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* does not support: http-client-0.7.11
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* does not support: time-1.9.3
         - wai-middleware-throttle < 0 # tried wai-middleware-throttle-0.3.0.1, but its *library* requires the disabled package: token-bucket
@@ -6751,9 +6603,7 @@ packages:
         - web3 < 0 # tried web3-1.0.0.0, but its *library* requires the disabled package: web3-ethereum
         - web3 < 0 # tried web3-1.0.0.0, but its *library* requires the disabled package: web3-polkadot
         - web3 < 0 # tried web3-1.0.0.0, but its *library* requires the disabled package: web3-provider
-        - webby < 0 # tried webby-1.0.1, but its *library* does not support: aeson-2.0.3.0
         - webby < 0 # tried webby-1.0.1, but its *library* does not support: formatting-7.1.3
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* does not support: aeson-2.0.3.0
         - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* does not support: base-4.15.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* does not support: language-javascript-0.7.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* does not support: webdriver-0.9.0.1
@@ -6773,9 +6623,6 @@ packages:
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* does not support: yesod-auth-1.6.10.5
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* does not support: yesod-core-1.6.21.0
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* does not support: yesod-form-1.7.0
-        - yesod-auth-fb < 0 # tried yesod-auth-fb-1.10.1, but its *library* requires the disabled package: fb
-        - yesod-auth-oauth2 < 0 # tried yesod-auth-oauth2-0.7.0.0, but its *library* requires the disabled package: hoauth2
-        - yesod-fb < 0 # tried yesod-fb-0.6.1, but its *library* requires the disabled package: fb
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* does not support: yesod-core-1.6.21.0
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* does not support: yesod-form-1.7.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* does not support: yesod-1.6.1.2
@@ -6783,15 +6630,14 @@ packages:
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* does not support: yesod-core-1.6.21.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* does not support: yesod-static-1.6.1.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires the disabled package: hamlet
-        - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* does not support: aeson-2.0.3.0
         - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* does not support: base-compat-0.11.2
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* does not support: servant-0.19
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* does not support: servant-client-0.19
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: aeson-2.0.3.0
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* does not support: servant-0.18.3
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* does not support: servant-client-0.18.3
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: aeson-1.5.6.0
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: base-compat-0.11.2
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: http-api-data-0.4.3
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: servant-0.19
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* does not support: servant-0.18.3
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: containers-0.6.4.1
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: flat-0.4.4
         - zm < 0 # tried zm-0.3.2, but its *library* does not support: model-0.5
@@ -6815,71 +6661,36 @@ packages:
       # https://github.com/commercialhaskell/stackage/issues/6402
       # https://github.com/commercialhaskell/stackage/issues/6243
       # https://github.com/commercialhaskell/stackage/issues/6393
-      - aeson >= 2.0.0.0
-      - aura >= 3.2.6
-      - avro >= 0.6.0.0
-      - cabal-flatpak >= 0.1.0.3
-      - core-data >= 0.3.0.0
-      - eventstore >= 1.4.2
-      - faktory >= 1.1.2.1
-      - flow >= 2.0.0.0
-      - forma >= 1.2.0
-      - geojson >= 4.1.0
-      - greskell >= 2.0.0.0
-      - greskell-core >= 1.0.0.0
-      - greskell-websocket >= 1.0.0.0
-      - hruby >= 0.4.0.0
-      - hspec-expectations-json >= 1.0.0.5
-      - http2 >= 3.0.3
-      - jose >= 0.9
-      - jsonpath >= 0.2.1.0
-      - kanji >= 3.5
-      - microlens-aeson >= 2.4
-      - mmark-cli >= 0.0.5.1
-      - pandoc-plot >= 1.4.0
-      - postgresql-binary >= 0.12.4.2
-      - servant-tracing >= 0.2.0.0
-      - shikensu >= 0.4.0
-      - stache >= 2.3.1
-      - stripe-scotty >= 1.1.0.1
-      - stripe-wreq >= 1.0.1.12
-      - telegram-bot-simple >= 0.3.8
-      - yaml >= 0.11.7
-      # compilation failures
-      - BiobaseBlast < 0 # 0.3.3.0
-      - Taxonomy < 0 # 2.2.0
-      - aeson-combinators < 0 # 0.0.5.0
-      - aeson-with < 0 # 0.1.2.0
-      - autodocodec < 0 # 0.0.1.0
-      - composable-associations-aeson < 0 # 0.1.0.1
-      - datadog < 0 # 0.2.5.0
-      - descriptive < 0 # 0.9.5
-      - elm2nix # 0.2.1
-      - etc < 0 # 0.4.1.0
-      - eventsource-api < 0 # 1.5.1
-      - fb < 0 # 2.1.1
-      - ghcjs-base-stub < 0 # 0.3.0.2
-      - highjson < 0 # 0.5.0.0
-      - hsebaysdk < 0 # 0.4.1.0
-      - jmacro < 0 # 0.6.17
-      - jose-jwt < 0 # 0.9.2
-      - json-rpc-generic < 0 # 0.2.1.6
-      - json-stream < 0 # 0.4.2.4
-      - kawhi < 0 # 0.3.0
-      - mergeful < 0 # 0.2.0.0
-      - nri-prelude < 0 # 0.6.0.6
-      - oauthenticated < 0 # 0.2.1.0
-      - pagure-cli < 0 # 0.2
-      - pushbullet-types < 0 # 0.4.1.0
-      - rigel-viz < 0 # 0.2.0.0
-      - servant-github-webhook < 0 # 0.4.2.0
-      - servant-tracing < 0 # 0.2.0.0
-      - simple-templates < 0 # 1.0.0
-      - stratosphere < 0 # 0.59.1
-      - swagger < 0 # 0.3.0
-      - template-toolkit < 0 # 0.1.1.0
-      - validity-aeson < 0 # 0.2.0.4
-      - xml-to-json < 0 # 2.0.1
+      - aeson < 2.0.0.0
+      - aura < 3.2.6
+      - avro < 0.6.0.0
+      - cabal-flatpak < 0.1.0.3
+      - core-data < 0.3.0.0
+      - eventstore < 1.4.2
+      - faktory < 1.1.2.1
+      - flow < 2.0.0.0
+      - forma < 1.2.0
+      - geojson < 4.1.0
+      - greskell < 2.0.0.0
+      - greskell-core < 1.0.0.0
+      - greskell-websocket < 1.0.0.0
+      - hruby < 0.4.0.0
+      - hspec-expectations-json < 1.0.0.5
+      - http2 < 3.0.3
+      - jose < 0.9
+      - jsonpath < 0.2.1.0
+      - kanji < 3.5
+      - microlens-aeson < 2.4
+      - mmark-cli < 0.0.5.1
+      - pandoc-plot < 1.4.0
+      - postgresql-binary < 0.12.4.2
+      - servant-tracing < 0.2.0.0
+      - shikensu < 0.4.0
+      - stache < 2.3.1
+      - stripe-scotty < 1.1.0.1
+      - stripe-wreq < 1.0.1.12
+      - telegram-bot-simple < 0.3.8
+      - yaml < 0.11.7
 
       # https://github.com/commercialhaskell/stackage/issues/6264
       # Requires GHC 9.2
@@ -7094,6 +6905,11 @@ skipped-builds:
 # or if Setup fails because of missing foreign libraries.
 # Otherwise place them in expected-test-failures.
 skipped-tests:
+    # aeson-2
+    # https://github.com/commercialhaskell/stackage/issues/6217
+    - jsonifier
+    - req
+
     # Missing foreign libraries
     - symengine
 
@@ -7224,11 +7040,12 @@ skipped-tests:
     #
     # Test bounds issues
     - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-th
-    - Frames # tried Frames-0.7.2, but its *test-suite* requires the disabled package: htoml
     - IPv6DB # tried IPv6DB-0.3.2, but its *test-suite* does not support: hspec-2.8.5
     - IPv6DB # tried IPv6DB-0.3.2, but its *test-suite* does not support: http-client-0.7.11
     - MissingH # tried MissingH-1.4.3.0, but its *test-suite* requires the disabled package: errorcall-eq-instance
+    - aeson # tried aeson-1.5.6.0, but its *test-suite* does not support: hashable-time-0.3
     - airship # tried airship-0.9.4, but its *test-suite* does not support: tasty-1.4.2.1
+    - algebraic-graphs # tried algebraic-graphs-0.5, but its *test-suite* does not support: QuickCheck-2.14.2
     - antiope-core # tried antiope-core-7.5.3, but its *test-suite* does not support: hspec-2.8.5
     - antiope-core # tried antiope-core-7.5.3, but its *test-suite* requires the disabled package: aeson-lens
     - antiope-messages # tried antiope-messages-7.5.3, but its *test-suite* does not support: hspec-2.8.5
@@ -7237,7 +7054,7 @@ skipped-tests:
     - antiope-sqs # tried antiope-sqs-7.5.3, but its *test-suite* does not support: hspec-2.8.5
     - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* does not support: hspec-2.8.5
     - asif # tried asif-6.0.4, but its *test-suite* does not support: doctest-0.18.2
-    - avro # tried avro-0.6.0.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
+    - avro # tried avro-0.5.2.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - barrier # tried barrier-0.1.1, but its *test-suite* does not support: lens-family-core-2.1.0
     - barrier # tried barrier-0.1.1, but its *test-suite* does not support: tasty-1.4.2.1
     - bits-extra # tried bits-extra-0.0.2.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7246,7 +7063,7 @@ skipped-tests:
     - boolean-normal-forms # tried boolean-normal-forms-0.0.1.1, but its *test-suite* does not support: QuickCheck-2.14.2
     - cassava-conduit # tried cassava-conduit-0.6.0, but its *test-suite* does not support: QuickCheck-2.14.2
     - chatwork # tried chatwork-0.1.3.5, but its *test-suite* does not support: hspec-2.8.5
-    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* does not support: servant-server-0.19
+    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* does not support: servant-server-0.18.3
     - chatwork # tried chatwork-0.1.3.5, but its *test-suite* does not support: warp-3.3.19
     - clay # tried clay-0.13.3, but its *test-suite* does not support: hspec-2.8.5
     - clay # tried clay-0.13.3, but its *test-suite* does not support: hspec-discover-2.8.5
@@ -7283,8 +7100,6 @@ skipped-tests:
     - galois-field # tried galois-field-1.0.2, but its *test-suite* does not support: semirings-0.6
     - galois-field # tried galois-field-1.0.2, but its *test-suite* does not support: tasty-1.4.2.1
     - generic-xmlpickler # tried generic-xmlpickler-0.1.0.6, but its *test-suite* does not support: tasty-1.4.2.1
-    - genvalidity-hspec-aeson # tried genvalidity-hspec-aeson-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-aeson
-    - genvalidity-sydtest-aeson # tried genvalidity-sydtest-aeson-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-aeson
     - ghc-prof # tried ghc-prof-1.4.1.9, but its *test-suite* does not support: attoparsec-0.14.4
     - gitlib-libgit2 # tried gitlib-libgit2-3.1.2.1, but its *test-suite* requires the disabled package: gitlib-test
     - haddock-library # tried haddock-library-1.10.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7309,7 +7124,7 @@ skipped-tests:
     - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* does not support: hspec-2.8.5
     - http-media # tried http-media-0.8.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
     - http-media # tried http-media-0.8.0.0, but its *test-suite* does not support: base-4.15.1.0
-    - http-streams # tried http-streams-0.8.9.6, but its *test-suite* requires the disabled package: snap-server
+    - http-streams # tried http-streams-0.8.9.4, but its *test-suite* requires the disabled package: snap-server
     - hw-balancedparens # tried hw-balancedparens-0.4.1.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-bits # tried hw-bits-0.7.2.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-conduit # tried hw-conduit-0.2.1.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7320,6 +7135,7 @@ skipped-tests:
     - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.0, but its *test-suite* does not support: hspec-2.8.5
     - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-ip # tried hw-ip-2.4.2.0, but its *test-suite* does not support: hspec-2.8.5
+    - hw-json # tried hw-json-1.3.2.2, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-json-simple-cursor # tried hw-json-simple-cursor-0.1.1.0, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-json-standard-cursor # tried hw-json-standard-cursor-0.2.3.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
     - hw-mquery # tried hw-mquery-0.2.1.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7336,7 +7152,6 @@ skipped-tests:
     - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* does not support: tasty-hspec-1.2
     - json-rpc-client # tried json-rpc-client-0.2.5.0, but its *test-suite* does not support: QuickCheck-2.14.2
     - jwt # tried jwt-0.11.0, but its *test-suite* does not support: doctest-0.18.2
-    - lackey # tried lackey-2.0.0.0, but its *test-suite* does not support: servant-0.19
     - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* does not support: hspec-2.8.5
     - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* does not support: hspec-core-2.8.5
     - libraft # tried libraft-0.5.0.0, but its *test-suite* requires the disabled package: quickcheck-state-machine
@@ -7371,7 +7186,7 @@ skipped-tests:
     - qnap-decrypt # tried qnap-decrypt-0.3.5, but its *test-suite* does not support: hspec-2.8.5
     - quickcheck-state-machine # tried quickcheck-state-machine-0.7.1, but its *test-suite* requires the disabled package: hs-rqlite
     - rakuten # tried rakuten-0.1.1.5, but its *test-suite* does not support: hspec-2.8.5
-    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* does not support: servant-server-0.19
+    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* does not support: servant-server-0.18.3
     - rakuten # tried rakuten-0.1.1.5, but its *test-suite* does not support: warp-3.3.19
     - records-sop # tried records-sop-0.1.1.0, but its *test-suite* does not support: hspec-2.8.5
     - req-url-extra # tried req-url-extra-0.1.1.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7382,14 +7197,12 @@ skipped-tests:
     - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* does not support: hspec-discover-2.8.5
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* does not support: hspec-2.8.5
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* does not support: hspec-discover-2.8.5
-    - servant-cassava # tried servant-cassava-0.10.1, but its *test-suite* does not support: servant-server-0.19
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* does not support: hspec-2.8.5
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* does not support: hspec-discover-2.8.5
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
-    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* does not support: aeson-2.0.3.0
+    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* does not support: aeson-1.5.6.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* does not support: hspec-2.8.5
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* does not support: http-api-data-0.4.3
-    - servant-lucid # tried servant-lucid-0.9.0.4, but its *test-suite* does not support: servant-server-0.19
     - servant-mock # tried servant-mock-0.8.7, but its *test-suite* does not support: hspec-wai-0.11.1
     - servant-quickcheck # tried servant-quickcheck-0.0.10.0, but its *test-suite* does not support: hspec-core-2.8.5
     - servant-streaming # tried servant-streaming-0.3.0.0, but its *test-suite* does not support: QuickCheck-2.14.2
@@ -7399,8 +7212,8 @@ skipped-tests:
     - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* does not support: warp-3.3.19
     - servant-swagger # tried servant-swagger-1.1.10, but its *test-suite* does not support: hspec-2.8.5
     - servant-swagger # tried servant-swagger-1.1.10, but its *test-suite* does not support: hspec-discover-2.8.5
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* does not support: aeson-2.0.3.0
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* does not support: servant-server-0.19
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* does not support: aeson-1.5.6.0
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* does not support: servant-server-0.18.3
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* does not support: hspec-2.8.5
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* does not support: network-transport-tcp-0.8.0
     - sexpr-parser # tried sexpr-parser-0.2.0.0, but its *test-suite* does not support: hspec-2.8.5
@@ -7746,7 +7559,7 @@ expected-test-failures:
 
     - functor-combinators # https://github.com/commercialhaskell/stackage/issues/6376
     - generic-lens # https://github.com/commercialhaskell/stackage/issues/6377
-    - geojson # 4.1.0
+    - geojson # 4.0.2
     - heap # 1.0.4 https://github.com/pruvisto/heap/issues/11
     - hsini # 0.5.1.2
     - hweblib # 0.6.3 https://github.com/aycanirican/hweblib/issues/3
@@ -7895,6 +7708,10 @@ expected-benchmark-failures:
 # or if Setup fails because of missing foreign libraries.
 # Otherwise place them in expected-benchmark-failures.
 skipped-benchmarks:
+    # aeson-2
+    # https://github.com/commercialhaskell/stackage/issues/6217
+    - jsonifier
+
     # Cyclic dependencies
     - attoparsec
     - case-insensitive
@@ -7975,9 +7792,8 @@ skipped-benchmarks:
     - distributed-process # tried distributed-process-0.7.4, but its *benchmarks* does not support: network-transport-tcp-0.8.0
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* does not support: criterion-1.5.13.0
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* does not support: aeson-2.0.3.0
+    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* does not support: aeson-1.5.6.0
     - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* does not support: time-1.9.3
-    - heist # tried heist-1.1.0.1, but its *benchmarks* does not support: statistics-0.16.0.1
     - hip # tried hip-1.5.6.0, but its *benchmarks* requires the disabled package: repa-algorithms
     - hw-eliasfano # tried hw-eliasfano-0.1.2.0, but its *benchmarks* requires the disabled package: hw-hspec-hedgehog
     - o-clock # tried o-clock-1.2.1, but its *benchmarks* requires the disabled package: tiempo


### PR DESCRIPTION
Reverts commercialhaskell/stackage#6334

Reverting as it creates cyclic deps which I don't know yet how to resolve. Will revert again when I do.

```
In the dependencies for criterion-1.5.13.0:
    aeson dependency cycle detected: aeson, criterion, base16-bytestring, aeson, Agda
needed since criterion is a build target.

In the dependencies for criterion-measurement-0.1.3.0:
    aeson dependency cycle detected: aeson, criterion, base16-bytestring, aeson, Agda
needed since criterion-measurement is a build target.

In the dependencies for microstache-1.0.2:
    aeson dependency cycle detected: aeson, criterion, base16-bytestring, aeson, Agda
needed since microstache is a build target.

In the dependencies for statistics-0.16.0.1:
    aeson dependency cycle detected: aeson, criterion, base16-bytestring, aeson, Agda
needed since statistics is a build target.

```