### PR TITLE
Re-enable universum in stackage nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5661,7 +5661,6 @@ packages:
         - type-level-numbers < 0 # 0.1.1.1
         - typelits-witnesses < 0 # 0.4.0.0
         - uncertain < 0 # 0.3.1.0
-        - universum < 0 # 1.7.3
         - unordered-intmap < 0 # 0.1.1
         - users-persistent < 0 # 0.5.0.2
         - wai-predicates < 0 # 1.0.0


### PR DESCRIPTION
Universum was previously removed from stackage nightly due to a lack of support for GHC 9.x.
This has been fixed in universum-1.8.1, and the `./verify-package universum-1.8.1` script is now passing.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
