### PR TITLE
Re-enable kind-generics-th

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6695,7 +6695,6 @@ packages:
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* does not support: time-1.11.1.1
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: aeson-2.0.3.0
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* does not support: katip-0.8.7.0
-        - kind-generics-th < 0 # tried kind-generics-th-0.2.2.2, but its *library* does not support: template-haskell-2.18.0.0
         - koji < 0 # tried koji-0.0.2, but its *library* requires the disabled package: haxr
         - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* does not support: aeson-2.0.3.0
         - kraken < 0 # tried kraken-0.1.0, but its *library* does not support: base-4.16.1.0


### PR DESCRIPTION
... now that it supports the latest version of `template-haskell`

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
