### PR TITLE
Add tmp-proc-{postgres,redis,rabbitmq}

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4823,6 +4823,9 @@ packages:
     "Tim Emiola <tim.emiola@gmail.com> @adetokunbo":
         - hspec-tmp-proc
         - tmp-proc
+        - tmp-proc-postgres
+        - tmp-proc-redis
+        - tmp-proc-rabbitmq
         - wai-middleware-delegate
 
     "Francisco Vallarino <fjvallarino@gmail.com> @fjvallarino":


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


The packages all verified ok; they are all up-to-date with their dependencies, but tmp-proc, on which they all depend, has an out-of-date dependency, mtl-2.3, which is broken.