### PR TITLE
Re-enable hpack

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6487,7 +6487,6 @@ packages:
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.6, but its *executable* requires the disabled package: graphviz
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.6, but its *executable* requires the disabled package: ixset-typed
-        - hpack < 0 # tried hpack-0.34.6, but its *library* does not support: Cabal-3.6.3.0
         - hpack-dhall < 0 # tried hpack-dhall-0.5.4, but its *library* requires the disabled package: hpack
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: aeson-2.0.3.0
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* does not support: bytestring-0.11.3.0


### PR DESCRIPTION
Cabal 3.6 support added in https://github.com/sol/hpack/pull/489 and
released as 0.34.7.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package hpack