### PR TITLE
re-enable sydtest-webdriver packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4085,6 +4085,9 @@ packages:
         - sydtest-servant
         - sydtest-typed-process
         - sydtest-wai
+        - sydtest-webdriver
+        - sydtest-webdriver-screenshot
+        - sydtest-webdriver-yesod
         - sydtest-yesod
         - typed-uuid
         - validity
@@ -4101,11 +4104,6 @@ packages:
         - validity-unordered-containers
         - validity-uuid
         - validity-vector
-
-      # webdriver has not been enabled
-      # - sydtest-webdriver
-      # - sydtest-webdriver-screenshot
-      # - sydtest-webdriver-yesod
 
 
     "Henry Laxen <nadine.and.henry@pobox.com> @HenryLaxen":


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
