### PR TITLE
The test suite of MMark 0.0.7.5 should not fail anymore

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8467,8 +8467,6 @@ expected-test-failures:
     - megaparsec-tests # 9.2.0
     - mighty-metropolis # https://github.com/jtobin/mighty-metropolis/issues/6
     - mixpanel-client # https://github.com/domenkozar/mixpanel-client/issues/7
-    - mmark # https://github.com/mmark-md/mmark/issues/80
-    - mmark-ext # https://github.com/mmark-md/mmark/issues/80
     - morpheus-graphql-app
     - mwc-random
     - nettle # https://github.com/stbuehler/haskell-nettle/issues/10


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
