### PR TITLE
Reinstated store-streaming

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7528,7 +7528,6 @@ packages:
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires free >=4.9 && < 5.1 and the snapshot contains free-5.1.10
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - stm-supply < 0 # tried stm-supply-0.2.0.0, but its *library* requires the disabled package: concurrent-supply
-        - store-streaming < 0 # tried store-streaming-0.2.0.3, but its *library* requires the disabled package: store-core
         - streaming-attoparsec < 0 # tried streaming-attoparsec-1.0.0.1, but its *library* requires the disabled package: streaming-bytestring
         - streaming-bytestring < 0 # tried streaming-bytestring-0.2.4, but its *library* requires ghc-prim >=0.4 && < 0.9 and the snapshot contains ghc-prim-0.9.0
         - streaming-cassava < 0 # tried streaming-cassava-0.2.0.0, but its *library* requires the disabled package: streaming-bytestring


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
