### PR TITLE
open-witness has been fixed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5490,7 +5490,6 @@ packages:
         - nri-prelude < 0 # 0.6.0.6 compile fail aeson 2.0
         - nvim-hs-contrib < 0 # 2.0.0.0
         - odbc < 0 # 0.2.6 odbc
-        - open-witness < 0 # 0.5
         - pdfinfo < 0 # 1.5.4
         - pencil < 0 # 1.0.1
         - persistent-typed-db < 0 # 0.1.0.5 compile fail aeson 2.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (Optional, replaced by GitHub Action check) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


### CI

Our CI tries to line up build-constraints.yaml with the current state
of Hackage. This means that failures that are unrelated to your PR may
cause the check to fail. If you think a failure is unrelated you can
simply ignore it and the Curators will let you know if there is
anything you need to do.
