### PR TITLE
Reenable `hyperloglog`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6481,7 +6481,6 @@ packages:
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* does not support: time-1.11.1.1
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* does not support: aeson-2.0.3.0
         - hyper < 0 # tried hyper-0.2.1.1, but its *library* does not support: base-4.16.1.0
-        - hyperloglog < 0 # tried hyperloglog-0.4.5, but its *library* requires the disabled package: siphash
         - hyraxAbif < 0 # tried hyraxAbif-0.2.3.27, but its *library* requires the disabled package: protolude
         - iconv < 0 # tried iconv-0.4.1.3, but its *library* does not support: bytestring-0.11.3.0
         - idris < 0 # tried idris-1.3.4, but its *library* does not support: Cabal-3.6.3.0


### PR DESCRIPTION
`hyperloglog-0.4.6` builds with GHC 9.2 as it no longer depends on `siphash`.

-----

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] (Optional, replaced by GitHub Action check) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
