### PR TITLE
Re-enable effectful-plugin

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4127,7 +4127,7 @@ packages:
     "Andrzej Rybczak <andrzej@rybczak.net> @arybczak":
         - effectful
         - effectful-core
-        - effectful-plugin < 0 # 1.0.0.0 buildable: False
+        - effectful-plugin
         - effectful-th
 
     "Stevan Andjelkovic <stevan.andjelkovic@here.com> @stevana":


### PR DESCRIPTION
Version 1.1.0.0 has support for GHC 9.4 (and upcoming 9.6).

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
