### PR TITLE
reinstate zenacy-html

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7883,7 +7883,6 @@ packages:
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.1
         - youtube < 0 # tried youtube-0.2.1.1, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
-        - zenacy-html < 0 # tried zenacy-html-2.0.4, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.12.2
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19.1


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
