### PR TITLE
Re-enable spacecookie

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7042,7 +7042,6 @@ packages:
         - socket-activation < 0 # tried socket-activation-0.1.0.2, but its *library* requires network >=2.3 && < 2.9 and the snapshot contains network-3.1.2.7
         - sound-collage < 0 # tried sound-collage-0.2.1, but its *executable* requires the disabled package: soxlib
         - soxlib < 0 # tried soxlib-0.0.3.1, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - spacecookie < 0 # tried spacecookie-1.0.0.1, but its *library* requires the disabled package: socket
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires inline-java >=0.7.0 && < 0.9 and the snapshot contains inline-java-0.10.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires jvm >=0.4.0.1 && < 0.5 and the snapshot contains jvm-0.6.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: distributed-closure


### PR DESCRIPTION
After 381f92f7b3c4affa7ae6e84730efa6aed2c28644 which enabled socket
again, there are no problems building spacecookie anymore.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
