### PR TITLE
Add tztime

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3867,6 +3867,7 @@ packages:
         - universum
         - with-utf8
         - uncaught-exception
+        - tztime
 
     "Holmusk <tech@holmusk.com> @arbus":
         - elm-street < 0 # 0.2.0.0 internal library
@@ -8308,6 +8309,7 @@ expected-haddock-failures:
     - hw-rankselect
     - doctest-parallel # https://github.com/commercialhaskell/stackage/issues/5014
     - d10 # 1.0.1.0
+    - tztime # https://github.com/commercialhaskell/stackage/issues/5014
 
 # end of expected-haddock-failures
 


### PR DESCRIPTION
I ran the `verify-package` script and ran into the same error as https://github.com/commercialhaskell/stackage/issues/5014 and #6371 (we have a test suite that uses `doctest-parallel`), so I added `tztime` to the `expected-haddock-failures` section as well.

```
doctest-parallel> Cabal-simple_mPHDZzAJ_3.6.3.0_ghc-9.2.4: internal error when calculating
doctest-parallel> Documentation created:
doctest-parallel> transitive package dependencies.
doctest-parallel> .stack-work/dist/x86_64-linux-tinfo6/Cabal-3.6.3.0/doc/html/doctest-parallel/index.html,
doctest-parallel> Debug info: [] 
```
----

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
