### PR TITLE
Unblock pantry-0.5.4@rev:1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6815,7 +6815,6 @@ packages:
         - pandoc-dhall-decoder < 0 # tried pandoc-dhall-decoder-0.1.0.1, but its *library* requires the disabled package: pandoc
         - pandoc-plot < 0 # tried pandoc-plot-1.5.1, but its *library* requires the disabled package: pandoc
         - pandoc-throw < 0 # tried pandoc-throw-0.1.0.0, but its *library* requires the disabled package: pandoc
-        - pantry < 0 # tried pantry-0.5.4, but its *library* does not support: Cabal-3.6.3.0
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* does not support: bytestring-0.11.3.0
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* does not support: template-haskell-2.18.0.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* does not support: bytestring-0.11.3.0
@@ -8741,7 +8740,6 @@ no-revisions:
 - gauge
 - stack
 - http-download
-- pantry
 - rio-prettyprint
 - hi-file-parser
 


### PR DESCRIPTION
As of revision 1 on Hackage, `pantry-0.5.4` builds with `Cabal-3.6.3.0`. This pull request proposes that the revision should be taken into account, and the package unblocked, on Stackage, with a view to including it in the GHC 9.2.2-based resolvers.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
