### PR TITLE
Remove TypeCompose, upper limit on spatial-math

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -310,11 +310,10 @@ packages:
     "Scott N. Walck <walck@lvc.edu> @walck":
         - cyclotomic
         - learn-physics
-        - TypeCompose
 
         # @ghorn
         - not-gloss
-        - spatial-math
+        - spatial-math < 0.3
 
     "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
         - siggy-chardust


### PR DESCRIPTION
Remove TypeCompose, which Conal Elliott is trying to deprecate.  Add upper bound to spatial-math so that it doesn't use TypeCompose.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
