### PR TITLE
reenable exception-hierarchy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6346,7 +6346,6 @@ packages:
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-api
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
         - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
-        - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.7, but its *library* requires template-haskell >=2.18 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - fast-builder < 0 # tried fast-builder-0.1.3.0, but its *library* requires base >=4.8 && < 4.16 and the snapshot contains base-4.17.0.0
         - fasta < 0 # tried fasta-0.10.4.2, but its *library* requires the disabled package: pipes-text
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.17.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
