### PR TITLE
Reenable hackage-cli

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6546,8 +6546,6 @@ packages:
         - gtk3 < 0 # tried gtk3-0.15.7, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - gtk3 < 0 # tried gtk3-0.15.7, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.1
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
-        - hackage-cli < 0 # tried hackage-cli-0.0.3.6, but its *executable* requires Cabal >=3.4 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - hackage-cli < 0 # tried hackage-cli-0.0.3.6, but its *executable* requires base >=4.10.0.0 && < 4.17 and the snapshot contains base-4.17.0.0
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.19.1
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant-client >=0.9 && < 0.13 and the snapshot contains servant-client-0.19


### PR DESCRIPTION
Hackage now has hackage-cli-0.1.0.0 that works with GHC 9.4 and Cabal 3.8

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
