### PR TITLE
Revert "Add back logging-effect"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4736,7 +4736,6 @@ packages:
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":
         - reactive-banana
         - rel8
-        - logging-effect
 
     "Grzegorz Milka <grzegorzmilka@gmail.com> @gregorias":
         - trimdent


### PR DESCRIPTION


I opened a PR yesterday which passed the CI. After merging, the merge commit fails to pass. I'm not sure why. As a test, I'm opening this PR which reverts that change to see whether the addition of logging-effect is the cause, or whether there's a completely unrelated ambient change that has occurred since yesterday.

![Screenshot from 2022-05-13 09-33-31](https://user-images.githubusercontent.com/11019/168244538-d9e480bd-30ec-426b-a1d8-6f287241ec9a.png)

Reverts commercialhaskell/stackage#6570