### PR TITLE
Add `time-units-types`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4606,7 +4606,8 @@ packages:
         - monad-logger-logstash
         - moss
         - network-wait
-        - servant-rate-limit < 0 # https://github.com/commercialhaskell/stackage/issues/6520
+        - servant-rate-limit
+        - time-units-types
         - wai-rate-limit
         - wai-rate-limit-redis
         - wai-saml2


### PR DESCRIPTION
This should fix #6520 and I have therefore re-enabled `servant-rate-limit` as well. Sorry about that.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):
