### PR TITLE
Unlock gmail-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1228,7 +1228,7 @@ packages:
         - binary-list
         - byteset
         - Clipboard
-        - gmail-simple < 0 # 0.1.0.2 https://github.com/Daniel-Diaz/gmail-simple/issues/1
+        - gmail-simple
         - grouped-list
         - haskintex
         - HaTeX


### PR DESCRIPTION
The issue was fixed in version 0.1.0.4. It builds against the current nightly.