### PR TITLE
Reenable oauthenticated

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5447,7 +5447,6 @@ packages:
         - n2o-protocols < 0 # 0.11.2
         - nri-prelude < 0 # 0.6.0.6 compile fail aeson 2.0
         - nvim-hs-contrib < 0 # 2.0.0.0
-        - oauthenticated < 0 # 0.2.1.0 compile fail aeson 2.0
         - odbc < 0 # 0.2.6 odbc
         - open-witness < 0 # 0.5
         - pdfinfo < 0 # 1.5.4


### PR DESCRIPTION
Should now compile with aeson 2.0

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
