### PR TITLE
Add hasql-interpolate

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2236,6 +2236,7 @@ packages:
         - aeson-better-errors
 
     "Mitchell Rosen <mitchellwrosen@gmail.com> @mitchellwrosen":
+        - hasql-interpolate
         - ki
         - ki-unlifted
         - tasty-hspec


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

I couldn't get the above script to work. `stack unpack` doesn't seem to grab the latest revision; how can I make it do that?
`hasql-interpolate-0.1.0.3` revision `1` is the latest version, and the one I'd like to get into Stackage.