### PR TITLE
Reenable tmp-proc and hspec-tmp-proc after release 0.5.1.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6476,8 +6476,6 @@ packages:
         - hspec-need-env < 0 # tried hspec-need-env-0.1.0.9, but its *library* requires base >=4.6.0.0 && < 4.16 and the snapshot contains base-4.16.3.0
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.16.3.0
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.9.7
-        - hspec-tmp-proc < 0 # tried hspec-tmp-proc-0.5.0.1, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.16.3.0
-        - hspec-tmp-proc < 0 # tried hspec-tmp-proc-0.5.0.1, but its *library* requires hspec >=2.7.0 && < 2.9.0 and the snapshot contains hspec-2.9.7
         - hspec-webdriver < 0 # tried hspec-webdriver-1.2.1, but its *library* requires hspec >=2.0 && < 2.8 and the snapshot contains hspec-2.9.7
         - hspec-webdriver < 0 # tried hspec-webdriver-1.2.1, but its *library* requires hspec-core >=2.0 && < 2.8 and the snapshot contains hspec-core-2.9.7
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.3.1
@@ -7093,7 +7091,6 @@ packages:
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: clay
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: threepenny-gui
         - thumbnail-plus < 0 # tried thumbnail-plus-1.0.5, but its *library* requires either < 5 and the snapshot contains either-5.0.2
-        - tmp-proc < 0 # tried tmp-proc-0.5.0.1, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.16.3.0
         - token-bucket < 0 # tried token-bucket-0.1.0.1, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.16.3.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.16.3.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


- tmp-proc does not use the latest version of one of its dependencies, mtl-2.3.0, as it is broken
- verify-package was run for tmp-proc; hspec-tmp-proc works as well, but can't be checked using verify-package as tmp-proc is not in the latest snapshot