### PR TITLE
add arbtt

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1385,6 +1385,7 @@ packages:
         - hweblib
 
     "Joachim Breitner <mail@joachim-breitner.de> @nomeata":
+        - arbtt
         - circle-packing
         - haskell-spacegoo
         - tasty-expected-failure

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1386,6 +1386,7 @@ packages:
 
     "Joachim Breitner <mail@joachim-breitner.de> @nomeata":
         - arbtt
+        - bytestring-progress # dependency of arbtt
         - circle-packing
         - haskell-spacegoo
         - tasty-expected-failure


### PR DESCRIPTION
The Debian package maintainers suggested I add `arbttt` to stackage to make their live easier. So let's try that…

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)