### PR TITLE
Update Freckle packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1143,21 +1143,21 @@ packages:
         - yesod-paginator
 
     "Freckle Engineering <freckle-engineering@renaissance.com> @pbrisbin @mjgpy3 @stevenxl":
-        - bcp47
-        - bcp47-orphans
-        - faktory
-        - graphula
-        - hspec-expectations-json
-        - yesod-page-cursor
-        - yesod-routes-flow
-        - nonempty-zipper
-        - sendgrid-v3
-        - yesod-auth-oauth2
-        - hspec-junit-formatter
         - aws-xray-client
         - aws-xray-client-persistent
         - aws-xray-client-wai
+        - bcp47
+        - bcp47-orphans
+        - faktory
         - freckle-app
+        - graphula
+        - hspec-expectations-json
+        - hspec-junit-formatter
+        - nonempty-zipper
+        - sendgrid-v3
+        - yesod-auth-oauth2
+        - yesod-page-cursor
+        - yesod-routes-flow
 
     "Felipe Lessa <felipe.lessa@gmail.com> @meteficha":
         - fb

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5774,7 +5774,6 @@ packages:
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* does not support: bytestring-0.11.3.0
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* does not support: lens-5.1
         - bcp47 < 0 # tried bcp47-0.2.0.6, but its *library* requires the disabled package: country
-        - bcp47 < 0 # tried bcp47-0.2.0.6, but its *library* requires the disabled package: generic-arbitrary
         - bcp47-orphans < 0 # tried bcp47-orphans-0.1.0.5, but its *library* requires the disabled package: bcp47
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: aeson-2.0.3.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* does not support: beam-core-0.9.2.1
@@ -6107,7 +6106,6 @@ packages:
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: poly-0.5.0.0
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* does not support: protolude-0.3.0
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
-        - generic-arbitrary < 0 # tried generic-arbitrary-0.2.0, but its *library* does not support: base-4.16.1.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: base-4.16.1.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* does not support: generic-deriving-1.14.1
         - geniplate-mirror < 0 # tried geniplate-mirror-0.7.8, but its *library* does not support: template-haskell-2.18.0.0
@@ -7775,7 +7773,6 @@ skipped-tests:
     - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
     - ghc-prof # tried ghc-prof-1.4.1.9, but its *test-suite* does not support: attoparsec-0.14.4
     - gitlib-libgit2 # tried gitlib-libgit2-3.1.2.1, but its *test-suite* requires the disabled package: gitlib-test
-    - graphula # tried graphula-2.0.1.1, but its *test-suite* requires the disabled package: generic-arbitrary
     - greskell # tried greskell-2.0.0.0, but its *test-suite* does not support: bytestring-0.11.3.0
     - greskell-core # tried greskell-core-1.0.0.0, but its *test-suite* does not support: bytestring-0.11.3.0
     - haddock-library # tried haddock-library-1.10.0, but its *test-suite* does not support: base-compat-0.12.1

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1139,7 +1139,6 @@ packages:
         - bugsnag-haskell
         - gravatar
         - load-env
-        - yesod-auth-oauth2
         - yesod-markdown
         - yesod-paginator
 

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1155,6 +1155,7 @@ packages:
         - yesod-auth-oauth2
         - hspec-junit-formatter
         - aws-xray-client
+        - aws-xray-client-persistent
         - aws-xray-client-wai
         - freckle-app
 
@@ -5354,7 +5355,6 @@ packages:
         - auto < 0 # 0.4.3.1
         - autodocodec < 0 # 0.0.1.0 compile fail aeson 2.0
         - aws-lambda-haskell-runtime < 0 # 4.1.1 compile fail aeson 2.0
-        - aws-xray-client < 0 # 0.1.0.1
         - backprop < 0 # 0.2.6.4
         - binary-ext < 0 # 2.0.4
         - bins < 0 # 0.1.2.0
@@ -5757,7 +5757,6 @@ packages:
         - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: avers
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: bytestring-conversion
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* does not support: lens-5.1
-        - aws-xray-client-wai < 0 # tried aws-xray-client-wai-0.1.0.1, but its *library* requires the disabled package: aws-xray-client
         - axel < 0 # tried axel-0.0.12, but its *library* does not support: base-4.16.1.0
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient-universe
         - b9 < 0 # tried b9-3.2.3, but its *library* does not support: aeson-2.0.3.0


### PR DESCRIPTION
I made separate commits for easy rebase in case something's incorrect. There are
further details in some individual commit messages.

- Remove redundant yesod-auth-oauth2
- Re-enable generic-arbitrary and Freckle dependents
- Add/enable aws-xray packages
- Sort Freckle-maintained packages

Checklist:

- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following...

### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
