### PR TITLE
Reenable datadog

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5384,7 +5384,6 @@ packages:
         - cuckoo-filter < 0 # 0.2.0.2 benchmarks are an exe
         - cuda < 0 # 0.11.0.0
         - data-default-instances-new-base < 0 # 0.0.2
-        - datadog < 0 # 0.2.5.0 compile fail aeson 2.0
         - descriptive < 0 # 0.9.5 compile fail aeson 2.0
         - distributed-closure < 0 # 0.4.2.0
         - djinn-ghc < 0 # 0.0.2.3


### PR DESCRIPTION
Should now compile with aeson 2.0

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage

(Tests are disabled)
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
