### PR TITLE
Remove freckle-app

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1179,7 +1179,6 @@ packages:
         - bcp47
         - bcp47-orphans
         - faktory
-        - freckle-app
         - graphula
         - hspec-expectations-json
         - hspec-junit-formatter
@@ -7928,9 +7927,6 @@ packages:
         - type-of-html-static < 0 # via type-of-html
         - drifter-sqlite < 0 # via sqlite-simple
 
-        # https://github.com/commercialhaskell/stackage/issues/6796
-        - freckle-app < 1.7.1
-
         # https://github.com/commercialhaskell/stackage/issues/6800
         - linear < 1.22
 
@@ -8611,7 +8607,6 @@ expected-test-failures:
     - eventstore # Event Store
     - faktory # connection refused, https://github.com/commercialhaskell/stackage/issues/5905
     - fb # Facebook app
-    - freckle-app # Memcachd
     - gdax # Needs environment variables set
     - ghc-imported-from # depends on haddocks being generated first https://github.com/fpco/stackage/pull/1315
     - ghc-mod # https://github.com/DanielG/ghc-mod/issues/611


### PR DESCRIPTION
This [not-quite-a-]library is not a good fit for Stackage, and not valuable for us to do the work to keep it in.