### PR TITLE
Add microaeson; move HsYAML family to @sjakobi

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -89,6 +89,7 @@ packages:
         - xor
         - http-io-streams
         - github
+        - microaeson
 
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
@@ -607,6 +608,8 @@ packages:
         - prettyprinter-compat-ansi-wl-pprint
         - prettyprinter-compat-annotated-wl-pprint
         - prettyprinter-convert-ansi-wl-pprint
+        - HsYAML
+        - HsYAML-aeson
 
     "Joe M <joe9mail@gmail.com> @joe9":
         - logger-thread
@@ -3055,7 +3058,6 @@ packages:
         - commonmark-extensions
         - commonmark-pandoc
         - unicode-collation
-        - HsYAML-aeson
         - ipynb
 
     "Karun Ramakrishnan <karun012@gmail.com> @karun012":
@@ -4849,7 +4851,6 @@ packages:
         - HTTP
         - HasBigDecimal
         - HsOpenSSL
-        - HsYAML
         - JuicyPixels-scale-dct
         - MemoTrie
         - NoHoed


### PR DESCRIPTION
New package `microaeson`.

I also took the liberty to move the `HsYAML` family to @sjakobi's care, who expressed interest in maintainership.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
