### PR TITLE
Stop maintaining the snap related packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4163,9 +4163,6 @@ packages:
         - pandoc-markdown-ghci-filter < 0 # 0.1.0.0 compile fail https://github.com/gdevanla/pandoc-markdown-ghci-filter/issues/3
 
     "Lucas David Traverso <lucas6246@gmail.com> @ludat":
-        - map-syntax
-        - heist
-        - snap
         - conferer
         - conferer-snap
         - conferer-warp
@@ -5471,6 +5468,9 @@ packages:
         - yesod-persistent
         - zlib
         - zlib-bindings
+        - map-syntax
+        - heist
+        - snap
 
     # If you stop maintaining a package (either just on stackage, or
     # completely), you can move it here. It will be disabled if it


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
