### PR TITLE
Add "deriving-trans", "monad-control-identity", wai-control

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -10,6 +10,11 @@ cabal-format-version: "3.0"
 # Constraints for brand new builds
 packages:
 
+    "Felix Springer <felixspringer149@gmail.com> @jumper149":
+        - deriving-trans
+        - monad-control-identity
+        - wai-control
+
     "Eric Schorn <eric.schorn@nccgroup.com> @eric-schorn":
         - pasta-curves
 


### PR DESCRIPTION
I maintain these packages and thought it would be a good idea to put them on stackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
