### PR TITLE
Add Co-Star Maintained Packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4783,6 +4783,14 @@ packages:
     "konsumlamm <konsumlamm@gmail.com> @konsumlamm":
         - rrb-vector
 
+    "Co-Star Astrological Society <tech@costarastrology.com> @costarastrology @prikhi":
+        - Plural
+        - byteslice
+        - cassava
+        - pwstore-fast
+        - run-st
+        - zigzag
+
     "Grandfathered dependencies":
         - Boolean
         - Cabal-syntax
@@ -5257,7 +5265,6 @@ packages:
         - Earley
         - bower-json < 0 # 1.0.0.1 compile fail aeson 2
         - boxes
-        - cassava
         - charsetdetect-ae # #6326/closed
         - coercible-utils # #6271
         - compiler-warnings # #6326/closed


### PR DESCRIPTION
Add `Plural`, `byteslice`, `pwstore-fast`, `zigzag`, & `run-st` to the package
set.

Adopt `cassava`.

Note: `byteslice` requires `run-st`. I manually validated that it builds successful when `run-st` is added to stackage by adding the latest `run-st` to `extra-deps` & building agaisnt nightly.

CC: @crushallhumans @kimberlykeller @beezee

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (Optional, replaced by GitHub Action check) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
