### PR TITLE
Reenable Agda

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5531,7 +5531,6 @@ packages:
     # verify if they have been fixeq.
     "Library and exe bounds failures":
         - ALUT < 0 # tried ALUT-2.4.0.3, but its *library* requires the disabled package: OpenAL
-        - Agda < 0 # tried Agda-2.6.2.1, but its *library* does not support: bytestring-0.11.3.0
         - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: streaming-bytestring
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* does not support: network-3.1.2.7


### PR DESCRIPTION
Agda-2.6.2.2 is compatible with the nightly snapshot (bytstring-0.11.3).

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version
