### PR TITLE
Re-enable servant-cassava

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6914,8 +6914,6 @@ packages:
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.19
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.19.1
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.11.1.1
-        - servant-cassava < 0 # tried servant-cassava-0.10.1, but its *library* requires base-compat >=0.9.1 && < 0.12 and the snapshot contains base-compat-0.12.1
-        - servant-cassava < 0 # tried servant-cassava-0.10.1, but its *library* requires servant >=0.7 && < 0.19 and the snapshot contains servant-0.19
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.0.3.0
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.19
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.0.3.0
@@ -7773,7 +7771,6 @@ skipped-tests:
     - schematic # tried schematic-0.5.1.0, but its *test-suite* requires base >=4.11 && < 4.13 and the snapshot contains base-4.16.3.0
     - servant-auth-docs # tried servant-auth-docs-0.2.10.0, but its *test-suite* requires doctest >=0.11.3 && < 0.19 and the snapshot contains doctest-0.20.0
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* requires lens-aeson >=1.0.2 && < 1.2 and the snapshot contains lens-aeson-1.2.1
-    - servant-cassava # tried servant-cassava-0.10.1, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.19 and the snapshot contains servant-server-0.19.1
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.9.7
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9 and the snapshot contains hspec-core-2.9.7
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires hspec >=2.6.0 && < 2.8 and the snapshot contains hspec-2.9.7


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      ./verify-package servant-cassava
