### PR TITLE
enable cabal-install-3.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3107,7 +3107,7 @@ packages:
 
     "Mikhail Glushenkov <mikhail.glushenkov@gmail.com> @23Skidoo":
         # - Cabal # take the one that ships with GHC
-        - cabal-install
+        - cabal-install < 3.8
         - pointful
 
     "Lennart Kolmodin <kolmodin@gmail.com> @kolmodin":
@@ -5972,10 +5972,6 @@ packages:
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires base >=4.3 && < 4.16 and the snapshot contains base-4.16.3.0
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.3, but its *executable* requires the disabled package: cabal-plan
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* requires HTTP >=4000.1.5 && < 4000.4 and the snapshot contains HTTP-4000.4.1
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* requires base >=4.8 && < 4.15 and the snapshot contains base-4.16.3.0
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* requires hashable >=1.0 && < 1.4 and the snapshot contains hashable-1.4.0.2
-        - cabal-install < 0 # tried cabal-install-3.6.2.0, but its *executable* requires time >=1.5.0.1 && < 1.11 and the snapshot contains time-1.11.1.1
         - cabal-plan < 0 # tried cabal-plan-0.7.2.1, but its *executable* requires optparse-applicative ^>=0.16.0.0 and the snapshot contains optparse-applicative-0.17.0.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.0.3.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.3.1


### PR DESCRIPTION
cabal-install-3.6.2.0 was recently [revised](https://github.com/haskell/cabal/pull/8435) on Hackage to allow building with Stackage Nightly :+1: 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
