### PR TITLE
Re-enable net-mqtt and net-mqtt-lens

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6725,8 +6725,6 @@ packages:
         - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires the disabled package: async-timer
         - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.16.2.0
         - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - net-mqtt < 0 # tried net-mqtt-0.8.2.0, but its *library* requires attoparsec >=0.13.2 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - net-mqtt-lens < 0 # tried net-mqtt-lens-0.1.1.0, but its *library* requires the disabled package: net-mqtt
         - nettle < 0 # tried nettle-0.3.0, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: hexstring
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: network-attoparsec


### PR DESCRIPTION
As far as I can tell from #5959, it was originally disabled due to
attoparsec and then later for websockets, but all of these issues have
been resolved.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
