### PR TITLE
Add back logging-effect

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4736,6 +4736,7 @@ packages:
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":
         - reactive-banana
         - rel8
+        - logging-effect
 
     "Grzegorz Milka <grzegorzmilka@gmail.com> @gregorias":
         - trimdent


### PR DESCRIPTION
It was removed at some point. I've confirmed that logging-effect-1.3.13 (latest on hackage) builds on nightly-2022-05-12 (today's), so I think we can add it back.