### PR TITLE
Remove upper bounds for hosc, #6802

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7843,9 +7843,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/6800
         - linear < 1.22
 
-        # https://github.com/commercialhaskell/stackage/issues/6802
-        - hosc < 0.20
-
         # https://github.com/commercialhaskell/stackage/issues/6808
         - nvim-hs < 2.3.2.0
 


### PR DESCRIPTION
hosc 0.20 now supported by tidal-1.9.3

Fixes #6802

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
