### PR TITLE
Re-enable massiv-persist and massiv-io. Remove disabled wai-middleware-auth

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3598,13 +3598,12 @@ packages:
         - printcess
 
     "Alexey Kuleshevich <lehins@yandex.ru> @lehins":
-        - wai-middleware-auth < 0 # 0.2.6.0 compile fail aeson 2
         - hip
         - massiv
-        - massiv-io < 0 # 1.0.0.1 ghc panic
+        - massiv-io
         - massiv-test
         - massiv-serialise
-        - massiv-persist < 0 # 1.0.0.2 compile fail
+        - massiv-persist
         - scheduler
         - Color
         - safe-decimal


### PR DESCRIPTION
I no longer maintain wai-middleware-auth and it seems to be disabled anyways. So, if there is need for it some one else can pick it up

`massiv-persist` has been fixed with a new release and `massiv-io` does not seem to panic

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
