### PR TITLE
reenable typecheck-plugin-nat-simple and ranged-list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5472,7 +5472,6 @@ packages:
         - tintin < 0 # 1.10.1
         - turtle-options < 0 # 0.1.0.4
         - type-assertions < 0 # 0.1.0.0
-        - typecheck-plugin-nat-simple < 0 # 0.1.0.2
         - ulid < 0 # 0.3.0.0
         - uncertain < 0 # 0.3.1.0
         - unordered-intmap < 0 # 0.1.1
@@ -6516,7 +6515,6 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: lens-5.0.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: req-3.10.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires the disabled package: extensible
-        - ranged-list < 0 # tried ranged-list-0.1.0.0, but its *library* requires the disabled package: typecheck-plugin-nat-simple
         - rdf < 0 # tried rdf-0.1.0.5, but its *library* does not support: attoparsec-0.14.4
         - reanimate < 0 # tried reanimate-1.1.5.0, but its *library* does not support: aeson-2.0.3.0
         - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires the disabled package: hsx2hs


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
