### PR TITLE
Add new toml-reader package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4503,6 +4503,7 @@ packages:
         - fourmolu
         - http-api-data-qq
         - persistent-mtl
+        - toml-reader
 
     "Akshay Mankar <itsakshaymankar@gmail.com> @akshaymankar":
         - jsonpath


### PR DESCRIPTION
Note: I did set up the integration test suite to not throw an error if the `toml-test` executable is not found. I do see that there's precedent for [installing executables in `debian-bootstrap.sh` for test suites](https://github.com/commercialhaskell/stackage/blob/eacede90c5b0738e74043bea5bbd35cbaf115a79/debian-bootstrap.sh#L293-L298); should I add the `toml-test` executable there?

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [debian-bootstrap.sh](https://github.com/commercialhaskell/stackage/blob/master/debian-bootstrap.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
