### PR TITLE
Re-enable servant-openapi3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7472,7 +7472,6 @@ packages:
         - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires the disabled package: servant-docs
         - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires the disabled package: servant-foreign
         - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-multipart
-        - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.5, but its *library* requires Cabal >=1.24 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires lens >=4.9 && < 5 and the snapshot contains lens-5.2


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
