### PR TITLE
Re-enable hie-bios (cf. #6784)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6685,7 +6685,6 @@ packages:
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.0.0
-        - hie-bios < 0 # tried hie-bios-0.11.0, but its *library* requires unix-compat >=0.5.1 && < 0.6 and the snapshot contains unix-compat-0.6
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.17.0.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
