### PR TITLE
GHC 9.4.3 updates

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -272,7 +272,7 @@ packages:
         - list-predicate
 
     "Guillaume Bouchard <guillaum.bouchard@gmail.com> @guibou":
-        - krank < 0 # 0.2.3 via GHC 9.2.4, https://github.com/commercialhaskell/stackage/issues/6666
+        - krank
         - pretty-terminal
         - PyF
 
@@ -330,7 +330,7 @@ packages:
         - git-vogue < 0 # 0.3.0.2 compile fail
 
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
-        - dunai < 0 # https://github.com/commercialhaskell/stackage/issues/6751
+        - dunai
         - essence-of-live-coding
         - essence-of-live-coding-gloss
         - essence-of-live-coding-pulse
@@ -2612,7 +2612,7 @@ packages:
         - ekg-wai
         - haxl-amazonka
         - hasql-migration
-        - servant-JuicyPixels
+        - servant-JuicyPixels < 0 # 0.3.1.0 compile fail
 
     "Steven Fontanella <steven.fontanella@gmail.com> @stevenfontanella":
         - microlens
@@ -4167,7 +4167,7 @@ packages:
         - snap
         - conferer
         - conferer-snap
-        - conferer-warp < 0 # https://github.com/commercialhaskell/stackage/issues/6683
+        - conferer-warp
         - conferer-hspec
         - conferer-aeson
 
@@ -4528,7 +4528,7 @@ packages:
         - gtk-strut
         - rate-limit
         - status-notifier-item
-        - taffybar < 0 # 3.3.0 compile fail https://github.com/taffybar/taffybar/issues/542
+        - taffybar
         - time-units
         - xml-helpers
         - xdg-desktop-entry
@@ -4574,6 +4574,8 @@ packages:
         - morpheus-graphql-app
         - morpheus-graphql-code-gen
         - morpheus-graphql-tests
+        - morpheus-graphql-code-gen-utils
+        - morpheus-graphql-server
 
     "Satoshi Egi <egi@egison.org> @egisatoshi":
         - backtracking
@@ -5412,7 +5414,7 @@ packages:
         - universe-some
         - unix-time
         - url
-        - utf8-light
+        - utf8-light < 0 # 0.4.2 compile fail
         - utf8-string
         - uuid-types
         - validationt
@@ -5528,7 +5530,7 @@ packages:
         - PSQueue < 0 # 1.1.1 bounds
         - Unique < 0 # 0.4.7.9 removed
         - cli < 0 # 0.2.0 removed
-        - co-log-core < 0 # 0.3.1.0 removed #5965/closed
+        - co-log-core < 0 # 0.3.2.0 removed #5965/closed
         - co-log-polysemy < 0 # 0.0.1.3 removed #5965/closed
         - fingertree-psqueue < 0 # 0.3 compile fail
         - hastache < 0 # 0.6.1 bounds
@@ -5546,7 +5548,7 @@ packages:
         - tinytemplate < 0 # 0.1.2.0 compile fail
         - tomland < 0 # 1.3.3.2 #5965/closed
         - type-combinators < 0 # 0.2.4.3 compile fail https://github.com/kylcarte/type-combinators/issues/8
-        - typerep-map < 0 # 0.5.0.0 internal library #5965/closed
+        - typerep-map < 0 # 0.6.0.0 internal library #5965/closed
         - universe-instances-base < 0 # 1.1 deprecated
         - universe-instances-trans < 0 # 1.1 deprecated
         - validation-selective < 0 # 0.1.0.2 #5965/closed
@@ -5620,7 +5622,6 @@ packages:
         - haskell-awk < 0 # 1.2.0.1
         - haskell-import-graph < 0 # 1.0.4
         - haskell-spacegoo < 0 # 0.2.0.1
-        - haskoin-node < 0 # 0.17.14 libsecp256k1
         - hbeanstalk < 0 # 0.2.4
         - hexstring < 0 # 0.11.1
         - highjson < 0 # 0.5.0.0 compile fail aeson 2.0
@@ -5659,7 +5660,7 @@ packages:
         - postgresql-transactional < 0 # 1.1.1
         - protocol-buffers < 0 # 2.4.17
         - pushbullet-types < 0 # 0.4.1.0 compile fail aeson 2.0
-        - raaz < 0 # 0.3.6 multiple libraries
+        - raaz < 0 # 0.3.7 multiple libraries
         - record-wrangler < 0 # 0.1.1.0
         - regex-compat-tdfa < 0 # 0.95.1.4
         - rescue < 0 # 0.4.2.1
@@ -5735,10 +5736,8 @@ packages:
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.21.10
         - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
-        - H < 0 # tried H-0.9.0.1, but its *executable* requires the disabled package: inline-r
         - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires base >=4.11.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - HStringTemplate < 0 # tried HStringTemplate-0.8.8, but its *library* requires template-haskell >=2.3 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - HasBigDecimal < 0 # tried HasBigDecimal-0.2.0.0, but its *executable* requires the disabled package: criterion
         - HaskellNet < 0 # tried HaskellNet-0.6.0.1, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.17.0.0
         - HaskellNet-SSL < 0 # tried HaskellNet-SSL-0.3.4.4, but its *library* requires the disabled package: HaskellNet
@@ -5774,7 +5773,7 @@ packages:
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.2.7
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
-        - Rattus < 0 # tried Rattus-0.5.0.1, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.2
+        - Rattus < 0 # tried Rattus-0.5.0.1, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.3
         - SciBaseTypes < 0 # tried SciBaseTypes-0.1.1.0, but its *library* requires the disabled package: DPutils
         - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.1
         - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* requires base >4.4 && < 4.14 and the snapshot contains base-4.17.0.0
@@ -5812,18 +5811,15 @@ packages:
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: cuda
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
-        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.1, but its *library* requires the disabled package: servant
-        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.1, but its *library* requires the disabled package: servant-client
-        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.1, but its *library* requires the disabled package: servant-client-core
         - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires aeson >=0.7 && < 1.6 || >=2.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - aeson-default < 0 # tried aeson-default-0.9.1.0, but its *library* requires aeson >=1.2 && < 2 and the snapshot contains aeson-2.1.1.0
         - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires aeson >=0.11 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.0.0
         - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires lens >=4.13 && < 5.2 and the snapshot contains lens-5.2
-        - aeson-schemas < 0 # tried aeson-schemas-1.3.5.1, but its *library* requires template-haskell >=2.12.0.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - aeson-schemas < 0 # tried aeson-schemas-1.3.5.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.1
-        - aeson-typescript < 0 # tried aeson-typescript-0.4.1.0, but its *library* requires the disabled package: string-interpolate
+        - aeson-schemas < 0 # tried aeson-schemas-1.4.0.0, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - aeson-schemas < 0 # tried aeson-schemas-1.4.0.0, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.1
+        - aeson-typescript < 0 # tried aeson-typescript-0.4.2.0, but its *library* requires the disabled package: string-interpolate
         - airship < 0 # tried airship-0.9.5, but its *library* requires mime-types >=0.1.0 && < 0.1.1 and the snapshot contains mime-types-0.1.1.0
         - alerts < 0 # tried alerts-0.1.2.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.1
         - alg < 0 # tried alg-0.2.13.1, but its *library* requires base >=4.11 && < 4.15 and the snapshot contains base-4.17.0.0
@@ -5958,7 +5954,7 @@ packages:
         - aura < 0 # tried aura-3.2.9, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.1.1.0
         - aura < 0 # tried aura-3.2.9, but its *library* requires algebraic-graphs >=0.1 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - aura < 0 # tried aura-3.2.9, but its *library* requires time >=1.8 && < 1.12 and the snapshot contains time-1.12.2
-        - autodocodec-openapi3 < 0 # tried autodocodec-openapi3-0.2.1.1, but its *library* requires the disabled package: openapi3
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires MonadRandom >=0.4.2.3 && < 0.6 and the snapshot contains MonadRandom-0.6
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires aeson >=1.1.2.1 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires base >=4.9.0.0 && < 4.15 and the snapshot contains base-4.17.0.0
@@ -5970,15 +5966,11 @@ packages:
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.1
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
         - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: avers
-        - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: servant
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: avers
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: bytestring-conversion
-        - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: servant
-        - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: servant-server
         - avro < 0 # tried avro-0.6.1.2, but its *library* requires the disabled package: HasBigDecimal
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires lens >=4.1 && < 5 and the snapshot contains lens-5.2
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.1
-        - aws < 0 # tried aws-0.22.1, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.11, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.11, but its *library* requires text ^>=1.2.4.1 and the snapshot contains text-2.0.1
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.11, but its *library* requires time ^>=1.9.3 || ^>=1.10 || ^>=1.11 and the snapshot contains time-1.12.2
@@ -5992,7 +5984,6 @@ packages:
         - barrier < 0 # tried barrier-0.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - barrier < 0 # tried barrier-0.1.1, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.1
         - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* requires base ==4.13.0.0 and the snapshot contains base-4.17.0.0
-        - base16 < 0 # tried base16-0.3.2.0, but its *library* requires base >=4.14 && < 4.17 and the snapshot contains base-4.17.0.0
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.3.1
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires lens >=4 && < 5.1 and the snapshot contains lens-5.2
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
@@ -6054,7 +6045,7 @@ packages:
         - blaze-colonnade < 0 # tried blaze-colonnade-1.2.2.1, but its *library* requires the disabled package: colonnade
         - bloomfilter < 0 # tried bloomfilter-2.0.1.0, but its *library* requires base >=4.4 && < 4.16 and the snapshot contains base-4.17.0.0
         - bnb-staking-csvs < 0 # tried bnb-staking-csvs-0.2.1.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.1
-        - board-games < 0 # tried board-games-0.3, but its *library* requires enummapset >=0.1 && < 0.7 and the snapshot contains enummapset-0.7.0.0
+        - board-games < 0 # tried board-games-0.3, but its *library* requires enummapset >=0.1 && < 0.7 and the snapshot contains enummapset-0.7.1.0
         - bookkeeping < 0 # tried bookkeeping-0.4.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.1
         - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.17.0.0
         - boomerang < 0 # tried boomerang-1.4.8, but its *library* requires template-haskell < 2.19 and the snapshot contains template-haskell-2.19.0.0
@@ -6064,22 +6055,19 @@ packages:
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires box ^>=0.8 and the snapshot contains box-0.9.0
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires time ^>=1.9 and the snapshot contains time-1.12.2
-        - breakpoint < 0 # tried breakpoint-0.1.0.0, but its *library* requires base >=4.14.0.0 && < 4.17.0.0 and the snapshot contains base-4.17.0.0
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires aeson ^>=2.0.1 and the snapshot contains aeson-2.1.1.0
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires base ^>=4.15.0 and the snapshot contains base-4.17.0.0
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires bytestring ^>=0.10.12 and the snapshot contains bytestring-0.11.3.1
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc ^>=9.0.1 and the snapshot contains ghc-9.4.2
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot ^>=9.0.1 and the snapshot contains ghc-boot-9.4.2
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot-th ^>=9.0.1 and the snapshot contains ghc-boot-th-9.4.2
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-exactprint ^>=0.6.4 and the snapshot contains ghc-exactprint-1.6.0
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc ^>=9.0.1 and the snapshot contains ghc-9.4.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot ^>=9.0.1 and the snapshot contains ghc-boot-9.4.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot-th ^>=9.0.1 and the snapshot contains ghc-boot-th-9.4.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-exactprint ^>=0.6.4 and the snapshot contains ghc-exactprint-1.6.1
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires semigroups ^>=0.19.2 and the snapshot contains semigroups-0.20
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires text ^>=1.2.5 and the snapshot contains text-2.0.1
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: hint
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: hledger
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: hledger-lib
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
-        - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
-        - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.0, but its *library* requires time >=1.4 && < 1.12 and the snapshot contains time-1.12.2
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: protolude
@@ -6146,19 +6134,17 @@ packages:
         - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
         - check-email < 0 # tried check-email-1.0.2, but its *library* requires the disabled package: email-validate
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.1.0
-        - chronos < 0 # tried chronos-1.1.4, but its *library* requires base >=4.14 && < 4.17 and the snapshot contains base-4.17.0.0
-        - chronos < 0 # tried chronos-1.1.4, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
-        - chronos < 0 # tried chronos-1.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
+        - chronos < 0 # tried chronos-1.1.5, but its *library* requires the disabled package: bytebuild
         - chronos-bench < 0 # tried chronos-bench-0.2.0.2, but its *library* requires the disabled package: chronos
         - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.17.0.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.2
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.3
         - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-boot >=8.6.0 && < 9.1 and the snapshot contains ghc-boot-9.4.2
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-boot >=8.6.0 && < 9.1 and the snapshot contains ghc-boot-9.4.3
         - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-prim >=0.3.1.0 && < 0.8 and the snapshot contains ghc-prim-0.9.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghci >=8.6.0 && < 9.1 and the snapshot contains ghci-9.4.2
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghci >=8.6.0 && < 9.1 and the snapshot contains ghci-9.4.3
         - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires aeson >=0.6.2.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.2
+        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.3
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
         - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
@@ -6169,7 +6155,7 @@ packages:
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - clay < 0 # tried clay-0.14.0, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.17.0.0
         - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.0.0
-        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.2
+        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.3
         - climb < 0 # tried climb-0.4.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* requires clock >=0.4.6 && < 0.8.0 and the snapshot contains clock-0.8.3
         - cmark < 0 # tried cmark-0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
@@ -6178,8 +6164,7 @@ packages:
         - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.17.0.0
         - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires the disabled package: co-log-core
         - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
-        - cointracking-imports < 0 # tried cointracking-imports-0.1.0.1, but its *library* requires text < 2 and the snapshot contains text-2.0.1
-        - colonnade < 0 # tried colonnade-1.2.0.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
+        - cointracking-imports < 0 # tried cointracking-imports-0.1.0.2, but its *library* requires the disabled package: xlsx
         - colonnade < 0 # tried colonnade-1.2.0.2, but its *library* requires semigroups >=0.18.2 && < 0.20 and the snapshot contains semigroups-0.20
         - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.17.0.0
@@ -6228,7 +6213,6 @@ packages:
         - country < 0 # tried country-0.2.3.1, but its *library* requires the disabled package: bytebuild
         - covariance < 0 # tried covariance-0.2.0.1, but its *library* requires the disabled package: statistics
         - crc32c < 0 # tried crc32c-0.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - credential-store < 0 # tried credential-store-0.1.2, but its *library* requires the disabled package: dbus
         - criterion < 0 # tried criterion-1.6.0.0, but its *library* requires the disabled package: statistics
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
@@ -6270,15 +6254,11 @@ packages:
         - data-forest < 0 # tried data-forest-0.1.0.9, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
         - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming-bytestring
-        - dbcleaner < 0 # tried dbcleaner-0.1.3, but its *library* requires the disabled package: postgresql-simple
-        - dbus < 0 # tried dbus-1.2.26, but its *library* requires template-haskell >=2.18 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - dbus-hslogger < 0 # tried dbus-hslogger-0.1.0.1, but its *library* requires the disabled package: dbus
         - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
-        - deepseq-generics < 0 # tried deepseq-generics-0.2.0.0, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.17.0.0
-        - deepseq-generics < 0 # tried deepseq-generics-0.2.0.0, but its *library* requires ghc-prim >=0.2 && < 0.9 and the snapshot contains ghc-prim-0.9.0
         - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.17.0.0
         - dense-linear-algebra < 0 # tried dense-linear-algebra-0.1.0.0, but its *library* requires the disabled package: vector-binary-instances
-        - dependent-map < 0 # tried dependent-map-0.4.0.0, but its *library* requires the disabled package: dependent-sum
+        - dependent-map < 0 # tried dependent-map-0.4.0.0, but its *library* requires constraints-extras >=0.2.3.0 && < 0.4 and the snapshot contains constraints-extras-0.4.0.0
+        - dependent-sum < 0 # tried dependent-sum-0.7.1.0, but its *library* requires constraints-extras >=0.2 && < 0.4 and the snapshot contains constraints-extras-0.4.0.0
         - dependent-sum < 0 # tried dependent-sum-0.7.1.0, but its *library* requires some >=1.0.1 && < 1.0.4 and the snapshot contains some-1.0.4.1
         - dependent-sum-template < 0 # tried dependent-sum-template-0.1.1.1, but its *library* requires the disabled package: dependent-sum
         - dependent-sum-template < 0 # tried dependent-sum-template-0.1.1.1, but its *library* requires the disabled package: th-extras
@@ -6300,7 +6280,6 @@ packages:
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.17.0.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.1
-        - dice < 0 # tried dice-0.1.0.1, but its *library* requires random-fu < 0.3 and the snapshot contains random-fu-0.3.0.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.0.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires attoparsec >=0.10.4.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.17.0.0
@@ -6323,7 +6302,7 @@ packages:
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
         - diversity < 0 # tried diversity-0.8.1.0, but its *library* requires the disabled package: fasta
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires text >=1.0.0 && < 2.0.0 and the snapshot contains text-2.0.1
-        - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-11.0.0
+        - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-12.0.0
         - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
         - doctest-driver-gen < 0 # tried doctest-driver-gen-0.3.0.5, but its *library* requires base >=4.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - doctest-extract < 0 # tried doctest-extract-0.1, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
@@ -6338,10 +6317,9 @@ packages:
         - download < 0 # tried download-0.3.2.7, but its *library* requires the disabled package: feed
         - download-curl < 0 # tried download-curl-0.1.4, but its *library* requires the disabled package: feed
         - drawille < 0 # tried drawille-0.1.2.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.6
-        - drifter-postgresql < 0 # tried drifter-postgresql-0.2.1, but its *library* requires the disabled package: postgresql-simple
+        - dunai < 0 # tried dunai-0.9.1, but its *library* requires MonadRandom >=0.2 && < 0.6 and the snapshot contains MonadRandom-0.6
         - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.17.0.0
         - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.2
-        - ed25519 < 0 # tried ed25519-0.0.5.0, but its *library* requires ghc-prim >=0.1 && < 0.9 and the snapshot contains ghc-prim-0.9.0
         - edit < 0 # tried edit-1.0.1.0, but its *library* requires QuickCheck >=2.10 && < 2.13 and the snapshot contains QuickCheck-2.14.2
         - edit < 0 # tried edit-1.0.1.0, but its *library* requires base >=4.9 && < 4.12 and the snapshot contains base-4.17.0.0
         - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* requires free >=4.9 && < 5 and the snapshot contains free-5.1.9
@@ -6393,14 +6371,10 @@ packages:
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
         - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
         - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.7, but its *library* requires template-haskell >=2.18 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - experimenter < 0 # tried experimenter-0.1.0.14, but its *library* requires the disabled package: persistent-postgresql
         - fast-builder < 0 # tried fast-builder-0.1.3.0, but its *library* requires base >=4.8 && < 4.16 and the snapshot contains base-4.17.0.0
         - fasta < 0 # tried fasta-0.10.4.2, but its *library* requires the disabled package: pipes-text
-        - fastmemo < 0 # tried fastmemo-0.1.0.1, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.0.0
-        - fastmemo < 0 # tried fastmemo-0.1.0.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.17.0.0
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires template-haskell >=2.2 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - fdo-notify < 0 # tried fdo-notify-0.3.1, but its *library* requires the disabled package: dbus
         - feed < 0 # tried feed-1.3.2.1, but its *library* requires base >=4 && < 4.17 and the snapshot contains base-4.17.0.0
         - feed < 0 # tried feed-1.3.2.1, but its *library* requires time < 1.12 and the snapshot contains time-1.12.2
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
@@ -6413,20 +6387,19 @@ packages:
         - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
         - forma < 0 # tried forma-1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.1
         - formatn < 0 # tried formatn-0.2.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
-        - fourmolu < 0 # tried fourmolu-0.8.2.0, but its *library* requires Cabal >=3.6 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - fourmolu < 0 # tried fourmolu-0.8.2.0, but its *library* requires ghc-lib-parser >=9.2 && < 9.3 and the snapshot contains ghc-lib-parser-9.4.2.20220822
-        - freckle-app < 0 # tried freckle-app-1.7.0.0, but its *library* requires the disabled package: postgresql-simple
+        - fourmolu < 0 # tried fourmolu-0.9.0.0, but its *library* requires Cabal >=3.6 && < 3.7 and the snapshot contains Cabal-3.8.1.0
+        - fourmolu < 0 # tried fourmolu-0.9.0.0, but its *library* requires ghc-lib-parser >=9.2 && < 9.3 and the snapshot contains ghc-lib-parser-9.4.3.20221104
         - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - friday < 0 # tried friday-0.2.3.1, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.6
         - friday-juicypixels < 0 # tried friday-juicypixels-0.1.2.4, but its *library* requires the disabled package: friday
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.0.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2
         - fuzzyset < 0 # tried fuzzyset-0.2.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
+        - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires poly >=0.3.2 && < 0.5 and the snapshot contains poly-0.5.0.0
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.2
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.17.0.0
-        - generic-monoid < 0 # tried generic-monoid-0.1.0.1, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.17.0.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires generic-deriving >=1.6 && < 1.14 and the snapshot contains generic-deriving-1.14.2
         - geniplate-mirror < 0 # tried geniplate-mirror-0.7.8, but its *library* requires template-haskell < 2.18 and the snapshot contains template-haskell-2.19.0.0
@@ -6434,17 +6407,16 @@ packages:
         - geojson < 0 # tried geojson-4.1.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
         - ghc-bignum-orphans < 0 # tried ghc-bignum-orphans-0.1.1, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.41.2
-        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.4.2
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.4.3
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text >=1.2.3.2 && < 1.3 and the snapshot contains text-2.0.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.2
         - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires ghc-prim >=0.5.3 && < 0.9 and the snapshot contains ghc-prim-0.9.0
-        - ghc-events < 0 # tried ghc-events-0.17.0.3, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.0.0
-        - ghc-parser < 0 # tried ghc-parser-0.2.4.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.2
+        - ghc-parser < 0 # tried ghc-parser-0.2.4.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.3
         - ghc-prof < 0 # tried ghc-prof-1.4.1.11, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.0.0
-        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.4.2
-        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.4.2
-        - ghc-typelits-presburger < 0 # tried ghc-typelits-presburger-0.6.2.0, but its *library* requires ghc < 9.3 and the snapshot contains ghc-9.4.2
+        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.4.3
+        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.4.3
+        - ghc-typelits-presburger < 0 # tried ghc-typelits-presburger-0.6.2.0, but its *library* requires ghc < 9.3 and the snapshot contains ghc-9.4.3
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.1
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
         - gi-gsk < 0 # tried gi-gsk-4.0.5, but its *library* requires gi-gdk ==4.0.* and the snapshot contains gi-gdk-3.0.26
@@ -6454,19 +6426,16 @@ packages:
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
         - gio < 0 # tried gio-0.13.8.2, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - git-annex < 0 # tried git-annex-10.20221003, but its *executable* requires the disabled package: aws
-        - git-annex < 0 # tried git-annex-10.20221003, but its *executable* requires the disabled package: bloomfilter
-        - git-annex < 0 # tried git-annex-10.20221003, but its *executable* requires the disabled package: dbus
-        - git-annex < 0 # tried git-annex-10.20221003, but its *executable* requires the disabled package: feed
-        - git-annex < 0 # tried git-annex-10.20221003, but its *executable* requires the disabled package: git-lfs
+        - git-annex < 0 # tried git-annex-10.20221103, but its *executable* requires the disabled package: bloomfilter
+        - git-annex < 0 # tried git-annex-10.20221103, but its *executable* requires the disabled package: feed
+        - git-annex < 0 # tried git-annex-10.20221103, but its *executable* requires the disabled package: git-lfs
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires aeson >=1.3 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - github < 0 # tried github-0.28.0.1, but its *library* requires the disabled package: deepseq-generics
+        - github < 0 # tried github-0.28.0.1, but its *library* requires the disabled package: binary-instances
         - github-rest < 0 # tried github-rest-1.1.2, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.1
         - github-rest < 0 # tried github-rest-1.1.2, but its *library* requires time >=1.8.0.2 && < 1.12 and the snapshot contains time-1.12.2
         - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.17.0.0
         - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.17.0.0
-        - github-webhooks < 0 # tried github-webhooks-0.16.0, but its *library* requires the disabled package: deepseq-generics
         - glabrous < 0 # tried glabrous-2.0.6, but its *library* requires aeson >=0.8.0.2 && < 1.6 || ==2.0.* and the snapshot contains aeson-2.1.1.0
         - glaze < 0 # tried glaze-0.3.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
@@ -6596,7 +6565,7 @@ packages:
         - gothic < 0 # tried gothic-0.1.8, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2
         - gothic < 0 # tried gothic-0.1.8, but its *library* requires lens-aeson >=1.0.2 && < 1.2 and the snapshot contains lens-aeson-1.2.2
         - gothic < 0 # tried gothic-0.1.8, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
-        - graphql-client < 0 # tried graphql-client-1.1.1, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
+        - graphql-client < 0 # tried graphql-client-1.2.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
         - greskell < 0 # tried greskell-2.0.0.0, but its *library* requires aeson >=2.0.2.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - greskell < 0 # tried greskell-2.0.0.0, but its *library* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.17.0.0
         - greskell < 0 # tried greskell-2.0.0.0, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.1
@@ -6620,7 +6589,7 @@ packages:
         - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - gtk < 0 # tried gtk-0.15.7, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - gtk < 0 # tried gtk-0.15.7, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.1
-        - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: dbus
+        - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: status-notifier-item
         - gtk3 < 0 # tried gtk3-0.15.7, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - gtk3 < 0 # tried gtk3-0.15.7, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.1
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
@@ -6629,12 +6598,10 @@ packages:
         - hackage-security < 0 # tried hackage-security-0.6.2.2, but its *library* requires Cabal >=1.14 && < 1.26 || >=2.0 && < 2.6 || >=3.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - hackage-security < 0 # tried hackage-security-0.6.2.2, but its *library* requires Cabal-syntax < 3.7 and the snapshot contains Cabal-syntax-3.8.1.0
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
-        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.19
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.19.1
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant-client >=0.9 && < 0.13 and the snapshot contains servant-client-0.19
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.1
-        - hadolint < 0 # tried hadolint-2.11.0, but its *library* requires the disabled package: email-validate
-        - hadolint < 0 # tried hadolint-2.11.0, but its *library* requires the disabled package: ilist
-        - hadolint < 0 # tried hadolint-2.11.0, but its *library* requires the disabled package: spdx
+        - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires language-docker >=11.0.0 && < 12 and the snapshot contains language-docker-12.0.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - hakyll < 0 # tried hakyll-4.15.1.1, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
@@ -6659,32 +6626,32 @@ packages:
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.4.2
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.4.3
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.0.0
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.4.0.1
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Diff >=0.3 && < 0.4 and the snapshot contains Diff-0.4.1
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires network >=2.6 && < 2.9 and the snapshot contains network-3.1.2.7
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.0.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.4.0.1
@@ -6692,40 +6659,37 @@ packages:
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.0.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires warp >=3.2 && < 3.3 and the snapshot contains warp-3.3.23
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.2
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.3
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
         - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires stm-containers >=0.2 && < 1 || >=1.1 && < 1.2 and the snapshot contains stm-containers-1.2
         - haskey-btree < 0 # tried haskey-btree-0.3.0.1, but its *library* requires text >=1.2.1 && < 2 and the snapshot contains text-2.0.1
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
         - haskintex < 0 # tried haskintex-0.8.0.1, but its *library* requires text >=0.11.2.3 && < 2 and the snapshot contains text-2.0.1
-        - haskoin-core < 0 # tried haskoin-core-0.21.2, but its *library* requires the disabled package: base16
-        - haskoin-store < 0 # tried haskoin-store-0.65.5, but its *library* requires the disabled package: haskoin-node
-        - haskoin-store-data < 0 # tried haskoin-store-data-0.65.5, but its *library* requires the disabled package: haskoin-core
+        - haskoin-store < 0 # tried haskoin-store-0.65.5, but its *library* requires the disabled package: ekg-statsd
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.17.0.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - hasql-queue < 0 # tried hasql-queue-1.2.0.2, but its *executable* requires the disabled package: tmp-postgres
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.1.0
@@ -6735,21 +6699,11 @@ packages:
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: amazonka-core
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: haxl
         - hedgehog-classes < 0 # tried hedgehog-classes-0.2.5.3, but its *library* requires hedgehog >=1 && < 1.2 and the snapshot contains hedgehog-1.2
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires aeson >=0.6 && < 1.5 and the snapshot contains aeson-2.1.1.0
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.17.0.0
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires dlist >=0.5 && < 0.9 and the snapshot contains dlist-1.0
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires hashable >=1.1 && < 1.4 and the snapshot contains hashable-1.4.1.0
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires text >=0.10 && < 1.3 and the snapshot contains text-2.0.1
-        - heist < 0 # tried heist-1.1.0.1, but its *library* requires time >=1.1 && < 1.11 and the snapshot contains time-1.12.2
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-0.11.3
-        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-1.3
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-1.4
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.0.0
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires semigroups >=0.18.3 && < 0.19 and the snapshot contains semigroups-0.20
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires vty >=5.15 && < =5.23 and the snapshot contains vty-5.37
-        - hex-text < 0 # tried hex-text-0.1.0.6, but its *library* requires base ^>=4.9 || ^>=4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
-        - hex-text < 0 # tried hex-text-0.1.0.6, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
         - hexpat < 0 # tried hexpat-0.20.13, but its *library* requires text >=0.5.0.0 && < 1.3.0.0 and the snapshot contains text-2.0.1
         - hgeometry < 0 # tried hgeometry-0.14, but its *library* requires the disabled package: vector-circular
         - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.14, but its *library* requires the disabled package: vector-circular
@@ -6758,7 +6712,6 @@ packages:
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - hidapi < 0 # tried hidapi-0.1.8, but its *library* requires the disabled package: deepseq-generics
         - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
         - hie-bios < 0 # tried hie-bios-0.11.0, but its *library* requires the disabled package: co-log-core
         - hie-bios < 0 # tried hie-bios-0.11.0, but its *library* requires unix-compat >=0.5.1 && < 0.6 and the snapshot contains unix-compat-0.6
@@ -6768,7 +6721,7 @@ packages:
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
-        - hint < 0 # tried hint-0.9.0.6, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.4.2
+        - hint < 0 # tried hint-0.9.0.6, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.4.3
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart-diagrams
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
@@ -6801,8 +6754,8 @@ packages:
         - hmpfr < 0 # tried hmpfr-0.4.4, but its *library* requires integer-gmp >=1.0 && < 1.1 and the snapshot contains integer-gmp-1.1
         - hnix-store-core < 0 # tried hnix-store-core-0.6.0.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
-        - hoauth2 < 0 # tried hoauth2-2.6.0, but its *library* requires memory ^>=0.17 and the snapshot contains memory-0.18.0
-        - hoauth2 < 0 # tried hoauth2-2.6.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
+        - hoauth2 < 0 # tried hoauth2-2.7.0, but its *library* requires memory ^>=0.17 and the snapshot contains memory-0.18.0
+        - hoauth2 < 0 # tried hoauth2-2.7.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires MissingH < =1.4.3.0 and the snapshot contains MissingH-1.5.0.1
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires parsec < =3.1.14.0 and the snapshot contains parsec-3.1.15.0
@@ -6813,13 +6766,13 @@ packages:
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.6
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires retry >=0.5 && < 0.8 and the snapshot contains retry-0.9.3.0
-        - hpc-lcov < 0 # tried hpc-lcov-1.0.1, but its *executable* requires text >=1.2.2.2 && < 1.4 and the snapshot contains text-2.0.1
+        - hpc-lcov < 0 # tried hpc-lcov-1.1.0, but its *executable* requires text >=1.2.2.2 && < 1.4 and the snapshot contains text-2.0.1
         - hpio < 0 # tried hpio-0.9.0.7, but its *executable* requires optparse-applicative >=0.11.0 && < 0.15 and the snapshot contains optparse-applicative-0.17.0.0
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires QuickCheck >=2.7.6 && < 2.13 and the snapshot contains QuickCheck-2.14.2
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires protolude ==0.2.* and the snapshot contains protolude-0.3.2
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.1
-        - hpqtypes-extras < 0 # tried hpqtypes-extras-1.16.1.0, but its *library* requires the disabled package: log-base
+        - hpqtypes-extras < 0 # tried hpqtypes-extras-1.16.2.0, but its *library* requires the disabled package: log-base
         - hprotoc < 0 # tried hprotoc-2.4.17, but its *library* requires the disabled package: protocol-buffers
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires statistics >=0.15.0.0 && < 0.16.0.0 and the snapshot contains statistics-0.16.1.0
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires time >=1.9.0.0 && < 1.10.0.0 and the snapshot contains time-1.12.2
@@ -6827,7 +6780,7 @@ packages:
         - hquantlib-time < 0 # tried hquantlib-time-0.0.5.1, but its *library* requires time >=1.9.0.0 && < 1.10.0.0 and the snapshot contains time-1.12.2
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.17.0.0
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.4.2
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.4.3
         - hsb2hs < 0 # tried hsb2hs-0.3.1, but its *executable* requires the disabled package: preprocessor-tools
         - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
@@ -6836,8 +6789,8 @@ packages:
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires fsnotify >=0.2.1 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.4.2
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser ==8.10.* and the snapshot contains ghc-lib-parser-9.4.2.20220822
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.4.3
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser ==8.10.* and the snapshot contains ghc-lib-parser-9.4.3.20221104
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires hlint >=3.0.0 && < 3.3.0 and the snapshot contains hlint-3.5
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.13.1
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2
@@ -6881,7 +6834,7 @@ packages:
         - idris < 0 # tried idris-1.3.4, but its *library* requires text >=1.2.1.0 && < 1.4 and the snapshot contains text-2.0.1
         - iff < 0 # tried iff-0.0.6, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.2
+        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.3
         - ihaskell-hvega < 0 # tried ihaskell-hvega-0.5.0.3, but its *library* requires the disabled package: ihaskell
         - ilist < 0 # tried ilist-0.4.0.1, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
@@ -6896,9 +6849,8 @@ packages:
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires lens >=4.9 && < 5.2 and the snapshot contains lens-5.2
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires text < 1.3 and the snapshot contains text-2.0.1
-        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.4.2
+        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.4.3
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
-        - inline-r < 0 # tried inline-r-0.10.5, but its *library* requires singletons >=0.9 && < 3 and the snapshot contains singletons-3.0.2
         - inliterate < 0 # tried inliterate-0.1.0, but its *library* requires the disabled package: cheapskate
         - int-cast < 0 # tried int-cast-0.2.0.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.0.0
         - integer-roots < 0 # tried integer-roots-1.0.2.0, but its *library* requires ghc-bignum < 1.3 and the snapshot contains ghc-bignum-1.3
@@ -6985,8 +6937,6 @@ packages:
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.1.1.0
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.7.2
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - katip-wai < 0 # tried katip-wai-0.1.2.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - kdt < 0 # tried kdt-0.2.5, but its *library* requires the disabled package: deepseq-generics
         - kind-generics-th < 0 # tried kind-generics-th-0.2.2.3, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - kleene < 0 # tried kleene-0.1, but its *library* requires base >=4.7.0.2 && < 4.17 and the snapshot contains base-4.17.0.0
         - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.1.0
@@ -6996,8 +6946,9 @@ packages:
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.1
         - l10n < 0 # tried l10n-0.1.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.1
         - lackey < 0 # tried lackey-2.0.0.3, but its *library* requires the disabled package: servant-foreign
-        - lambdabot-core < 0 # tried lambdabot-core-5.3.0.2, but its *library* requires random-fu >=0.2.6.2 && < 0.3 and the snapshot contains random-fu-0.3.0.0
-        - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.0.2, but its *library* requires the disabled package: lambdabot-core
+        - lambdabot-core < 0 # tried lambdabot-core-5.3.1, but its *library* requires the disabled package: dependent-map
+        - lambdabot-core < 0 # tried lambdabot-core-5.3.1, but its *library* requires the disabled package: dependent-sum
+        - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.1, but its *library* requires the disabled package: lambdabot-core
         - language-avro < 0 # tried language-avro-0.1.4.0, but its *library* requires the disabled package: avro
         - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* requires template-haskell < 2.16 and the snapshot contains template-haskell-2.19.0.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.1.0
@@ -7010,12 +6961,13 @@ packages:
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires lens >=4.12 && < 5 and the snapshot contains lens-5.2
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires megaparsec >=7 && < 9 and the snapshot contains megaparsec-9.2.2
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires memory >=0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant >=0.9 && < 0.18 and the snapshot contains servant-0.19
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant >=0.9 && < 0.18 and the snapshot contains servant-0.19.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant-client >=0.9 && < 0.18 and the snapshot contains servant-client-0.19
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - lapack < 0 # tried lapack-0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - lapack-hmatrix < 0 # tried lapack-hmatrix-0.0.0.1, but its *library* requires the disabled package: lapack
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires the disabled package: utf8-light
         - learn-physics < 0 # tried learn-physics-0.6.5, but its *library* requires the disabled package: spatial-math
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens ==4.* and the snapshot contains lens-5.2
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.2
@@ -7035,12 +6987,11 @@ packages:
         - libraft < 0 # tried libraft-0.5.0.0, but its *executable* requires the disabled package: postgresql-simple-url
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: monad-metrics
-        - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: postgresql-simple
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: protolude
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.8.1.0
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.17.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2
-        - linear-base < 0 # tried linear-base-0.2.0, but its *library* requires the disabled package: linear-generics
+        - linear-base < 0 # tried linear-base-0.3.0, but its *library* requires the disabled package: linear-generics
         - linear-circuit < 0 # tried linear-circuit-0.1.0.4, but its *library* requires the disabled package: lapack
         - linear-generics < 0 # tried linear-generics-0.2, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
@@ -7061,25 +7012,23 @@ packages:
         - logger-thread < 0 # tried logger-thread-0.1.0.2, but its *library* requires the disabled package: protolude
         - logging-effect < 0 # tried logging-effect-1.3.13, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - logging-effect < 0 # tried logging-effect-1.3.13, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.4.2
+        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.4.3
         - lsp < 0 # tried lsp-1.6.0.0, but its *library* requires the disabled package: co-log-core
         - lsp-test < 0 # tried lsp-test-0.14.1.0, but its *library* requires the disabled package: co-log-core
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.1.1.0
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.1.2.7
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.19
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.19.1
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant-client >=0.11 && < 0.14 and the snapshot contains servant-client-0.19
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires text >=1.2.2.2 && < 2 and the snapshot contains text-2.0.1
         - lxd-client-config < 0 # tried lxd-client-config-0.1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: monad-metrics
-        - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: servant-server
         - magico < 0 # tried magico-0.0.2.3, but its *executable* requires the disabled package: lapack
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.1
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.2.2
         - mandrill < 0 # tried mandrill-0.5.6.0, but its *library* requires text >=1.0.0.0 && < 1.3 and the snapshot contains text-2.0.1
-        - map-syntax < 0 # tried map-syntax-0.3, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.17.0.0
         - markup < 0 # tried markup-4.2.0, but its *library* requires the disabled package: attoparsec-uri
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires aeson >=0.11 && < 1.3 and the snapshot contains aeson-2.1.1.0
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.13.1
@@ -7095,7 +7044,7 @@ packages:
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires formatting >=6.3.7 && < 6.4 and the snapshot contains formatting-7.1.3
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires http-client >=0.5.14 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires optparse-applicative >=0.14.3.0 && < 0.15 and the snapshot contains optparse-applicative-0.17.0.0
-        - mbug < 0 # tried mbug-1.3.2, but its *library* requires scalpel-core >=0.5.1 && < 0.6 and the snapshot contains scalpel-core-0.6.2
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires scalpel-core >=0.5.1 && < 0.6 and the snapshot contains scalpel-core-0.6.2.1
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires time >=1.8.0.2 && < 1.9 and the snapshot contains time-1.12.2
         - mcmc < 0 # tried mcmc-0.8.0.1, but its *library* requires the disabled package: statistics
@@ -7104,7 +7053,7 @@ packages:
         - medea < 0 # tried medea-1.2.0, but its *library* requires bytestring ^>=0.10.8.2 and the snapshot contains bytestring-0.11.3.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires hashable >=1.2.7.0 && < 1.4.0.0 and the snapshot contains hashable-1.4.1.0
         - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.0.1
-        - mega-sdist < 0 # tried mega-sdist-0.4.3.0, but its *executable* requires pantry >=0.6 and the snapshot contains pantry-0.5.7
+        - mega-sdist < 0 # tried mega-sdist-0.4.2.1, but its *executable* requires the disabled package: pantry
         - memfd < 0 # tried memfd-1.0.1.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.0.0
@@ -7125,7 +7074,7 @@ packages:
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.5
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant-client >=0.13 && < 0.16 and the snapshot contains servant-client-0.19
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
@@ -7140,7 +7089,6 @@ packages:
         - mini-egison < 0 # tried mini-egison-1.0.0, but its *library* requires the disabled package: egison-pattern-src-th-mode
         - minio-hs < 0 # tried minio-hs-1.6.0, but its *library* requires the disabled package: relude
         - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: jsaddle
-        - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: servant
         - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: servant-lucid
         - mmark < 0 # tried mmark-0.0.7.6, but its *library* requires the disabled package: email-validate
         - mmark-cli < 0 # tried mmark-cli-0.0.5.1, but its *executable* requires the disabled package: mmark
@@ -7148,7 +7096,7 @@ packages:
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
         - mole < 0 # tried mole-0.0.7, but its *executable* requires base >=4.11 && < 4.15 and the snapshot contains base-4.17.0.0
         - mole < 0 # tried mole-0.0.7, but its *executable* requires the disabled package: snap-server
-        - monad-bayes < 0 # tried monad-bayes-1.0.0, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
+        - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
         - monad-control-aligned < 0 # tried monad-control-aligned-0.0.1.1, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2
         - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.1
         - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires text < 1.3 and the snapshot contains text-2.0.1
@@ -7157,17 +7105,15 @@ packages:
         - monad-skeleton < 0 # tried monad-skeleton-0.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
         - mono-traversable-keys < 0 # tried mono-traversable-keys-0.2.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql < 0 # tried morpheus-graphql-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql < 0 # tried morpheus-graphql-0.24.0, but its *library* requires the disabled package: morpheus-graphql-server
-        - morpheus-graphql-app < 0 # tried morpheus-graphql-app-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.24.0, but its *library* requires the disabled package: morpheus-graphql-code-gen-utils
-        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.24.0, but its *library* requires the disabled package: morpheus-graphql-code-gen-utils
-        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.24.0, but its *library* requires the disabled package: morpheus-graphql-server
-        - morpheus-graphql-core < 0 # tried morpheus-graphql-core-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql-subscriptions < 0 # tried morpheus-graphql-subscriptions-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
-        - morpheus-graphql-tests < 0 # tried morpheus-graphql-tests-0.24.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql < 0 # tried morpheus-graphql-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-app < 0 # tried morpheus-graphql-app-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-code-gen-utils < 0 # tried morpheus-graphql-code-gen-utils-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-core < 0 # tried morpheus-graphql-core-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-server < 0 # tried morpheus-graphql-server-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-subscriptions < 0 # tried morpheus-graphql-subscriptions-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
+        - morpheus-graphql-tests < 0 # tried morpheus-graphql-tests-0.27.0, but its *library* requires text >=1.2.3 && < 1.3.0 and the snapshot contains text-2.0.1
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.0.0
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires hashable >=1.1.2.4 && < 1.4 and the snapshot contains hashable-1.4.1.0
@@ -7219,9 +7165,9 @@ packages:
         - not-gloss < 0 # tried not-gloss-0.7.7.0, but its *library* requires the disabled package: vector-binary-instances
         - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires the disabled package: nri-prelude
-        - nri-http < 0 # tried nri-http-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - nri-http < 0 # tried nri-http-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
-        - nri-http < 0 # tried nri-http-0.1.0.4, but its *library* requires the disabled package: nri-prelude
+        - nri-http < 0 # tried nri-http-0.1.1.0, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
+        - nri-http < 0 # tried nri-http-0.1.1.0, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
+        - nri-http < 0 # tried nri-http-0.1.1.0, but its *library* requires the disabled package: nri-prelude
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires the disabled package: nri-prelude
@@ -7237,8 +7183,8 @@ packages:
         - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires the disabled package: nri-prelude
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant >=0.16.2 && < 0.19 and the snapshot contains servant-0.19
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant-server >=0.16.2 && < 0.19 and the snapshot contains servant-server-0.19.1
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant >=0.16.2 && < 0.19 and the snapshot contains servant-0.19.1
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant-server >=0.16.2 && < 0.19 and the snapshot contains servant-server-0.19.2
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires the disabled package: nri-prelude
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* requires numhask >=0.3 && < 0.6 and the snapshot contains numhask-0.10.1.0
         - numhask-space < 0 # tried numhask-space-0.10.0.0, but its *library* requires text >=1.2.3.1 && < 2 and the snapshot contains text-2.0.1
@@ -7254,27 +7200,20 @@ packages:
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires text >=1.2.4.0 && < 1.3 and the snapshot contains text-2.0.1
         - one-liner < 0 # tried one-liner-2.1, but its *library* requires the disabled package: linear-base
         - one-liner-instances < 0 # tried one-liner-instances-0.1.3.0, but its *library* requires the disabled package: one-liner
-        - opaleye < 0 # tried opaleye-0.9.6.1, but its *library* requires the disabled package: postgresql-simple
-        - openapi3 < 0 # tried openapi3-3.2.2, but its *library* requires aeson >=1.4.2.0 && < 1.6 || >=2.0.1.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - openapi3 < 0 # tried openapi3-3.2.2, but its *library* requires base >=4.11.1.0 && < 4.17 and the snapshot contains base-4.17.0.0
-        - openapi3 < 0 # tried openapi3-3.2.2, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2
-        - openapi3 < 0 # tried openapi3-3.2.2, but its *library* requires template-haskell >=2.13.0.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - opentelemetry-extra < 0 # tried opentelemetry-extra-0.8.0, but its *library* requires the disabled package: ghc-events
         - opentelemetry-extra < 0 # tried opentelemetry-extra-0.8.0, but its *library* requires the disabled package: jsonifier
-        - opentelemetry-lightstep < 0 # tried opentelemetry-lightstep-0.8.0, but its *executable* requires the disabled package: ghc-events
+        - opentelemetry-lightstep < 0 # tried opentelemetry-lightstep-0.8.0, but its *library* requires the disabled package: opentelemetry-extra
         - optima < 0 # tried optima-0.4.0.3, but its *library* requires the disabled package: attoparsec-data
-        - ormolu < 0 # tried ormolu-0.5.0.1, but its *library* requires Cabal >=3.6 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - ormolu < 0 # tried ormolu-0.5.0.1, but its *library* requires ghc-lib-parser >=9.2 && < 9.3 and the snapshot contains ghc-lib-parser-9.4.2.20220822
         - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.8.1.0
+        - pairing < 0 # tried pairing-1.1.0, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires groups >=0.4.1 && < 0.5 and the snapshot contains groups-0.5.3
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.2
         - pandoc < 0 # tried pandoc-2.19.2, but its *library* requires gridtables >=0.0.3 && < 0.1 and the snapshot contains gridtables-0.1.0.0
         - pandoc-csv2table < 0 # tried pandoc-csv2table-1.0.9, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - pandoc-dhall-decoder < 0 # tried pandoc-dhall-decoder-0.1.0.1, but its *library* requires the disabled package: pandoc
-        - pandoc-plot < 0 # tried pandoc-plot-1.5.4, but its *library* requires the disabled package: pandoc
+        - pandoc-plot < 0 # tried pandoc-plot-1.5.5, but its *library* requires the disabled package: pandoc
         - pandoc-throw < 0 # tried pandoc-throw-0.1.0.0, but its *library* requires the disabled package: pandoc
         - pango < 0 # tried pango-0.13.8.2, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - pango < 0 # tried pango-0.13.8.2, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.1
@@ -7293,7 +7232,7 @@ packages:
         - path-text-utf8 < 0 # tried path-text-utf8-0.0.1.10, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
         - path-text-utf8 < 0 # tried path-text-utf8-0.0.1.10, but its *library* requires text ^>=1.2.2 and the snapshot contains text-2.0.1
         - pedersen-commitment < 0 # tried pedersen-commitment-0.2.0, but its *library* requires the disabled package: protolude
-        - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.7
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.8
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires hashtables ==1.0.* and the snapshot contains hashtables-1.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires monad-control ==0.3.* and the snapshot contains monad-control-1.0.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.19.0.0
@@ -7301,24 +7240,21 @@ packages:
         - perf < 0 # tried perf-0.10.1, but its *library* requires deepseq >=1.4.4 && < 1.4.8 and the snapshot contains deepseq-1.4.8.0
         - perf < 0 # tried perf-0.10.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
         - perf < 0 # tried perf-0.10.1, but its *library* requires time ^>=1.9 and the snapshot contains time-1.12.2
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires MonadRandom >=0.5.1.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.0.0
         - persist < 0 # tried persist-0.1.1.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - persistable-record < 0 # tried persistable-record-0.6.0.5, but its *library* requires the disabled package: product-isomorphic
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: persistable-record
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query-HDBC
-        - persistent-mongoDB < 0 # tried persistent-mongoDB-2.13.0.1, but its *library* requires http-api-data >=0.3.7 && < 0.5 and the snapshot contains http-api-data-0.5
         - persistent-mongoDB < 0 # tried persistent-mongoDB-2.13.0.1, but its *library* requires resource-pool >=0.2 && < 0.3 and the snapshot contains resource-pool-0.3.1.0
-        - persistent-mtl < 0 # tried persistent-mtl-0.4.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.17.0.0
-        - persistent-mtl < 0 # tried persistent-mtl-0.4.0.0, but its *library* requires persistent >=2.8.2 && < 2.14 and the snapshot contains persistent-2.14.3.0
-        - persistent-mtl < 0 # tried persistent-mtl-0.4.0.0, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.3.1.0
-        - persistent-mtl < 0 # tried persistent-mtl-0.4.0.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.0, but its *library* requires base >=4.14 && < 4.16 and the snapshot contains base-4.17.0.0
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.0, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.3.1.0
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.0, but its *library* requires text >=1.2.4 && < 1.3 and the snapshot contains text-2.0.1
         - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-1.6.0
-        - persistent-postgresql < 0 # tried persistent-postgresql-2.13.5.0, but its *library* requires the disabled package: postgresql-simple
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
-        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.12
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.12.1
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires text >=1.1.0 && < 2 and the snapshot contains text-2.0.1
-        - pg-transact < 0 # tried pg-transact-0.3.2.0, but its *library* requires the disabled package: postgresql-simple
         - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires JuicyPixels >=3.2.8 && < 3.3 and the snapshot contains JuicyPixels-3.3.7
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
@@ -7371,14 +7307,7 @@ packages:
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires base >=4.6.0.0 && < 4.15 and the snapshot contains base-4.17.0.0
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires containers >=0.5.9.2 && < =0.6.4.1 and the snapshot contains containers-0.6.6
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires ghc-prim >=0.4 && < 0.7 and the snapshot contains ghc-prim-0.9.0
-        - postgres-options < 0 # tried postgres-options-0.2.0.0, but its *library* requires the disabled package: generic-monoid
-        - postgresql-migration < 0 # tried postgresql-migration-0.2.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - postgresql-migration < 0 # tried postgresql-migration-0.2.1.4, but its *library* requires time >=1.4 && < 1.12 and the snapshot contains time-1.12.2
         - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: inflections
-        - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: postgresql-simple
-        - postgresql-schema < 0 # tried postgresql-schema-0.1.14, but its *library* requires the disabled package: postgresql-simple
-        - postgresql-simple < 0 # tried postgresql-simple-0.6.4, but its *library* requires base >=4.6.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
-        - postgresql-simple < 0 # tried postgresql-simple-0.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - postgresql-simple-url < 0 # tried postgresql-simple-url-0.2.1.0, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.0.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires HTTP >=4000.3.7 && < 4000.4 and the snapshot contains HTTP-4000.4.1
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires aeson >=1.4.7 && < 1.6 and the snapshot contains aeson-2.1.1.0
@@ -7391,10 +7320,9 @@ packages:
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens >=4.14 && < 5.1 and the snapshot contains lens-5.2
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens-aeson >=1.0.1 && < 1.2 and the snapshot contains lens-aeson-1.2.2
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires swagger2 >=2.4 && < 2.7 and the snapshot contains swagger2-2.8.5
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires swagger2 >=2.4 && < 2.7 and the snapshot contains swagger2-2.8.6
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.1
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires time >=1.6 && < 1.11 and the snapshot contains time-1.12.2
-        - pqueue < 0 # tried pqueue-1.4.2.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - prairie < 0 # tried prairie-0.0.1.0, but its *library* requires template-haskell >=2.15 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - pred-set < 0 # tried pred-set-0.0.1, but its *library* requires the disabled package: HSet
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: pred-set
@@ -7410,14 +7338,13 @@ packages:
         - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - proto-lens-optparse < 0 # tried proto-lens-optparse-0.1.1.9, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.1.2, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.4.2
+        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.4.3
         - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
         - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
         - protolude < 0 # tried protolude-0.3.2, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.0.0
         - protolude < 0 # tried protolude-0.3.2, but its *library* requires ghc-prim >=0.3 && < 0.9 and the snapshot contains ghc-prim-0.9.0
-        - psql-helpers < 0 # tried psql-helpers-0.1.0.0, but its *library* requires the disabled package: postgresql-simple
         - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.17.0.0
         - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.17.0.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.0.0
@@ -7445,12 +7372,9 @@ packages:
         - random-source < 0 # tried random-source-0.3.0.11, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.17.0.0
         - rank2classes < 0 # tried rank2classes-1.4.6, but its *library* requires the disabled package: data-functor-logistic
         - rate-limit < 0 # tried rate-limit-1.4.2, but its *library* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
-        - reactive-banana < 0 # tried reactive-banana-1.3.1.0, but its *library* requires the disabled package: pqueue
-        - readable < 0 # tried readable-0.3.1, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - readable < 0 # tried readable-0.3.1, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.1.1.0
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.17.0.0
-        - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.15, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.2
+        - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.15, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.3
         - records-sop < 0 # tried records-sop-0.1.1.0, but its *library* requires ghc-prim >=0.5 && < 0.8 and the snapshot contains ghc-prim-0.9.0
         - redis-io < 0 # tried redis-io-1.1.0, but its *library* requires the disabled package: tinylog
         - redis-resp < 0 # tried redis-resp-1.0.0, but its *library* requires the disabled package: bytestring-conversion
@@ -7516,12 +7440,11 @@ packages:
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.12.2
         - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.1
         - saltine < 0 # tried saltine-0.1.1.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - sandwich < 0 # tried sandwich-0.1.1.2, but its *library* requires the disabled package: string-interpolate
+        - sandwich < 0 # tried sandwich-0.1.2.0, but its *library* requires the disabled package: string-interpolate
         - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.1.0, but its *library* requires the disabled package: string-interpolate
         - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.6, but its *library* requires the disabled package: sandwich
         - sandwich-slack < 0 # tried sandwich-slack-0.1.1.0, but its *library* requires the disabled package: string-interpolate
-        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.1.0, but its *library* requires the disabled package: string-interpolate
-        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.1.0, but its *library* requires the disabled package: webdriver
+        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.1.2.0, but its *library* requires the disabled package: string-interpolate
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
@@ -7530,7 +7453,6 @@ packages:
         - scalendar < 0 # tried scalendar-1.1.1, but its *library* requires containers >=0.5.7.1 && < 0.6 and the snapshot contains containers-0.6.6
         - scalendar < 0 # tried scalendar-1.1.1, but its *library* requires text >=1.2.0.0 && < 2 and the snapshot contains text-2.0.1
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires aeson >=1 && < 1.4.3.0 and the snapshot contains aeson-2.1.1.0
-        - secp256k1-haskell < 0 # tried secp256k1-haskell-0.6.1, but its *library* requires the disabled package: base16
         - selda < 0 # tried selda-0.5.2.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
         - selda < 0 # tried selda-0.5.2.0, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - selda-json < 0 # tried selda-json-0.1.1.1, but its *library* requires aeson >=1.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
@@ -7554,91 +7476,52 @@ packages:
         - sequence-formats < 0 # tried sequence-formats-1.6.6.1, but its *library* requires the disabled package: pipes-safe
         - sequenceTools < 0 # tried sequenceTools-1.5.2, but its *executable* requires the disabled package: pipes-safe
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.1
-        - servant < 0 # tried servant-0.19, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant < 0 # tried servant-0.19, but its *library* requires http-api-data >=0.4.1 && < 0.4.4 and the snapshot contains http-api-data-0.5
-        - servant-JuicyPixels < 0 # tried servant-JuicyPixels-0.3.1.0, but its *executable* requires the disabled package: servant-server
-        - servant-JuicyPixels < 0 # tried servant-JuicyPixels-0.3.1.0, but its *library* requires the disabled package: servant
-        - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires jose >=0.7.0.0 && < 0.10 and the snapshot contains jose-0.10
         - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2
-        - servant-auth-client < 0 # tried servant-auth-client-0.4.1.0, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
+        - servant-auth-client < 0 # tried servant-auth-client-0.4.1.0, but its *library* requires the disabled package: servant-auth
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.5
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-types >=0.9 && < 0.12 and the snapshot contains http-types-0.12.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires memory >=0.11 && < 0.15 and the snapshot contains memory-0.18.0
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.19
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.19.1
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.19.1
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.19.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
-        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
+        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* requires the disabled package: servant-auth
+        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* requires the disabled package: servant-docs
         - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires jose >=0.7.0.0 && < 0.10 and the snapshot contains jose-0.10
-        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2
-        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires memory >=0.14.16 && < 0.18 and the snapshot contains memory-0.18.0
         - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires monad-time >=0.3.1.0 && < 0.4 and the snapshot contains monad-time-0.4.0.0
-        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires time >=1.5.0.1 && < 1.12 and the snapshot contains time-1.12.2
-        - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires text ==1.* and the snapshot contains text-2.0.1
-        - servant-blaze < 0 # tried servant-blaze-0.9.1, but its *library* requires the disabled package: servant
-        - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires the disabled package: servant
-        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant
-        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-client
-        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-client-core
-        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-server
-        - servant-checked-exceptions-core < 0 # tried servant-checked-exceptions-core-2.2.0.1, but its *library* requires the disabled package: servant
+        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-checked-exceptions-core
         - servant-checked-exceptions-core < 0 # tried servant-checked-exceptions-core-2.2.0.1, but its *library* requires the disabled package: servant-docs
-        - servant-client < 0 # tried servant-client-0.19, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-client < 0 # tried servant-client-0.19, but its *library* requires time >=1.6.0.1 && < 1.12 and the snapshot contains time-1.12.2
-        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - servant-conduit < 0 # tried servant-conduit-0.15.1, but its *library* requires the disabled package: servant
-        - servant-docs < 0 # tried servant-docs-0.12, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-docs < 0 # tried servant-docs-0.12, but its *library* requires lens >=4.17 && < 5.2 and the snapshot contains lens-5.2
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.1.1.0
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.19
+        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.19.1
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
-        - servant-elm < 0 # tried servant-elm-0.7.2, but its *library* requires the disabled package: servant
         - servant-elm < 0 # tried servant-elm-0.7.2, but its *library* requires the disabled package: servant-foreign
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.17.0.0
-        - servant-exceptions < 0 # tried servant-exceptions-0.2.1, but its *library* requires the disabled package: servant
-        - servant-exceptions-server < 0 # tried servant-exceptions-server-0.2.1, but its *library* requires the disabled package: servant
-        - servant-exceptions-server < 0 # tried servant-exceptions-server-0.2.1, but its *library* requires the disabled package: servant-server
-        - servant-foreign < 0 # tried servant-foreign-0.15.4, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-foreign < 0 # tried servant-foreign-0.15.4, but its *library* requires lens >=4.17 && < 5.2 and the snapshot contains lens-5.2
-        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires time >=1.6.0.1 && < 1.12 and the snapshot contains time-1.12.2
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires lens >=4.17 && < 5.2 and the snapshot contains lens-5.2
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.6.6
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires formatting >=6.2 && < 6.4 and the snapshot contains formatting-7.1.3
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires lens >=4.15 && < 4.18 and the snapshot contains lens-5.2
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant >=0.9 && < 0.17 and the snapshot contains servant-0.19
+        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant >=0.9 && < 0.17 and the snapshot contains servant-0.19.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - servant-lucid < 0 # tried servant-lucid-0.9.0.5, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
-        - servant-machines < 0 # tried servant-machines-0.15.1, but its *library* requires the disabled package: servant
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires QuickCheck >=2.12.6.1 && < 2.14 and the snapshot contains QuickCheck-2.14.2
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.17.0.0
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.12.2
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.1
-        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires lens >=4.17 && < 5.2 and the snapshot contains lens-5.2
-        - servant-multipart-api < 0 # tried servant-multipart-api-0.12.1, but its *library* requires the disabled package: servant
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-client
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19.1
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.2
+        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires the disabled package: servant-docs
+        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires the disabled package: servant-foreign
         - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-multipart
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-server
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *library* requires the disabled package: servant
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *library* requires the disabled package: servant-client-core
         - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.5, but its *library* requires Cabal >=1.24 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.5, but its *library* requires aeson >=1.4.2.0 && < 1.6 || >=2.0.1.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.5, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.5, but its *library* requires lens >=4.17 && < 5.2 and the snapshot contains lens-5.2
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires lens >=4.9 && < 5 and the snapshot contains lens-5.2
@@ -7646,51 +7529,36 @@ packages:
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires servant-docs >=0.11.1 && < 0.12 and the snapshot contains servant-docs-0.12
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - servant-pipes < 0 # tried servant-pipes-0.15.3, but its *library* requires the disabled package: pipes-safe
-        - servant-pipes < 0 # tried servant-pipes-0.15.3, but its *library* requires the disabled package: servant
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.1.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.0.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base-compat-batteries >=0.10.1 && < 0.12 and the snapshot contains base-compat-batteries-0.12.2
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires hspec >=2.5.6 && < 2.8 and the snapshot contains hspec-2.10.6
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-client >=0.17 && < 0.19 and the snapshot contains servant-client-0.19
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.2
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
-        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant
-        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant-client
-        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant-server
-        - servant-rawm < 0 # tried servant-rawm-1.0.0.0, but its *library* requires the disabled package: servant
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - servant-server < 0 # tried servant-server-0.19.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-server < 0 # tried servant-server-0.19.1, but its *library* requires http-api-data >=0.4.1 && < 0.4.4 and the snapshot contains http-api-data-0.5
-        - servant-static-th < 0 # tried servant-static-th-1.0.0.0, but its *library* requires the disabled package: servant
-        - servant-static-th < 0 # tried servant-static-th-1.0.0.0, but its *library* requires the disabled package: servant-server
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19.1
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant >=0.14 && < 0.15 and the snapshot contains servant-0.19
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant >=0.14 && < 0.15 and the snapshot contains servant-0.19.1
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant-client-core >=0.14 && < 0.15 and the snapshot contains servant-client-core-0.19
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires servant-server >=0.13 && < 0.15 and the snapshot contains servant-server-0.19.1
-        - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires servant-server >=0.13 && < 0.15 and the snapshot contains servant-server-0.19.2
         - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant-foreign
-        - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant-server
-        - servant-swagger < 0 # tried servant-swagger-1.1.11, but its *library* requires the disabled package: servant
-        - servant-swagger < 0 # tried servant-swagger-1.1.11, but its *library* requires the disabled package: swagger2
         - servant-swagger-ui < 0 # tried servant-swagger-ui-0.3.5.4.5.0, but its *library* requires aeson >=0.8.0.2 && < 2.1.0 and the snapshot contains aeson-2.1.1.0
         - servant-swagger-ui < 0 # tried servant-swagger-ui-0.3.5.4.5.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-swagger-ui-core < 0 # tried servant-swagger-ui-core-0.3.5, but its *library* requires aeson >=0.8.0.2 && < 2.1.0 and the snapshot contains aeson-2.1.1.0
         - servant-swagger-ui-core < 0 # tried servant-swagger-ui-core-0.3.5, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.0.0
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires aeson >=0.8.0.2 && < 2.1.0 and the snapshot contains aeson-2.1.1.0
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.0.0
-        - servant-websockets < 0 # tried servant-websockets-2.0.0, but its *library* requires the disabled package: servant-server
-        - servant-xml < 0 # tried servant-xml-1.0.1.4, but its *library* requires the disabled package: servant
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.17.0.0
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.19
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.19.1
         - serverless-haskell < 0 # tried serverless-haskell-0.12.6, but its *library* requires the disabled package: amazonka-core
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-2.0.1, but its *library* requires persistent ==2.13.* and the snapshot contains persistent-2.14.3.0
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
@@ -7725,11 +7593,10 @@ packages:
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.17.0.0
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.5
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.13.1
-        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires servant >=0.12 && < 0.19 and the snapshot contains servant-0.19
+        - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires servant >=0.12 && < 0.19 and the snapshot contains servant-0.19.1
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires servant-client >=0.12 && < 0.19 and the snapshot contains servant-client-0.19
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires servant-client-core >=0.12 && < 0.19 and the snapshot contains servant-client-core-0.19
         - slack-web < 0 # tried slack-web-0.4.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - slist < 0 # tried slist-0.2.0.1, but its *library* requires base >=4.10.1.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - slynx < 0 # tried slynx-0.7.0.1, but its *library* requires the disabled package: statistics
         - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.17.0.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.0.0
@@ -7741,19 +7608,7 @@ packages:
         - smash-microlens < 0 # tried smash-microlens-0.1.0.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.1.1.0
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires aeson >=0.6 && < 1.5 and the snapshot contains aeson-2.1.1.0
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.17.0.0
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires dlist >=0.5 && < 0.9 and the snapshot contains dlist-1.0
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires hashable >=1.2.0.6 && < 1.4 and the snapshot contains hashable-1.4.1.0
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires lens >=3.7.6 && < 4.20 and the snapshot contains lens-5.2
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires mwc-random >=0.8 && < 0.15 and the snapshot contains mwc-random-0.15.0.2
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - snap < 0 # tried snap-1.1.3.1, but its *library* requires the disabled package: snap-server
-        - snap < 0 # tried snap-1.1.3.1, but its *library* requires time >=1.1 && < 1.10 and the snapshot contains time-1.12.2
-        - snap-blaze < 0 # tried snap-blaze-0.2.1.5, but its *library* requires the disabled package: snap-core
-        - snap-core < 0 # tried snap-core-1.0.5.0, but its *library* requires the disabled package: readable
         - soap < 0 # tried soap-0.2.3.6, but its *library* requires the disabled package: iconv
         - soap-openssl < 0 # tried soap-openssl-0.1.0.2, but its *library* requires the disabled package: soap
         - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires the disabled package: soap
@@ -7784,7 +7639,7 @@ packages:
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires free >=4.9 && < 5.1 and the snapshot contains free-5.1.9
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - statistics < 0 # tried statistics-0.16.1.0, but its *library* requires the disabled package: vector-binary-instances
-        - status-notifier-item < 0 # tried status-notifier-item-0.3.1.0, but its *library* requires the disabled package: dbus
+        - status-notifier-item < 0 # tried status-notifier-item-0.3.1.0, but its *library* requires the disabled package: byte-order
         - stm-supply < 0 # tried stm-supply-0.2.0.0, but its *library* requires the disabled package: concurrent-supply
         - store < 0 # tried store-0.7.16, but its *library* requires the disabled package: store-core
         - store-core < 0 # tried store-core-0.4.4.4, but its *library* requires text >=1.2.0.4 && < 2.0 and the snapshot contains text-2.0.1
@@ -7828,7 +7683,7 @@ packages:
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
         - stylish-haskell < 0 # tried stylish-haskell-0.14.3.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.1.1.0
-        - stylish-haskell < 0 # tried stylish-haskell-0.14.3.0, but its *library* requires ghc >=9.2 && < 9.3 and the snapshot contains ghc-9.4.2
+        - stylish-haskell < 0 # tried stylish-haskell-0.14.3.0, but its *library* requires ghc >=9.2 && < 9.3 and the snapshot contains ghc-9.4.3
         - stylish-haskell < 0 # tried stylish-haskell-0.14.3.0, but its *library* requires ghc-lib-parser-ex >=9.2.0.3 && < 9.3 and the snapshot contains ghc-lib-parser-ex-9.4.0.0
         - stylish-haskell < 0 # tried stylish-haskell-0.14.3.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - sv < 0 # tried sv-1.4.0.1, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
@@ -7853,23 +7708,17 @@ packages:
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires network >=2.6.2 && < 2.8 and the snapshot contains network-3.1.2.7
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
-        - swagger2 < 0 # tried swagger2-2.8.5, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0
-        - swagger2 < 0 # tried swagger2-2.8.5, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.0.0
         - swish < 0 # tried swish-0.10.2.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.2, but its *library* requires the disabled package: persistent-postgresql
-        - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.2, but its *library* requires the disabled package: tmp-postgres
-        - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-client
-        - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-server
         - synthesizer-alsa < 0 # tried synthesizer-alsa-0.5.0.6, but its *library* requires the disabled package: alsa-seq
         - synthesizer-alsa < 0 # tried synthesizer-alsa-0.5.0.6, but its *library* requires the disabled package: synthesizer-dimensional
         - synthesizer-dimensional < 0 # tried synthesizer-dimensional-0.8.1, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - synthesizer-midi < 0 # tried synthesizer-midi-0.6.1.1, but its *library* requires the disabled package: synthesizer-dimensional
+        - taffybar < 0 # tried taffybar-4.0.0, but its *library* requires scotty >=0.11.0 && < 0.12.0 and the snapshot contains scotty-0.12.1
         - tagchup < 0 # tried tagchup-0.4.1.1, but its *library* requires bytestring >=0.9.0.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
-        - tasty-autocollect < 0 # tried tasty-autocollect-0.3.1.0, but its *library* requires ghc >=8.10 && < 9.3 and the snapshot contains ghc-9.4.2
+        - tasty-autocollect < 0 # tried tasty-autocollect-0.3.1.0, but its *library* requires ghc >=8.10 && < 9.3 and the snapshot contains ghc-9.4.3
         - tasty-autocollect < 0 # tried tasty-autocollect-0.3.1.0, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - tasty-hedgehog < 0 # tried tasty-hedgehog-1.3.1.0, but its *library* requires hedgehog >=1.0.2 && < 1.1.3 and the snapshot contains hedgehog-1.2
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.6
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.4.2.3
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires time >=1.5 && < 1.9 and the snapshot contains time-1.12.2
@@ -7877,11 +7726,8 @@ packages:
         - tasty-wai < 0 # tried tasty-wai-0.1.2.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.2.7
         - tdigest < 0 # tried tdigest-0.2.1.1, but its *library* requires vector-algorithms >=0.7.0.1 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
-        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.6, but its *library* requires the disabled package: servant
-        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.6, but its *library* requires the disabled package: servant-client
-        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.6, but its *library* requires the disabled package: servant-server
+        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.6, but its *library* requires the disabled package: servant-multipart-client
         - template < 0 # tried template-0.2.0.10, but its *library* requires text >=0.7.2 && < 1.3 and the snapshot contains text-2.0.1
-        - termbox < 0 # tried termbox-0.3.0, but its *library* requires base ^>=4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract
@@ -7893,20 +7739,17 @@ packages:
         - text-regex-replace < 0 # tried text-regex-replace-0.1.1.4, but its *library* requires text-icu >=0.7 && < 0.8 and the snapshot contains text-icu-0.8.0.2
         - th-extras < 0 # tried th-extras-0.0.0.6, but its *library* requires template-haskell < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - th-lego < 0 # tried th-lego-0.3.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.1
-        - th-test-utils < 0 # tried th-test-utils-1.1.1, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - th-test-utils < 0 # tried th-test-utils-1.2.0, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
         - threepenny-gui < 0 # tried threepenny-gui-0.9.1.0, but its *library* requires the disabled package: snap-server
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: clay
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: threepenny-gui
         - through-text < 0 # tried through-text-0.1.0.0, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.17.0.0
         - thumbnail-plus < 0 # tried thumbnail-plus-1.0.5, but its *library* requires either < 5 and the snapshot contains either-5.0.2
-        - timer-wheel < 0 # tried timer-wheel-0.3.0, but its *library* requires base ^>=4.9 || ^>=4.10 || ^>=4.11 || ^>=4.12 || ^>=4.13 || ^>=4.14 || ^>=4.15 || ^>=4.16 and the snapshot contains base-4.17.0.0
         - tldr < 0 # tried tldr-0.9.2, but its *library* requires the disabled package: cmark
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.6.0
         - tlynx < 0 # tried tlynx-0.7.0.1, but its *library* requires the disabled package: statistics
-        - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires the disabled package: generic-monoid
-        - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires the disabled package: postgresql-simple
-        - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.5.2.1, but its *library* requires the disabled package: postgresql-simple
+        - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.5.2.1, but its *library* requires postgresql-simple >=0.5.4.0 && < 0.6.5 and the snapshot contains postgresql-simple-0.6.5
         - token-bucket < 0 # tried token-bucket-0.1.0.1, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.17.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
@@ -7922,9 +7765,9 @@ packages:
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires persistent-sqlite >=2.8 && < 2.11 and the snapshot contains persistent-sqlite-2.13.1.0
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires resource-pool >=0.2 && < 0.3 and the snapshot contains resource-pool-0.3.1.0
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.0.0
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant >=0.13 && < 0.17 and the snapshot contains servant-0.19
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant-server >=0.13 && < 0.17 and the snapshot contains servant-server-0.19.1
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires wai-extra >=3.0.27 && < 3.1 and the snapshot contains wai-extra-3.1.12.1
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant >=0.13 && < 0.17 and the snapshot contains servant-0.19.1
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant-server >=0.13 && < 0.17 and the snapshot contains servant-server-0.19.2
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires wai-extra >=3.0.27 && < 3.1 and the snapshot contains wai-extra-3.1.13.0
         - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
         - transformers-either < 0 # tried transformers-either-0.1.2, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.1
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.17.0.0
@@ -7967,11 +7810,9 @@ packages:
         - urlpath < 0 # tried urlpath-9.0.1, but its *library* requires the disabled package: attoparsec-uri
         - userid < 0 # tried userid-0.1.3.7, but its *library* requires aeson >=0.9 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - userid < 0 # tried userid-0.1.3.7, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.0.0
-        - users-postgresql-simple < 0 # tried users-postgresql-simple-0.5.0.2, but its *library* requires the disabled package: postgresql-simple
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text-short >=0.1.1 && < 0.1.4 and the snapshot contains text-short-0.1.5
-        - utf8-light < 0 # tried utf8-light-0.4.2, but its *library* requires base < 4.16 and the snapshot contains base-4.17.0.0
         - vado < 0 # tried vado-0.0.14, but its *library* requires base >=4.0.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - variable-media-field < 0 # tried variable-media-field-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: variable-media-field
@@ -7988,7 +7829,7 @@ packages:
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires aeson >=1.2 && < 2.0 and the snapshot contains aeson-2.1.1.0
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.0.0
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires brick >0.26.1 && < 0.54 and the snapshot contains brick-1.3
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires brick >0.26.1 && < 0.54 and the snapshot contains brick-1.4
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector-algorithms >=0.6.0.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
@@ -8004,7 +7845,6 @@ packages:
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
         - wai-saml2 < 0 # tried wai-saml2-0.3.0.1, but its *library* requires text < 2 and the snapshot contains text-2.0.1
-        - wai-session-postgresql < 0 # tried wai-session-postgresql-0.2.1.3, but its *library* requires the disabled package: postgresql-simple
         - wai-transformers < 0 # tried wai-transformers-0.1.0, but its *library* requires the disabled package: monad-control-aligned
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires attoparsec >=0.13 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires base >=4.8 && < 4.14 and the snapshot contains base-4.17.0.0
@@ -8049,12 +7889,9 @@ packages:
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.1
         - webby < 0 # tried webby-1.1.0, but its *library* requires the disabled package: relude
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* requires aeson >=0.6.2.0 && < 1.6 and the snapshot contains aeson-2.1.1.0
-        - webdriver < 0 # tried webdriver-0.9.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.0.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
-        - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.9.0.1
+        - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.10.0.0
         - webgear-core < 0 # tried webgear-core-1.0.4, but its *library* requires jose >=0.8.3.1 && < 0.10 and the snapshot contains jose-0.10
-        - webgear-openapi < 0 # tried webgear-openapi-1.0.4, but its *library* requires the disabled package: openapi3
         - webgear-openapi < 0 # tried webgear-openapi-1.0.4, but its *library* requires the disabled package: webgear-core
         - webgear-server < 0 # tried webgear-server-1.0.4, but its *library* requires jose >=0.8.3.1 && < 0.10 and the snapshot contains jose-0.10
         - websockets-simple < 0 # tried websockets-simple-0.2.0, but its *library* requires the disabled package: monad-control-aligned
@@ -8086,7 +7923,7 @@ packages:
         - writer-cps-full < 0 # tried writer-cps-full-0.1.0.0, but its *library* requires the disabled package: writer-cps-morph
         - writer-cps-lens < 0 # tried writer-cps-lens-0.1.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2
         - ws < 0 # tried ws-0.0.5, but its *library* requires the disabled package: attoparsec-uri
-        - xlsx < 0 # tried xlsx-1.0.0.1, but its *library* requires lens >=3.8 && < 5.2 and the snapshot contains lens-5.2
+        - xlsx < 0 # tried xlsx-1.1.0.1, but its *library* requires the disabled package: hexpat
         - xlsx-tabular < 0 # tried xlsx-tabular-0.2.2.1, but its *library* requires the disabled package: xlsx
         - xml-lens < 0 # tried xml-lens-0.3.1, but its *library* requires text >=0.7 && < 2 and the snapshot contains text-2.0.1
         - xml-parser < 0 # tried xml-parser-0.1.1, but its *library* requires text >=1.2.4 && < 2 and the snapshot contains text-2.0.1
@@ -8125,17 +7962,17 @@ packages:
         - zenacy-html < 0 # tried zenacy-html-2.0.4, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.12.2
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19.1
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant-client >=0.9 && < 0.12 and the snapshot contains servant-client-0.19
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires aeson >=0.7 && < 1.3 and the snapshot contains aeson-2.1.1.0
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.12.2
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19.1
         - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - zm < 0 # tried zm-0.3.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - zm < 0 # tried zm-0.3.2, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.6
-        - zm < 0 # tried zm-0.3.2, but its *library* requires flat ==0.3.* and the snapshot contains flat-0.5.2
+        - zm < 0 # tried zm-0.3.2, but its *library* requires flat ==0.3.* and the snapshot contains flat-0.6
         - zm < 0 # tried zm-0.3.2, but its *library* requires model >=0.4.4 && < 0.5 and the snapshot contains model-0.5
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.0.0
@@ -8448,9 +8285,7 @@ skipped-tests:
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires doctest >=0.16.2 && < 0.20 and the snapshot contains doctest-0.20.1
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires hedgehog >=1.0.2 && < 1.2 and the snapshot contains hedgehog-1.2
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-discover >=4.2.1 && < 4.3 and the snapshot contains tasty-discover-5.0.0
-    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-hedgehog >=1.0.0.2 && < 1.2 and the snapshot contains tasty-hedgehog-1.3.1.0
-    - accelerate-bignum # tried accelerate-bignum-0.3.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
-    - accelerate-io-vector # tried accelerate-io-vector-0.1.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-hedgehog >=1.0.0.2 && < 1.2 and the snapshot contains tasty-hedgehog-1.4.0.0
     - airship # tried airship-0.9.5, but its *test-suite* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
     - airship # tried airship-0.9.5, but its *test-suite* requires tasty >=0.10.1 && < 1.3 and the snapshot contains tasty-1.4.2.3
     - airship # tried airship-0.9.5, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.1
@@ -8472,13 +8307,11 @@ skipped-tests:
     - async-refresh-tokens # tried async-refresh-tokens-0.4.0.0, but its *test-suite* requires the disabled package: criterion
     - barrier # tried barrier-0.1.1, but its *test-suite* requires lens-family-core >=1.2 && < 1.3 and the snapshot contains lens-family-core-2.1.2
     - barrier # tried barrier-0.1.1, but its *test-suite* requires tasty >=0.10 && < 0.12 and the snapshot contains tasty-1.4.2.3
-    - binance-exports # tried binance-exports-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - binary-generic-combinators # tried binary-generic-combinators-0.4.4.0, but its *test-suite* requires the disabled package: byte-order
     - binary-tagged # tried binary-tagged-0.3.1, but its *test-suite* requires the disabled package: binary-instances
     - bloodhound # tried bloodhound-0.21.0.0, but its *test-suite* requires the disabled package: quickcheck-properties
     - boolean-normal-forms # tried boolean-normal-forms-0.0.1.1, but its *test-suite* requires QuickCheck >=2.10 && < 2.14 and the snapshot contains QuickCheck-2.14.2
     - brittany # tried brittany-0.14.0.2, but its *test-suite* requires hspec ^>=2.8.3 and the snapshot contains hspec-2.10.6
-    - bsb-http-chunked # tried bsb-http-chunked-0.0.0.4, but its *test-suite* requires the disabled package: tasty-hedgehog
     - buffer-builder # tried buffer-builder-0.2.4.8, but its *test-suite* requires the disabled package: criterion
     - buttplug-hs-core # tried buttplug-hs-core-0.1.0.1, but its *test-suite* requires hspec >=2.7.8 && < 2.9 and the snapshot contains hspec-2.10.6
     - bytebuild # tried bytebuild-0.3.11.0, but its *test-suite* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
@@ -8489,13 +8322,12 @@ skipped-tests:
     - cassava-conduit # tried cassava-conduit-0.6.0, but its *test-suite* requires QuickCheck ==2.12.* and the snapshot contains QuickCheck-2.14.2
     - cayley-client # tried cayley-client-0.4.19.2, but its *test-suite* requires aeson >=0.8.0.2 && < 1.6 || ==2.0.* and the snapshot contains aeson-2.1.1.0
     - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.10.6
-    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.19.1
+    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.19.2
     - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.3.23
     - cleff # tried cleff-0.3.3.0, but its *test-suite* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.0.0
     - cleff # tried cleff-0.3.3.0, but its *test-suite* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
     - colour # tried colour-2.3.6, but its *test-suite* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
     - construct # tried construct-0.3.1.1, but its *test-suite* requires monoid-subclasses >=1.0 && < 1.2 and the snapshot contains monoid-subclasses-1.2
-    - cron # tried cron-0.7.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - csg # tried csg-0.1.0.6, but its *test-suite* requires doctest < 0.17 and the snapshot contains doctest-0.20.1
     - csg # tried csg-0.1.0.6, but its *test-suite* requires tasty < 1.3 and the snapshot contains tasty-1.4.2.3
     - d10 # tried d10-1.0.1.0, but its *test-suite* requires hedgehog ^>=1.0.1 || ^>=1.1 and the snapshot contains hedgehog-1.2
@@ -8522,10 +8354,8 @@ skipped-tests:
     - email-validate # tried email-validate-2.3.2.16, but its *test-suite* requires doctest >=0.8 && < 0.20 and the snapshot contains doctest-0.20.1
     - email-validate # tried email-validate-2.3.2.16, but its *test-suite* requires hspec >=2.2.3 && < 2.10 and the snapshot contains hspec-2.10.6
     - errors-ext # tried errors-ext-0.4.2, but its *test-suite* requires the disabled package: binary-ext
-    - esqueleto # tried esqueleto-3.5.8.1, but its *test-suite* requires the disabled package: postgresql-simple
     - euler-tour-tree # tried euler-tour-tree-0.1.1.0, but its *test-suite* requires the disabled package: sequence
     - eventsource-stub-store # tried eventsource-stub-store-1.1.1, but its *test-suite* requires the disabled package: eventsource-store-specs
-    - evm-opcodes # tried evm-opcodes-0.1.2, but its *test-suite* requires the disabled package: tasty-hedgehog
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework-th
     - filepath-bytestring # tried filepath-bytestring-1.4.2.1.12, but its *test-suite* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.4.2.2
     - filtrable # tried filtrable-0.1.6.0, but its *test-suite* requires tasty >=1.3.1 && < 1.4 and the snapshot contains tasty-1.4.2.3
@@ -8542,7 +8372,6 @@ skipped-tests:
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires integer-gmp >=1.0.2 && < 1.1 and the snapshot contains integer-gmp-1.1
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires semirings >=0.5 && < 0.6 and the snapshot contains semirings-0.6
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires tasty >=1.2 && < 1.3 and the snapshot contains tasty-1.4.2.3
-    - gemini-exports # tried gemini-exports-0.1.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - generic-data # tried generic-data-1.0.0.0, but its *test-suite* requires the disabled package: one-liner
     - generic-xmlpickler # tried generic-xmlpickler-0.1.0.6, but its *test-suite* requires tasty >=0.10 && < 1.3 and the snapshot contains tasty-1.4.2.3
     - greskell # tried greskell-2.0.0.0, but its *test-suite* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
@@ -8550,7 +8379,7 @@ skipped-tests:
     - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec >=2.4.4 && < 2.10 and the snapshot contains hspec-2.10.6
     - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires optparse-applicative ^>=0.15 and the snapshot contains optparse-applicative-0.17.0.0
-    - hal # tried hal-1.0.0, but its *test-suite* requires hedgehog >=1.0.3 && < 1.2 and the snapshot contains hedgehog-1.2
+    - hal # tried hal-1.0.0.1, but its *test-suite* requires hedgehog >=1.0.3 && < 1.2 and the snapshot contains hedgehog-1.2
     - hasbolt # tried hasbolt-0.1.6.2, but its *test-suite* requires hspec >=2.4.1 && < 2.9 and the snapshot contains hspec-2.10.6
     - haskell-names # tried haskell-names-0.9.9, but its *test-suite* requires tasty >=0.12 && < 1.3 and the snapshot contains tasty-1.4.2.3
     - haskell-tools-builtin-refactorings # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.4.2.3
@@ -8571,12 +8400,10 @@ skipped-tests:
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires lens >=4.12 && < 5 and the snapshot contains lens-5.2
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
     - hasmin # tried hasmin-1.0.3, but its *test-suite* requires doctest >=0.11 && < 0.17 and the snapshot contains doctest-0.20.1
-    - heist # tried heist-1.1.0.1, but its *test-suite* requires lens >=4.3 && < 4.20 and the snapshot contains lens-5.2
     - hidden-char # tried hidden-char-0.1.0.2, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.10.6
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires QuickCheck < 2.12 and the snapshot contains QuickCheck-2.14.2
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires base < 4.12 and the snapshot contains base-4.17.0.0
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires hspec >=2.2 && < 2.6 and the snapshot contains hspec-2.10.6
-    - hledger-stockquotes # tried hledger-stockquotes-0.1.2.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - horizontal-rule # tried horizontal-rule-0.5.0.0, but its *test-suite* requires the disabled package: HMock
     - hsdev # tried hsdev-0.3.4.0, but its *test-suite* requires lens-aeson >=1.0 && < 1.2 and the snapshot contains lens-aeson-1.2.2
     - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* requires hspec ==2.7.* and the snapshot contains hspec-2.10.6
@@ -8587,14 +8414,11 @@ skipped-tests:
     - indexed-containers # tried indexed-containers-0.1.0.2, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.10.6
     - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty >=0.11.0.2 && < 1.2 and the snapshot contains tasty-1.4.2.3
     - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty-hspec >=1.1.2 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.1
-    - jose # tried jose-0.10, but its *test-suite* requires the disabled package: tasty-hedgehog
     - json-rpc-client # tried json-rpc-client-0.2.5.0, but its *test-suite* requires QuickCheck >=2.4.2 && < 2.14 and the snapshot contains QuickCheck-2.14.2
-    - lackey # tried lackey-2.0.0.3, but its *test-suite* requires the disabled package: servant
     - language-javascript # tried language-javascript-0.7.1.0, but its *test-suite* requires the disabled package: utf8-light
     - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec ==2.7.* and the snapshot contains hspec-2.10.6
     - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.10.6
     - linear-accelerate # tried linear-accelerate-0.7.0.0, but its *test-suite* requires doctest >=0.11.1 && < 0.17 and the snapshot contains doctest-0.20.1
-    - linear-base # tried linear-base-0.2.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5
     - lrucaching # tried lrucaching-0.3.3, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.10.6
     - lxd-client # tried lxd-client-0.1.0.6, but its *test-suite* requires turtle >=1.3.6 && < 1.6 and the snapshot contains turtle-1.6.1
@@ -8613,13 +8437,10 @@ skipped-tests:
     - msgpack # tried msgpack-1.0.1.0, but its *test-suite* requires QuickCheck ==2.12.* and the snapshot contains QuickCheck-2.14.2
     - msgpack # tried msgpack-1.0.1.0, but its *test-suite* requires tasty ==1.2.* and the snapshot contains tasty-1.4.2.3
     - multistate # tried multistate-0.8.0.4, but its *test-suite* requires hspec >=2 && < 2.9 and the snapshot contains hspec-2.10.6
-    - murmur3 # tried murmur3-1.0.5, but its *test-suite* requires the disabled package: base16
     - mwc-random # tried mwc-random-0.15.0.2, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.20.1
     - nakadi-client # tried nakadi-client-0.7.0.0, but its *test-suite* requires classy-prelude >=1.4.0 && < 1.5.0 and the snapshot contains classy-prelude-1.5.0.2
     - next-ref # tried next-ref-0.1.0.2, but its *test-suite* requires hspec >=2 && < 2.3 and the snapshot contains hspec-2.10.6
-    - nonempty-containers # tried nonempty-containers-0.3.4.4, but its *test-suite* requires the disabled package: tasty-hedgehog
     - numhask-prelude # tried numhask-prelude-0.5.0, but its *test-suite* requires doctest >=0.13 && < 0.17 and the snapshot contains doctest-0.20.1
-    - o-clock # tried o-clock-1.3.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - optics # tried optics-0.4.2, but its *test-suite* requires inspection-testing >=0.4.1.1 && < 0.5 and the snapshot contains inspection-testing-0.5
     - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell
     - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell-quickcheck
@@ -8632,71 +8453,56 @@ skipped-tests:
     - polysemy # tried polysemy-1.7.1.0, but its *test-suite* requires inspection-testing >=0.4.2 && < 0.5 and the snapshot contains inspection-testing-0.5
     - polysemy-plugin # tried polysemy-plugin-0.4.3.1, but its *test-suite* requires doctest >=0.16.0.1 && < 0.19 and the snapshot contains doctest-0.20.1
     - polysemy-plugin # tried polysemy-plugin-0.4.3.1, but its *test-suite* requires inspection-testing >=0.4.2 && < 0.5 and the snapshot contains inspection-testing-0.5
-    - postgresql-libpq-notify # tried postgresql-libpq-notify-0.2.0.0, but its *test-suite* requires the disabled package: postgres-options
-    - postgresql-libpq-notify # tried postgresql-libpq-notify-0.2.0.0, but its *test-suite* requires the disabled package: tmp-postgres
     - postgrest # tried postgrest-9.0.1, but its *test-suite* requires hspec >=2.3 && < 2.9 and the snapshot contains hspec-2.10.6
     - printcess # tried printcess-0.1.0.3, but its *test-suite* requires HUnit >=1.3 && < 1.6 and the snapshot contains HUnit-1.6.2.0
     - printcess # tried printcess-0.1.0.3, but its *test-suite* requires QuickCheck >=2.8 && < 2.10 and the snapshot contains QuickCheck-2.14.2
     - qnap-decrypt # tried qnap-decrypt-0.3.5, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.10.6
     - quickcheck-state-machine # tried quickcheck-state-machine-0.7.1, but its *test-suite* requires the disabled package: hs-rqlite
     - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.10.6
-    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.19.1
+    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.19.2
     - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.3.23
     - records-sop # tried records-sop-0.1.1.0, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.10.6
     - redact # tried redact-0.4.0.0, but its *test-suite* requires the disabled package: HMock
+    - registry # tried registry-0.3.3.4, but its *test-suite* requires MonadRandom < 0.6 and the snapshot contains MonadRandom-0.6
     - registry # tried registry-0.3.3.4, but its *test-suite* requires tasty-discover < 4.3 and the snapshot contains tasty-discover-5.0.0
     - rel8 # tried rel8-1.4.0.0, but its *test-suite* requires hedgehog ^>=1.0 || ^>=1.1 and the snapshot contains hedgehog-1.2
     - relude # tried relude-1.1.0.0, but its *test-suite* requires hedgehog >=1.0 && < 1.2 and the snapshot contains hedgehog-1.2
     - req-url-extra # tried req-url-extra-0.1.1.0, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.10.6
     - rest-rewrite # tried rest-rewrite-0.4.0, but its *test-suite* requires time >=1.9.3 && < 1.10 and the snapshot contains time-1.12.2
-    - retry # tried retry-0.9.3.0, but its *test-suite* requires the disabled package: tasty-hedgehog
-    - rng-utils # tried rng-utils-0.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-th
     - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.14.2
     - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.10.6
     - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.10.6
     - schematic # tried schematic-0.5.1.0, but its *test-suite* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.0.0
-    - scotty # tried scotty-0.12, but its *test-suite* requires text < 2.0 and the snapshot contains text-2.0.1
-    - servant # tried servant-0.19, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
-    - servant # tried servant-0.19, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
+    - servant # tried servant-0.19.1, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
+    - servant # tried servant-0.19.1, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires hspec >=2.5.5 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires jose >=0.7.0.0 && < 0.10 and the snapshot contains jose-0.10
-    - servant-auth-docs # tried servant-auth-docs-0.2.10.0, but its *test-suite* requires doctest >=0.11.3 && < 0.19 and the snapshot contains doctest-0.20.1
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* requires hspec >=2.5.5 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-auth-server # tried servant-auth-server-0.4.7.0, but its *test-suite* requires lens-aeson >=1.0.2 && < 1.2 and the snapshot contains lens-aeson-1.2.2
     - servant-auth-swagger # tried servant-auth-swagger-0.2.10.1, but its *test-suite* requires hspec >=2.5.5 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-auth-swagger # tried servant-auth-swagger-0.2.10.1, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.10 and the snapshot contains hspec-discover-2.10.6
-    - servant-blaze # tried servant-blaze-0.9.1, but its *test-suite* requires the disabled package: servant-server
-    - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires the disabled package: servant-server
     - servant-client # tried servant-client-0.19, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-client # tried servant-client-0.19, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-client-core # tried servant-client-core-0.19, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-client-core # tried servant-client-core-0.19, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
-    - servant-conduit # tried servant-conduit-0.15.1, but its *test-suite* requires the disabled package: servant-client
-    - servant-conduit # tried servant-conduit-0.15.1, but its *test-suite* requires the disabled package: servant-server
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.10.6
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9 and the snapshot contains hspec-core-2.10.6
-    - servant-elm # tried servant-elm-0.7.2, but its *test-suite* requires the disabled package: servant-client
     - servant-foreign # tried servant-foreign-0.15.4, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-foreign # tried servant-foreign-0.15.4, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-http-streams # tried servant-http-streams-0.18.4, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
     - servant-http-streams # tried servant-http-streams-0.18.4, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
-    - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires hspec >=2.6.0 && < 2.8 and the snapshot contains hspec-2.10.6
-    - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.8 and the snapshot contains hspec-discover-2.10.6
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.10.6
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires http-api-data >=0.3.7 && < 0.4.2 and the snapshot contains http-api-data-0.5
-    - servant-machines # tried servant-machines-0.15.1, but its *test-suite* requires the disabled package: servant-client
-    - servant-machines # tried servant-machines-0.15.1, but its *test-suite* requires the disabled package: servant-server
     - servant-mock # tried servant-mock-0.8.7, but its *test-suite* requires hspec-wai >=0.9.0 && < 0.11 and the snapshot contains hspec-wai-0.11.1
-    - servant-pipes # tried servant-pipes-0.15.3, but its *test-suite* requires the disabled package: servant-client
-    - servant-pipes # tried servant-pipes-0.15.3, but its *test-suite* requires the disabled package: servant-server
+    - servant-multipart # tried servant-multipart-0.12.1, but its *test-suite* requires the disabled package: tasty-wai
     - servant-quickcheck # tried servant-quickcheck-0.0.10.0, but its *test-suite* requires hspec-core >=2.5.5 && < 2.8 and the snapshot contains hspec-core-2.10.6
-    - servant-server # tried servant-server-0.19.1, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
-    - servant-server # tried servant-server-0.19.1, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
+    - servant-server # tried servant-server-0.19.2, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.6
+    - servant-server # tried servant-server-0.19.2, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-streaming # tried servant-streaming-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.13 and the snapshot contains QuickCheck-2.14.2
     - servant-streaming-client # tried servant-streaming-client-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.2
     - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.2
@@ -8706,14 +8512,13 @@ skipped-tests:
     - servant-swagger # tried servant-swagger-1.1.11, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.6
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.1.1.0
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.12.2
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.19.1
+    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.19.2
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.10.6
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires the disabled package: network-transport-tcp
     - sexpr-parser # tried sexpr-parser-0.2.2.0, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.10.6
     - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.10.6
     - simple-vec3 # tried simple-vec3-0.6.0.1, but its *test-suite* requires the disabled package: doctest-driver-gen
     - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-0.11.3
-    - snap # tried snap-1.1.3.1, but its *test-suite* requires QuickCheck >=2.4.2 && < 2.14 and the snapshot contains QuickCheck-2.14.2
     - spacecookie # tried spacecookie-1.0.0.2, but its *test-suite* requires the disabled package: download-curl
     - squeal-postgresql # tried squeal-postgresql-0.9.0.0, but its *test-suite* requires the disabled package: with-utf8
     - static-text # tried static-text-0.2.0.7, but its *test-suite* requires the disabled package: doctest-driver-gen
@@ -8731,19 +8536,17 @@ skipped-tests:
     - sv # tried sv-1.4.0.1, but its *test-suite* requires lens >=4 && < 4.20 and the snapshot contains lens-5.2
     - sv # tried sv-1.4.0.1, but its *test-suite* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
     - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.4.2.3
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty-hedgehog >=0.1 && < 1.1 and the snapshot contains tasty-hedgehog-1.3.1.0
+    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty-hedgehog >=0.1 && < 1.1 and the snapshot contains tasty-hedgehog-1.4.0.0
     - sv # tried sv-1.4.0.1, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
     - sv-cassava # tried sv-cassava-0.3, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.1
     - sv-core # tried sv-core-0.5, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.4.2.3
-    - swagger2 # tried swagger2-2.8.5, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.10.6
+    - swagger2 # tried swagger2-2.8.6, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.10.6
     - sydtest-yesod # tried sydtest-yesod-0.3.0.1, but its *test-suite* requires the disabled package: yesod
     - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell-quickcheck
     - tar # tried tar-0.5.1.1, but its *test-suite* requires the disabled package: bytestring-handle
-    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.2.3
-    - termonad # tried termonad-4.3.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
     - transient # tried transient-0.7.0.0, but its *test-suite* requires random ==1.1 and the snapshot contains random-1.2.1.1
     - type-errors # tried type-errors-0.2.0.0, but its *test-suite* requires doctest >=0.16.0.1 && < 0.20 and the snapshot contains doctest-0.20.1
@@ -8756,10 +8559,8 @@ skipped-tests:
     - ucam-webauth-types # tried ucam-webauth-types-0.1.0.0, but its *test-suite* requires hspec >=2.0.0 && < 2.8 and the snapshot contains hspec-2.10.6
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires QuickCheck >=2.9 && < 2.14 and the snapshot contains QuickCheck-2.14.2
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.10.6
-    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - validation # tried validation-1.1.2, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.2
     - validation # tried validation-1.1.2, but its *test-suite* requires lens >=4 && < 5 and the snapshot contains lens-5.2
-    - wai-rate-limit-redis # tried wai-rate-limit-redis-0.2.0.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.10.6
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.1
@@ -8777,7 +8578,7 @@ skipped-tests:
     - wide-word # tried wide-word-0.1.1.2, but its *test-suite* requires hedgehog ==1.0.* and the snapshot contains hedgehog-1.2
     - wild-bind-x11 # tried wild-bind-x11-0.2.0.14, but its *test-suite* requires time >=1.5.0 && < 1.10 and the snapshot contains time-1.12.2
     - wreq # tried wreq-0.5.3.3, but its *test-suite* requires the disabled package: snap-server
-    - xmlhtml # tried xmlhtml-0.2.5.2, but its *test-suite* requires hspec >=2.4 && < 2.10 and the snapshot contains hspec-2.10.6
+    - xlsx # tried xlsx-1.1.0.1, but its *test-suite* requires lens >=3.8 && < 5.2 and the snapshot contains lens-5.2
     - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod
     - yesod-static-angular # tried yesod-static-angular-0.1.8, but its *test-suite* requires yesod-test >=1.2 && < 1.6 and the snapshot contains yesod-test-1.6.15
     - yesod-test # tried yesod-test-1.6.15, but its *test-suite* requires the disabled package: yesod-form
@@ -9358,6 +9159,7 @@ skipped-benchmarks:
     - apecs # tried apecs-0.9.4, but its *benchmarks* requires the disabled package: criterion
     - avers # tried avers-0.0.17.1, but its *benchmarks* requires criterion >=1.1.4.0 && < 1.6 and the snapshot contains criterion-1.6.0.0
     - aws-xray-client # tried aws-xray-client-0.1.0.2, but its *benchmarks* requires the disabled package: criterion
+    - base16 # tried base16-0.3.2.1, but its *benchmarks* requires the disabled package: criterion
     - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *benchmarks* requires the disabled package: criterion
     - base58-bytestring # tried base58-bytestring-0.1.0, but its *benchmarks* requires the disabled package: criterion
     - base64 # tried base64-0.4.2.4, but its *benchmarks* requires the disabled package: criterion
@@ -9379,7 +9181,7 @@ skipped-benchmarks:
     - cacophony # tried cacophony-0.10.1, but its *benchmarks* requires the disabled package: criterion
     - cborg-json # tried cborg-json-0.2.5.0, but its *benchmarks* requires criterion >=1.0 && < 1.6 and the snapshot contains criterion-1.6.0.0
     - cdar-mBound # tried cdar-mBound-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
-    - chronos # tried chronos-1.1.4, but its *benchmarks* requires the disabled package: thyme
+    - chronos # tried chronos-1.1.5, but its *benchmarks* requires the disabled package: thyme
     - cipher-aes # tried cipher-aes-0.2.11, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
     - cipher-camellia # tried cipher-camellia-0.0.2, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
     - cipher-rc4 # tried cipher-rc4-0.1.4, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
@@ -9400,6 +9202,7 @@ skipped-benchmarks:
     - data-has # tried data-has-0.4.0.0, but its *benchmarks* requires the disabled package: criterion
     - data-msgpack # tried data-msgpack-0.0.13, but its *benchmarks* requires the disabled package: criterion
     - data-sketches # tried data-sketches-0.3.1.0, but its *benchmarks* requires the disabled package: criterion
+    - dbus # tried dbus-1.2.27, but its *benchmarks* requires the disabled package: criterion
     - diagrams-lib # tried diagrams-lib-1.4.5.3, but its *benchmarks* requires the disabled package: criterion
     - dimensional # tried dimensional-1.5, but its *benchmarks* requires the disabled package: criterion
     - discrimination # tried discrimination-0.5, but its *benchmarks* requires the disabled package: criterion
@@ -9437,10 +9240,7 @@ skipped-benchmarks:
     - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.0.0
     - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
     - hasmin # tried hasmin-1.0.3, but its *benchmarks* requires criterion >=0.11 && < 1.6 and the snapshot contains criterion-1.6.0.0
-    - heist # tried heist-1.1.0.1, but its *benchmarks* requires criterion >=1.0 && < 1.6 and the snapshot contains criterion-1.6.0.0
-    - heist # tried heist-1.1.0.1, but its *benchmarks* requires criterion-measurement >=0.1 && < 0.2 and the snapshot contains criterion-measurement-0.2.0.0
-    - heist # tried heist-1.1.0.1, but its *benchmarks* requires statistics >=0.11 && < 0.16 and the snapshot contains statistics-0.16.1.0
-    - hgeometry # tried hgeometry-0.14, but its *benchmarks* requires the disabled package: deepseq-generics
+    - heist # tried heist-1.1.1.0, but its *benchmarks* requires the disabled package: statistics
     - hindent # tried hindent-5.3.4, but its *benchmarks* requires the disabled package: criterion
     - histogram-fill # tried histogram-fill-0.9.1.0, but its *benchmarks* requires the disabled package: criterion
     - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *benchmarks* requires the disabled package: criterion
@@ -9458,7 +9258,7 @@ skipped-benchmarks:
     - hw-json-simple-cursor # tried hw-json-simple-cursor-0.1.1.1, but its *benchmarks* requires the disabled package: criterion
     - hw-json-standard-cursor # tried hw-json-standard-cursor-0.2.3.2, but its *benchmarks* requires the disabled package: criterion
     - hw-packed-vector # tried hw-packed-vector-0.2.1.1, but its *benchmarks* requires the disabled package: criterion
-    - hw-prim # tried hw-prim-0.6.3.1, but its *benchmarks* requires the disabled package: criterion
+    - hw-prim # tried hw-prim-0.6.3.2, but its *benchmarks* requires the disabled package: criterion
     - hw-rankselect # tried hw-rankselect-0.13.4.1, but its *benchmarks* requires the disabled package: criterion
     - hw-rankselect-base # tried hw-rankselect-base-0.3.4.1, but its *benchmarks* requires the disabled package: criterion
     - hw-simd # tried hw-simd-0.1.2.1, but its *benchmarks* requires the disabled package: criterion
@@ -9468,10 +9268,12 @@ skipped-benchmarks:
     - identicon # tried identicon-0.2.2, but its *benchmarks* requires the disabled package: criterion
     - include-file # tried include-file-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
     - incremental-parser # tried incremental-parser-0.5.0.4, but its *benchmarks* requires monoid-subclasses < 1.2 and the snapshot contains monoid-subclasses-1.2
+    - inline-r # tried inline-r-1.0.0, but its *benchmarks* requires the disabled package: criterion
     - intset-imperative # tried intset-imperative-0.1.0.0, but its *benchmarks* requires the disabled package: criterion
     - invert # tried invert-1.0.0.2, but its *benchmarks* requires the disabled package: criterion
     - katip # tried katip-0.8.7.2, but its *benchmarks* requires the disabled package: criterion
     - kazura-queue # tried kazura-queue-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - kdt # tried kdt-0.2.5, but its *benchmarks* requires the disabled package: criterion
     - lens # tried lens-5.2, but its *benchmarks* requires the disabled package: criterion
     - lifted-base # tried lifted-base-0.2.3.12, but its *benchmarks* requires the disabled package: criterion
     - loop # tried loop-0.3.0, but its *benchmarks* requires the disabled package: criterion
@@ -9485,9 +9287,9 @@ skipped-benchmarks:
     - memcache # tried memcache-0.3.0.1, but its *benchmarks* requires the disabled package: criterion
     - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *benchmarks* requires criterion >=1.4.1 && < 1.6 and the snapshot contains criterion-1.6.0.0
     - minisat-solver # tried minisat-solver-0.1, but its *benchmarks* requires the disabled package: easyrender
-    - modern-uri # tried modern-uri-0.3.5.0, but its *benchmarks* requires the disabled package: criterion
+    - modern-uri # tried modern-uri-0.3.6.0, but its *benchmarks* requires the disabled package: criterion
     - monad-memo # tried monad-memo-0.5.4, but its *benchmarks* requires the disabled package: criterion
-    - mongoDB # tried mongoDB-2.7.1.1, but its *benchmarks* requires the disabled package: criterion
+    - mongoDB # tried mongoDB-2.7.1.2, but its *benchmarks* requires the disabled package: criterion
     - monoid-extras # tried monoid-extras-0.6.1, but its *benchmarks* requires the disabled package: criterion
     - netpbm # tried netpbm-1.0.4, but its *benchmarks* requires the disabled package: criterion
     - network-uri # tried network-uri-2.6.4.1, but its *benchmarks* requires the disabled package: criterion
@@ -9500,6 +9302,7 @@ skipped-benchmarks:
     - pava # tried pava-0.1.1.4, but its *benchmarks* requires the disabled package: criterion
     - pcre2 # tried pcre2-2.2.1, but its *benchmarks* requires the disabled package: criterion
     - persistent # tried persistent-2.14.3.0, but its *benchmarks* requires the disabled package: criterion
+    - pg-transact # tried pg-transact-0.3.2.0, but its *benchmarks* requires the disabled package: criterion
     - phantom-state # tried phantom-state-0.2.1.2, but its *benchmarks* requires the disabled package: criterion
     - pipes # tried pipes-4.3.16, but its *benchmarks* requires the disabled package: criterion
     - polysemy # tried polysemy-1.7.1.0, but its *benchmarks* requires the disabled package: freer-simple
@@ -9523,7 +9326,7 @@ skipped-benchmarks:
     - rng-utils # tried rng-utils-0.3.1, but its *benchmarks* requires the disabled package: criterion
     - sampling # tried sampling-0.3.5, but its *benchmarks* requires the disabled package: criterion
     - sandi # tried sandi-0.5, but its *benchmarks* requires the disabled package: criterion
-    - scalpel-core # tried scalpel-core-0.6.2, but its *benchmarks* requires the disabled package: criterion
+    - scalpel-core # tried scalpel-core-0.6.2.1, but its *benchmarks* requires the disabled package: criterion
     - scanner # tried scanner-0.3.1, but its *benchmarks* requires the disabled package: criterion
     - search-algorithms # tried search-algorithms-0.3.2, but its *benchmarks* requires the disabled package: criterion
     - semver # tried semver-0.4.0.1, but its *benchmarks* requires the disabled package: criterion
@@ -9533,7 +9336,7 @@ skipped-benchmarks:
     - sets # tried sets-0.0.6.2, but its *benchmarks* requires the disabled package: criterion
     - sexp-grammar # tried sexp-grammar-2.3.4.0, but its *benchmarks* requires the disabled package: criterion
     - simple-vec3 # tried simple-vec3-0.6.0.1, but its *benchmarks* requires the disabled package: criterion
-    - skylighting-core # tried skylighting-core-0.13.1, but its *benchmarks* requires the disabled package: criterion
+    - skylighting-core # tried skylighting-core-0.13.1.1, but its *benchmarks* requires the disabled package: criterion
     - sorted-list # tried sorted-list-0.2.1.0, but its *benchmarks* requires the disabled package: criterion
     - sourcemap # tried sourcemap-0.1.7, but its *benchmarks* requires the disabled package: criterion
     - stache # tried stache-2.3.3, but its *benchmarks* requires the disabled package: criterion
@@ -9554,6 +9357,7 @@ skipped-benchmarks:
     - text-show # tried text-show-3.10, but its *benchmarks* requires the disabled package: criterion
     - thread-local-storage # tried thread-local-storage-0.2, but its *benchmarks* requires the disabled package: criterion
     - tidal # tried tidal-1.9.2, but its *benchmarks* requires the disabled package: criterion
+    - tmp-postgres # tried tmp-postgres-1.34.1.0, but its *benchmarks* requires the disabled package: criterion
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: criterion-plus
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: stm-stats
     - turtle # tried turtle-1.6.1, but its *benchmarks* requires text < 1.3 and the snapshot contains text-2.0.1
@@ -9565,7 +9369,7 @@ skipped-benchmarks:
     - unicode-transforms # tried unicode-transforms-0.4.0.1, but its *benchmarks* requires path >=0.0.0 && < 0.9 and the snapshot contains path-0.9.2
     - unicode-transforms # tried unicode-transforms-0.4.0.1, but its *benchmarks* requires path-io >=0.1.0 && < 1.7 and the snapshot contains path-io-1.7.0
     - union # tried union-0.1.2, but its *benchmarks* requires the disabled package: criterion
-    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *benchmarks* requires the disabled package: deepseq-generics
+    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *benchmarks* requires the disabled package: criterion
     - varying # tried varying-0.8.1.0, but its *benchmarks* requires the disabled package: criterion
     - vec # tried vec-0.4.1, but its *benchmarks* requires criterion >=1.4.0.0 && < 1.6 and the snapshot contains criterion-1.6.0.0
     - vectortiles # tried vectortiles-1.5.1, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.0.0


### PR DESCRIPTION
diff (`(*)` are packages i didn't compile locally):
```
+ H-1.0.0 (*)
+ HStringTemplate-0.8.8
+ advent-of-code-api-0.2.8.1
+ autodocodec-openapi3-0.2.1.1
+ aws-0.23
+ base16-0.3.2.1
+ breakpoint-0.1.1.1
+ bugzilla-redhat-1.0.0
+ credential-store-0.1.2
+ dbcleaner-0.1.3
+ dbus-1.2.27
+ dbus-hslogger-0.1.0.1
+ deepseq-generics-0.2.0.0
+ dice-0.1.1
+ drifter-postgresql-0.2.1
+ ed25519-0.0.5.0
+ experimenter-0.1.0.14
+ fastmemo-0.1.1
+ fdo-notify-0.3.1
+ freckle-app-1.7.0.0
+ generic-monoid-0.1.0.1
+ ghc-events-0.18.0
+ github-webhooks-0.16.0
+ haskoin-core-0.21.2 (*)
+ haskoin-node-0.18.1 (*)
+ haskoin-store-data-0.65.5 (*)
+ hasql-queue-1.2.0.2
+ heist-1.1.1.0
+ hex-text-0.1.0.7
+ hidapi-0.1.8
+ inline-r-1.0.0 (*)
+ katip-wai-0.1.2.1
+ kdt-0.2.5
+ krank-0.3.0
+ map-syntax-0.3
+ opaleye-0.9.6.1
+ openapi3-3.2.2
+ ormolu-0.5.1.0
+ persistent-postgresql-2.13.5.0
+ pg-transact-0.3.2.0
+ postgres-options-0.2.0.0
+ postgresql-migration-0.2.1.6
+ postgresql-schema-0.1.14
+ postgresql-simple-0.6.5
+ pqueue-1.4.3.0
+ psql-helpers-0.1.0.0
+ reactive-banana-1.3.1.0
+ readable-0.3.1
+ secp256k1-haskell-0.6.1 (*)
+ servant-0.19.1
+ servant-blaze-0.9.1
+ servant-cassava-0.10.2
+ servant-client-0.19
+ servant-client-core-0.19
+ servant-conduit-0.15.1
+ servant-exceptions-0.2.1
+ servant-exceptions-server-0.2.1
+ servant-http-streams-0.18.4
+ servant-machines-0.15.1
+ servant-multipart-api-0.12.1
+ servant-rate-limit-0.2.0.0
+ servant-rawm-1.0.0.0
+ servant-server-0.19.2
+ servant-static-th-1.0.0.0
+ servant-swagger-1.1.11
+ servant-websockets-2.0.0
+ servant-xml-1.0.1.4
+ slist-0.2.1.0
+ snap-blaze-0.2.1.5
+ snap-core-1.0.5.0
+ swagger2-2.8.6
+ sydtest-persistent-postgresql-0.2.0.2
+ sydtest-servant-0.2.0.2
+ tasty-hedgehog-1.4.0.0
+ termbox-1.1.0
+ timer-wheel-0.4.0.1
+ tmp-postgres-1.34.1.0
+ users-postgresql-simple-0.5.0.2
+ wai-session-postgresql-0.2.1.3
+ webdriver-0.10.0.0
```
