### PR TITLE
Add keyed-vals* packages to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4847,6 +4847,10 @@ packages:
     "Tim Emiola <tim.emiola@gmail.com> @adetokunbo":
         - benri-hspec
         - hspec-tmp-proc
+        - keyed-vals
+        - keyed-vals-hspec-tests
+        - keyed-vals-mem
+        - keyed-vals-redis
         - redis-glob
         - tmp-proc
         - tmp-proc-postgres


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

> I modified the script to build multiple packages