### PR TITLE
Reinstate direct-sqlite & sqlite-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7005,7 +7005,6 @@ packages:
         - splint < 0 # tried splint-1.0.1.5, but its *library* requires ghc >=8.10 && < 8.11 || >=9.0 && < 9.1 and the snapshot contains ghc-9.2.2
         - splint < 0 # tried splint-1.0.1.5, but its *library* requires hlint >=3.3 && < 3.4 and the snapshot contains hlint-3.4
         - split-record < 0 # tried split-record-0.1.1.4, but its *executable* requires the disabled package: soxlib
-        - sqlite-simple < 0 # tried sqlite-simple-0.4.18.0, but its *library* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
         - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* requires text >=1.2 && < 1.2.4 and the snapshot contains text-1.2.5.0
         - squeal-postgresql < 0 # tried squeal-postgresql-0.9.0.0, but its *library* requires the disabled package: records-sop
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires dhall >=1 && < 1.41 and the snapshot contains dhall-1.41.1

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -12,7 +12,7 @@ packages:
 
     "Martin Bednar <bednam17@fit.cvut.cz> @martin-bednar":
         - wai-middleware-bearer
-    
+
     "Xy Ren <xy.r@outlook.com> @re-xyr":
         - cleff
         - cleff-plugin
@@ -6010,7 +6010,6 @@ packages:
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.11.1.1
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.6.3.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
-        - direct-sqlite < 0 # tried direct-sqlite-2.3.26, but its *library* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires the disabled package: distributed-process
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires the disabled package: network-transport
         - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [debian-bootstrap.sh](https://github.com/commercialhaskell/stackage/blob/master/debian-bootstrap.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
