### PR TITLE
Re-enable doctest-driver-gen

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6293,7 +6293,6 @@ packages:
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires text >=1.0.0 && < 2.0.0 and the snapshot contains text-2.0.1
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-12.0.0
         - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
-        - doctest-driver-gen < 0 # tried doctest-driver-gen-0.3.0.5, but its *library* requires base >=4.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - doctest-extract < 0 # tried doctest-extract-0.1, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
         - download < 0 # tried download-0.3.2.7, but its *library* requires the disabled package: feed
         - download-curl < 0 # tried download-curl-0.1.4, but its *library* requires the disabled package: feed


### PR DESCRIPTION
doctest-driver-gen-0.3.0.6 solve this problem.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
