### PR TITLE
Add co-log-core to grandfathered dependencies to unblock hie-bios and lsp

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5004,6 +5004,7 @@ packages:
         - classy-prelude-conduit
         - clientsession
         - cmark-gfm
+        - co-log-core
         - colour
         - colourista
         - commutative-semigroups
@@ -5529,7 +5530,6 @@ packages:
         - PSQueue < 0 # 1.1.1 bounds
         - Unique < 0 # 0.4.7.9 removed
         - cli < 0 # 0.2.0 removed
-        - co-log-core < 0 # 0.3.2.0 removed #5965/closed
         - co-log-polysemy < 0 # 0.0.1.3 removed #5965/closed
         - fingertree-psqueue < 0 # 0.3 compile fail
         - hastache < 0 # 0.6.1 bounds
@@ -6157,7 +6157,6 @@ packages:
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark ==0.5.* and the snapshot contains cmark-0.6
         - cmark-lucid < 0 # tried cmark-lucid-0.1.0.0, but its *library* requires the disabled package: cmark
         - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.17.0.0
-        - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires the disabled package: co-log-core
         - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
         - cointracking-imports < 0 # tried cointracking-imports-0.1.0.2, but its *library* requires the disabled package: xlsx
         - colonnade < 0 # tried colonnade-1.2.0.2, but its *library* requires semigroups >=0.18.2 && < 0.20 and the snapshot contains semigroups-0.20
@@ -6697,7 +6696,6 @@ packages:
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
-        - hie-bios < 0 # tried hie-bios-0.11.0, but its *library* requires the disabled package: co-log-core
         - hie-bios < 0 # tried hie-bios-0.11.0, but its *library* requires unix-compat >=0.5.1 && < 0.6 and the snapshot contains unix-compat-0.6
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.17.0.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
@@ -6992,8 +6990,6 @@ packages:
         - logging-effect < 0 # tried logging-effect-1.3.13, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - logging-effect < 0 # tried logging-effect-1.3.13, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.4.3
-        - lsp < 0 # tried lsp-1.6.0.0, but its *library* requires the disabled package: co-log-core
-        - lsp-test < 0 # tried lsp-test-0.14.1.0, but its *library* requires the disabled package: co-log-core
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.1.1.0
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.1.2.7
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.19.1


### PR DESCRIPTION
https://hackage.haskell.org/package/co-log-core-0.3.2.0 supports GHC 9.4. 
Cf. #6660.