### PR TITLE
Re-enable password and password-instances

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6732,7 +6732,6 @@ packages:
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell ==2.15.* and the snapshot contains template-haskell-2.18.0.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires parser-combinators >=1.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
-        - password < 0 # tried password-3.0.1.0, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.7
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires hashtables ==1.0.* and the snapshot contains hashtables-1.3
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires monad-control ==0.3.* and the snapshot contains monad-control-1.0.3.1
@@ -7744,7 +7743,6 @@ skipped-tests:
     - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell-quickcheck
     - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.9.7
     - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec-discover >=2.2 && < 2.8 and the snapshot contains hspec-discover-2.9.7
-    - password-instances # tried password-instances-3.0.0.0, but its *test-suite* requires the disabled package: password
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
     - polysemy # tried polysemy-1.7.1.0, but its *test-suite* requires doctest >=0.16.0.1 && < 0.19 and the snapshot contains doctest-0.20.0
     - polysemy-plugin # tried polysemy-plugin-0.4.3.1, but its *test-suite* requires doctest >=0.16.0.1 && < 0.19 and the snapshot contains doctest-0.20.0
@@ -8235,8 +8233,6 @@ expected-test-failures:
     - hspec-expectations-pretty-diff # https://github.com/unrelentingtech/hspec-expectations-pretty-diff/issues/7
     - hw-kafka-client # missing exe https://github.com/commercialhaskell/stackage/pull/5542
     - pandoc # https://github.com/jgm/pandoc/issues/5582
-    - password # Module not visible https://github.com/cdepillabout/password/issues/2
-    - password-instances # Module not visible https://github.com/commercialhaskell/stackage/issues/4653
     - pcg-random # https://github.com/cchalmers/pcg-random/pull/7
     - persistent-mongoDB # Requires a running server
     - persistent-mysql # https://github.com/commercialhaskell/stackage/issues/4764


### PR DESCRIPTION
Re-enable `password` and `password-instances` libraries.

This was brought up at https://github.com/cdepillabout/password/issues/60.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
