### PR TITLE
re-enable esqueleto

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6090,7 +6090,6 @@ packages:
         - envy < 0 # tried envy-2.1.0.0, but its *library* does not support: bytestring-0.11.3.0
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
         - equal-files < 0 # tried equal-files-0.0.5.3, but its *executable* does not support: bytestring-0.11.3.0
-        - esqueleto < 0 # tried esqueleto-3.5.3.1, but its *library* does not support: time-1.11.1.1
         - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.6, but its *library* requires the disabled package: gloss
         - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
         - event < 0 # tried event-0.1.4, but its *library* does not support: containers-0.6.5.1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
