### PR TITLE
Re-enable lmza conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6656,7 +6656,6 @@ packages:
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: network-3.1.2.7
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-0.19
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* does not support: servant-client-0.19
-        - lzma-conduit < 0 # tried lzma-conduit-1.2.2, but its *library* does not support: bytestring-0.11.3.0
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-core
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
@@ -8346,7 +8345,6 @@ expected-test-failures:
 
     - hspec-expectations-pretty-diff # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
     - hw-kafka-client # missing exe https://github.com/commercialhaskell/stackage/pull/5542
-    - lzma-conduit # https://github.com/alphaHeavy/lzma-conduit/issues/19
     - pandoc # https://github.com/jgm/pandoc/issues/5582
     - password # Module not visible https://github.com/cdepillabout/password/issues/2
     - password-instances # Module not visible https://github.com/commercialhaskell/stackage/issues/4653


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):
      ./verify-package $package # or $package-$version


Version 1.2.3 fixes the bounds issue (and the test failure)

See
https://github.com/alphaHeavy/lzma-conduit/pull/22
https://github.com/alphaHeavy/lzma-conduit/issues/19