### PR TITLE
Re-enable ghc-parser, ihaskell, ihaskell-vega

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6181,7 +6181,6 @@ packages:
         - geniplate-mirror < 0 # tried geniplate-mirror-0.7.8, but its *library* requires template-haskell < 2.18 and the snapshot contains template-haskell-2.18.0.0
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.41.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.2.4
-        - ghc-parser < 0 # tried ghc-parser-0.2.3.0, but its *library* requires ghc >=8.0 && < 9.1 and the snapshot contains ghc-9.2.4
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.2.4
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires the disabled package: ghcjs-dom-jsaddle
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
@@ -6502,8 +6501,6 @@ packages:
         - idris < 0 # tried idris-1.3.4, but its *library* requires network >=2.7 && < 3.1.2 and the snapshot contains network-3.1.2.7
         - idris < 0 # tried idris-1.3.4, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
         - iff < 0 # tried iff-0.0.6, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - ihaskell < 0 # tried ihaskell-0.10.2.2, but its *library* requires the disabled package: ghc-parser
-        - ihaskell-hvega < 0 # tried ihaskell-hvega-0.5.0.3, but its *library* requires the disabled package: ihaskell
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: log-warper
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: text-format


### PR DESCRIPTION
Thanks to https://github.com/IHaskell/IHaskell/issues/1367, these should work with GHC 9.2 now.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

(I verified for `ghc-parser`, but couldn't verify `ihaskell` since it depends on `ghc-parser`.)