### PR TITLE
Re-enable tracing-control

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7501,7 +7501,6 @@ packages:
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: servant-server-0.19
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* does not support: wai-extra-3.1.8
         - tracing < 0 # tried tracing-0.0.7.2, but its *library* does not support: time-1.11.1.1
-        - tracing-control < 0 # tried tracing-control-0.0.7.2, but its *library* does not support: time-1.11.1.1
         - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* does not support: mmorph-1.2.0
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: base-4.16.1.0
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* does not support: writer-cps-transformers-0.5.6.1


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
