### PR TITLE
Add lucid2 package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -987,6 +987,7 @@ packages:
         - hostname-validate
         - ini
         - lucid
+        - lucid2
         - pdfinfo
         - pure-io
         - sourcemap


### PR DESCRIPTION
This adds the major release lucid2 which features breaking changes (and would break about 70 package on Hackage) over lucid1. See [CHANGELOG](https://github.com/chrisdone/lucid/blob/master/lucid2/CHANGELOG.md), if interested. It is fully intended to sit side-by-side with lucid v1.

It's been tested with GHC 9.2 and has fewer dependencies than lucid1, so I'm certain it'll pass CI.