### PR TITLE
MissingH: takeover, reenable testsuite

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -56,26 +56,29 @@ packages:
         - geniplate-mirror
 
     "Andreas Abel <andreas.abel@gu.se> @andreasabel":
-        - BNFC
-        - Sit
-        - STMonadTrans
+
         - Agda
         - agda2lagda
+        - BNFC
         - cabal-clean
-        - ListLike
-        - haskell-src
         - fix-whitespace
-        - hs-tags
         - goldplate
         - hasktags
+        - hs-tags
+        - java-adt
+        - Sit
+
+        - haskell-src
+        - ListLike
+        - MissingH
         - regex-base
         - regex-compat
         - regex-pcre
         - regex-posix
         - regex-posix-clib
         - regex-tdfa
-        - java-adt
         - shelly
+        - STMonadTrans
         - tasty-silver
 
     "Diogo Biazus <diogo@biazus.ca>":
@@ -1551,7 +1554,6 @@ packages:
         - interpolatedstring-perl6
         - iproute
         - missing-foreign
-        - MissingH
         - multimap
         - parallel-io
         - text-binary
@@ -7241,7 +7243,6 @@ skipped-tests:
     - Frames # tried Frames-0.7.2, but its *test-suite* requires the disabled package: htoml
     - IPv6DB # tried IPv6DB-0.3.2, but its *test-suite* does not support: hspec-2.8.5
     - IPv6DB # tried IPv6DB-0.3.2, but its *test-suite* does not support: http-client-0.7.11
-    - MissingH # tried MissingH-1.4.3.0, but its *test-suite* requires the disabled package: errorcall-eq-instance
     - airship # tried airship-0.9.4, but its *test-suite* does not support: tasty-1.4.2.1
     - antiope-core # tried antiope-core-7.5.3, but its *test-suite* does not support: hspec-2.8.5
     - antiope-core # tried antiope-core-7.5.3, but its *test-suite* requires the disabled package: aeson-lens


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version
