### PR TITLE
Reenable servant-swagger, servant-openapi3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7898,10 +7898,6 @@ skipped-tests:
     # https://github.com/clash-lang/clash-compiler/issues/1622
     - clash-prelude
 
-    # restrictive bound on lens-aeson < 1.2 https://github.com/commercialhaskell/stackage/issues/6485
-    - servant-openapi3
-    - servant-swagger
-
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
     # Test bounds issues
@@ -8567,7 +8563,6 @@ expected-test-failures:
     - relapse # 1.0.0.0 #5948/closed
     - secp256k1-haskell # #5948/closed
     - servant-static-th # 1.0.0.0 Tasty issue: https://github.com/commercialhaskell/stackage/issues/6090
-    - servant-swagger # https://github.com/commercialhaskell/stackage/pull/6494
     - snappy # Could not find module ‘Functions’
     - store # 0.7.14
     - text-icu # 0.7.1.0 https://github.com/bos/text-icu/issues/32


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I've updated Hackage revisions and uploaded newer servant-swagger.

### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
