### PR TITLE
Reenable th-test-utils

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7740,7 +7740,6 @@ packages:
         - text-regex-replace < 0 # tried text-regex-replace-0.1.1.4, but its *library* requires text-icu >=0.7 && < 0.8 and the snapshot contains text-icu-0.8.0.2
         - th-extras < 0 # tried th-extras-0.0.0.6, but its *library* requires template-haskell < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - th-lego < 0 # tried th-lego-0.3.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.1
-        - th-test-utils < 0 # tried th-test-utils-1.2.0, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
         - threepenny-gui < 0 # tried threepenny-gui-0.9.1.0, but its *library* requires the disabled package: snap-server
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: clay


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
