### PR TITLE
added registry back

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6523,7 +6523,6 @@ packages:
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* does not support: regex-base-0.94.0.2
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* does not support: regex-pcre-builtin-0.95.2.3.8.44
         - regex-tdfa-text < 0 # tried regex-tdfa-text-1.0.0.3, but its *library* does not support: regex-base-0.94.0.2
-        - registry < 0 # tried registry-0.2.1.0, but its *library* requires the disabled package: protolude
         - relapse < 0 # tried relapse-1.0.0.0, but its *library* does not support: attoparsec-0.14.4
         - relational-query < 0 # tried relational-query-0.12.3.0, but its *library* requires the disabled package: persistable-record
         - relational-query < 0 # tried relational-query-0.12.3.0, but its *library* requires the disabled package: product-isomorphic


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] (Optional, replaced by GitHub Action check) On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I could not run the script above since it is targeting the nightly resolver but also because it removes the `stack.yaml` file which is needed to resolve the missing `protolude` dependency. Is this ok or should I do something else? Thanks
