### PR TITLE
re-enable alarmclock and bank-holidays-england

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5638,7 +5638,6 @@ packages:
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: semigroups-0.20
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: wai-3.2.3
         - airship < 0 # tried airship-0.9.4, but its *library* does not support: wai-extra-3.1.8
-        - alarmclock < 0 # tried alarmclock-0.7.0.5, but its *library* does not support: time-1.11.1.1
         - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: util
         - align-audio < 0 # tried align-audio-0.0, but its *executable* requires the disabled package: soxlib
         - alsa-seq < 0 # tried alsa-seq-0.6.0.8, but its *library* does not support: bytestring-0.11.3.0
@@ -5788,7 +5787,6 @@ packages:
         - b9 < 0 # tried b9-3.2.0, but its *library* does not support: shake-0.19.6
         - b9 < 0 # tried b9-3.2.0, but its *library* requires the disabled package: posix-pty
         - b9 < 0 # tried b9-3.2.0, but its *library* requires the disabled package: template
-        - bank-holidays-england < 0 # tried bank-holidays-england-0.2.0.6, but its *library* does not support: time-1.11.1.1
         - barrier < 0 # tried barrier-0.1.1, but its *library* does not support: bytestring-0.11.3.0
         - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* does not support: base-4.16.1.0
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* does not support: bytestring-0.11.3.0


### PR DESCRIPTION
i maintain both these and the time version bound has been bumped and released

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
