### PR TITLE
Re-enable conduit-algorithms

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5923,7 +5923,6 @@ packages:
         - compressed < 0 # tried compressed-3.11, but its *library* does not support: containers-0.6.5.1
         - compressed < 0 # tried compressed-3.11, but its *library* does not support: hashable-1.4.0.2
         - concurrent-supply < 0 # tried concurrent-supply-0.1.8, but its *library* does not support: hashable-1.4.0.2
-        - conduit-algorithms < 0 # tried conduit-algorithms-0.0.12.0, but its *library* requires the disabled package: lzma-conduit
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* does not support: bytestring-0.11.3.0
         - conduit-throttle < 0 # tried conduit-throttle-0.3.1.0, but its *library* requires the disabled package: throttle-io-stream
         - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* does not support: bytestring-0.11.3.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

 Now that `lzma-conduit` has been re-enabled, `conduit-algorithms` can also be brought back.