### PR TITLE
Re-enable benchpress

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5814,7 +5814,6 @@ packages:
         - beam-sqlite < 0 # tried beam-sqlite-0.5.1.2, but its *library* requires the disabled package: sqlite-simple
         - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart
         - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart-diagrams
-        - benchpress < 0 # tried benchpress-0.2.2.18, but its *library* does not support: base-4.16.1.0
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: brick-0.68
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: bytestring-0.11.3.0
         - bhoogle < 0 # tried bhoogle-0.1.3.5, but its *executable* does not support: directory-1.3.6.2


### PR DESCRIPTION
It is now compatible with base-4.16.0.0 as of v0.2.2.19, which includes https://github.com/WillSewell/benchpress/pull/14

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
