### PR TITLE
Reenable sdl2-gfx, sdl2-mixer and sdl2-image

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3673,7 +3673,7 @@ packages:
         - pipes-misc
         - stm-extras
 
-    "Siniša Biđin <sinisa@bidin.eu> @sbidin":
+    "Siniša Biđin <sinisa@bidin.eu> @sbidin": []
 
     "Aditya Manthramurthy <aditya.mmy@gmail.com> @donatello":
         - minio-hs

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3674,9 +3674,6 @@ packages:
         - stm-extras
 
     "Siniša Biđin <sinisa@bidin.eu> @sbidin":
-        - sdl2-image
-        - sdl2-mixer
-        - sdl2-gfx
 
     "Aditya Manthramurthy <aditya.mmy@gmail.com> @donatello":
         - minio-hs
@@ -4197,6 +4194,9 @@ packages:
         - polysemy-video
         - polysemy-vinyl
         - primitive-offset
+        - sdl2-gfx
+        - sdl2-image
+        - sdl2-mixer
         - shake-plus
         - shake-plus-extended
         - simple-media-timestamp

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5629,9 +5629,6 @@ packages:
         - rescue < 0 # 0.4.2.1
         - rigel-viz < 0 # 0.2.0.0 compile fail aeson 2.0
         - rose-trees < 0 # 0.0.4.5 compilation seems to hang?
-        - sdl2-gfx < 0 # 0.3.0.0 SDL2_gfx
-        - sdl2-image < 0 # 2.1.0.0 SDL2_image
-        - sdl2-mixer < 0 # 1.2.0.0 SDL2_mixer
         - servant-cli < 0 # 0.1.0.2 compile fail aeson 2.0
         - servant-github-webhook < 0 # 0.4.2.0 compile fail aeson 2.0
         - servant-tracing < 0 # 0.2.0.0 compile fail aeson 2.0


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
