### PR TITLE
Reenable http-api-data-qq

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6812,9 +6812,6 @@ packages:
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.1.0
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.0.1
-        - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.0.0
-        - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
         - hw-json < 0 # tried hw-json-1.3.2.3, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires text >=1.2.3.2 && < 2 and the snapshot contains text-2.0.1
         - hwk < 0 # tried hwk-0.6, but its *executable* requires the disabled package: hint


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
