### PR TITLE
mcmc: reenable

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6799,7 +6799,6 @@ packages:
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: optparse-applicative-0.17.0.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: scalpel-core-0.6.2
         - mbug < 0 # tried mbug-1.3.2, but its *library* does not support: time-1.11.1.1
-        - mcmc < 0 # tried mcmc-0.6.2.0, but its *library* requires the disabled package: monad-parallel
         - medea < 0 # tried medea-1.2.0, but its *library* does not support: aeson-2.0.3.0
         - medea < 0 # tried medea-1.2.0, but its *library* does not support: algebraic-graphs-0.6
         - medea < 0 # tried medea-1.2.0, but its *library* does not support: bytestring-0.11.3.0


### PR DESCRIPTION
Build was fixed with version 0.6.2.2.