### PR TITLE
Reinstated double-conversion and dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1840,9 +1840,9 @@ packages:
         - pipes-network-tls
         - safe-money
         - vector-bytes-instances
-        - xmlbf-xeno    
-        - xmlbf-xmlhtml 
-        - xmlbf         
+        - xmlbf-xeno
+        - xmlbf-xmlhtml
+        - xmlbf
 
     "Tomas Carnecky @wereHamster":
         - avers
@@ -7916,16 +7916,9 @@ packages:
         - resourcet < 1.3.0
 
         # https://github.com/commercialhaskell/stackage/issues/6761
-        - double-conversion < 0 # https://github.com/haskell/double-conversion/issues/34
-        - blaze-textual < 0
-        - reanimate-svg < 0
-        - type-of-html < 0
-        - sqlite-simple < 0 # via blaze-textual
         - path-formatting < 0 # requires old formatting
         - simple-media-timestamp-formatting < 0 # requires old formatting
         - srt-formatting < 0 # requires old formatting
-        - type-of-html-static < 0 # via type-of-html
-        - drifter-sqlite < 0 # via sqlite-simple
 
         # https://github.com/commercialhaskell/stackage/issues/6800
         - linear < 1.22
@@ -8052,9 +8045,6 @@ package-flags:
 
     sdl2:
       recent-ish: false
-
-    formatting:
-      no-double-conversion: true
 
 
 # end of package-flags


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
