### PR TITLE
re-enable hjsmin

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6505,7 +6505,6 @@ packages:
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart-diagrams
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
-        - hjsmin < 0 # tried hjsmin-0.2.0.4, but its *executable* does not support: bytestring-0.11.3.0
         - hledger-web < 0 # tried hledger-web-1.25, but its *library* requires the disabled package: yesod-core
         - hlint < 0 # tried hlint-3.3.6, but its *library* does not support: ghc-lib-parser-9.2.2.20220307
         - hlint < 0 # tried hlint-3.3.6, but its *library* does not support: ghc-lib-parser-ex-9.2.0.3


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


NB: The verify-package script fails with a test suite failure because it is hard-coded to look for a cabal-install dist-newstyle dir. I've confirmed that the test suite passes