### PR TITLE
Add linear-generics and remove upper-bound on linear-base

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4698,7 +4698,7 @@ packages:
         - strong-path
 
     "Arnaud Spiwack <arnaud.spiwack@tweag.io> @aspiwack":
-        - linear-base < 0.2  # https://github.com/commercialhaskell/stackage/issues/6526
+        - linear-base
         - linear-generics
 
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":


### PR DESCRIPTION
As a co-maintainer of linear-generics, let me add it to stackage (see also linear-generics/linear-generics#14).
This lets me remove the upper-bound on linear-base introduced due to #6526 . Many thanks to the Stackage crew for flagging this.

Fixes #6526.

## Checklist
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

