### PR TITLE
Remove “qm-interpolated-string” from broken packages list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6858,7 +6858,6 @@ packages:
         - protolude < 0 # tried protolude-0.3.1, but its *executable* requires base >=4.6 && < 4.15 and the snapshot contains base-4.16.2.0
         - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.16.2.0
         - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.16.2.0
-        - qm-interpolated-string < 0 # tried qm-interpolated-string-0.3.0.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.0.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires bytestring >=0.10.0.0 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128


### PR DESCRIPTION
New release `0.3.1.0` should build just fine now.

See also CI test against a nightly snapshot:
https://github.com/unclechu/haskell-qm-interpolated-string/runs/7394233664

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
