### PR TITLE
Add network-wait

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4597,6 +4597,7 @@ packages:
         - logstash
         - monad-logger-logstash
         - moss
+        - network-wait
         - wai-rate-limit
         - wai-rate-limit-redis
         - wai-saml2


### PR DESCRIPTION
This change adds the `network-wait` package. The `verify-package` script seems to fail while building the haddocks for `socks-0.6.1` and `ansi-terminal-0.11.1` -- I am not really sure why (but possibly due to https://gitlab.haskell.org/ghc/ghc/-/issues/20903), but it doesn't seem like something caused by my package. I have run the script without the `--haddock` flag and that worked fine at least.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version
