### PR TITLE
Add gi-freetype2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3305,7 +3305,7 @@ packages:
         - gi-gmodule
         - gi-pango
         - gi-xlib
-        - gi-harfbuzz < 0.0.6 # https://github.com/commercialhaskell/stackage/issues/6644
+        - gi-harfbuzz
         - gi-gsk
         - gi-gtksource
         - gi-javascriptcore

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3311,6 +3311,7 @@ packages:
         - gi-javascriptcore
         - gi-vte
         - gi-webkit2
+        - gi-freetype2
 
     "Brandon Simmons <brandon.m.simmons@gmail.com> @jberryman":
         - directory-tree


### PR DESCRIPTION
Needed in newer versions of gi-harfbuzz, see https://github.com/commercialhaskell/stackage/issues/6644