### PR TITLE
Add time-domain and sort my packages alphabetically

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -326,17 +326,18 @@ packages:
 
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
         - dunai
-        - rhine
-        - rhine-gloss
-        - finite-typelits
         - essence-of-live-coding
         - essence-of-live-coding-gloss
         - essence-of-live-coding-pulse
         - essence-of-live-coding-quickcheck
         - essence-of-live-coding-warp
-        - pulse-simple
-        - simple-affine-space
+        - finite-typelits
         - has-transformers
+        - pulse-simple
+        - rhine
+        - rhine-gloss
+        - simple-affine-space
+        - time-domain
 
     "Paul Johnson <paul@cogito.org.uk> @PaulJohnson":
         - geodetics


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
