### PR TITLE
webdriver: re-enable and change maintainer

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -374,6 +374,7 @@ packages:
         - sandwich-slack
         - sandwich-webdriver
         - slack-progressbar
+        - webdriver
 
     "Paulo Tanaka <paulot@fb.com> @paulot":
         # on behalf of Bryan O'Sullivan @bos:
@@ -3925,7 +3926,6 @@ packages:
         - distributed-process-monad-control
 
     "Adam Curtis <kallisti.dev@gmail.com> @kallisti-dev":
-        - webdriver
         - cond
 
     "Naoto Shimazaki <naoto.shimazaki@gmail.com> @nshimaza":
@@ -6870,7 +6870,6 @@ packages:
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.11.1.1
         - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires the disabled package: salak
         - saltine < 0 # tried saltine-0.1.1.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.0.6, but its *library* requires the disabled package: webdriver
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.16.3.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.17.0
@@ -7167,8 +7166,6 @@ packages:
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.17.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.18.0.0
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* requires aeson >=0.6.2.0 && < 1.6 and the snapshot contains aeson-2.0.3.0
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.16.3.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.9.0.1
         - websockets-simple < 0 # tried websockets-simple-0.2.0, but its *library* requires the disabled package: monad-control-aligned


### PR DESCRIPTION
I recently completed a Hackage package takeover for `webdriver`. Now it builds on the latest GHCs.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version
