### PR TITLE
Remove upper version bounds on text-show-instances

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7851,9 +7851,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/6815
         - polysemy < 1.8
-
-        # https://github.com/commercialhaskell/stackage/issues/6822
-        - text-show-instances < 3.9.3
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
`text-show-instances-3.9.4` now allows building with `aeson-2.1.*`, which is the latest major release of `aeson` and the one that Stackage Nightly uses. As a result, there is no longer any need to constraint the upper version bounds on `text-show-instances` in `build-constraints.yaml`.

Fixes #6822.

-----

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
