### PR TITLE
Fix aws-sns-verify failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8053,6 +8053,9 @@ package-flags:
     formatting:
       no-double-conversion: true
 
+    aws-sns-verify:
+      development: true
+
 
 # end of package-flags
 
@@ -8809,7 +8812,6 @@ expected-test-failures:
     - xmlbf
     - yesod-gitrev # needs a git repo https://github.com/commercialhaskell/stackage/issues/6132
     - yesod-markdown # https://github.com/pbrisbin/yesod-markdown/issues/77
-    - aws-sns-verify # https://github.com/commercialhaskell/stackage/issues/6777
 
     # Assertion failures due to module name ambiguity.
     # These _should_ be fixed by using the `hide` section of this file


### PR DESCRIPTION
This package has a development flag that triggers some CPP to ensure local development can be handled correctly. Setting this flag should fix any build issues.

This addresses https://github.com/commercialhaskell/stackage/issues/6777

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
