### PR TITLE
Re-enable hakyll

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6362,7 +6362,6 @@ packages:
         - hadolint < 0 # tried hadolint-2.9.3, but its *library* requires the disabled package: spdx
         - hadolint < 0 # tried hadolint-2.9.3, but its *library* requires the disabled package: timerep
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* does not support: bytestring-0.11.3.0
-        - hakyll < 0 # tried hakyll-4.15.1.1, but its *library* does not support: template-haskell-2.18.0.0
         - hal < 0 # tried hal-0.4.10, but its *library* requires the disabled package: envy
         - hamilton < 0 # tried hamilton-0.1.0.3, but its *library* requires the disabled package: typelits-witnesses
         - hapistrano < 0 # tried hapistrano-0.4.3.0, but its *executable* does not support: optparse-applicative-0.17.0.0


### PR DESCRIPTION
4.15.1.1-r2 allows template-haskell 2.18.0.0.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

  This doesn't work for me, even though 10 hours passed since I published the Hackage revision. `verify-package` claims that Hakyll still requires template-haskell `>=2.14 && <2.18`. I'm submitting the PR anyway to see what CI thinks of that.

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
