### PR TITLE
Add new bugsnag packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1145,6 +1145,9 @@ packages:
 
     "Patrick Brisbin @pbrisbin":
         - bugsnag-haskell
+        - bugsnag
+        - bugsnag-wai
+        - bugsnag-yesod
         - gravatar
         - load-env
         - yesod-markdown


### PR DESCRIPTION
I broke my bugsnag-haskell package down into three separate ones to
avoid unnecessary dependencies for non-web-framework users. Decided to
keep the now-deprecated package here too since it's not broken, it will
just see no more development.
