### PR TITLE
reenable typecheck-plugin-nat-simple and ranged-list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5509,7 +5509,6 @@ packages:
         - turtle-options < 0 # 0.1.0.4
         - type-assertions < 0 # 0.1.0.0
         - type-level-numbers < 0 # 0.1.1.1
-        - typecheck-plugin-nat-simple < 0 # 0.1.0.4
         - typelits-witnesses < 0 # 0.4.0.0
         - ulid < 0 # 0.3.0.0
         - uncertain < 0 # 0.3.1.0
@@ -6902,7 +6901,6 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* does not support: req-3.11.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires the disabled package: extensible
         - random-source < 0 # tried random-source-0.3.0.11, but its *library* does not support: base-4.16.1.0
-        - ranged-list < 0 # tried ranged-list-0.1.0.0, but its *library* requires the disabled package: typecheck-plugin-nat-simple
         - rate-limit < 0 # tried rate-limit-1.4.2, but its *library* does not support: time-1.11.1.1
         - rattletrap < 0 # tried rattletrap-11.2.6, but its *library* does not support: text-1.2.5.0
         - rdf < 0 # tried rdf-0.1.0.5, but its *library* does not support: attoparsec-0.14.4


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (Optional, replaced by GitHub Action check) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
