### PR TITLE
Re-enable email-validate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6333,7 +6333,6 @@ packages:
         - elynx < 0 # tried elynx-0.7.0.1, but its *executable* requires the disabled package: tlynx
         - elynx-markov < 0 # tried elynx-markov-0.7.0.1, but its *library* requires the disabled package: statistics
         - elynx-tree < 0 # tried elynx-tree-0.7.0.1, but its *library* requires the disabled package: statistics
-        - email-validate < 0 # tried email-validate-2.3.2.16, but its *library* requires template-haskell >=2.10.0.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: typelits-witnesses
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
         - equal-files < 0 # tried equal-files-0.0.5.3, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

I havn't re-enabled the dependent packages since I don't know how to test them with the `verify-package` script.
