### PR TITLE
Enable cabal2spec build again. Version 2.6.4 supports Cabal-3.8.x.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6080,7 +6080,6 @@ packages:
         - ca-province-codes < 0 # tried ca-province-codes-1.0.0.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.1
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.3, but its *executable* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.1.0
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.3, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
-        - cabal2spec < 0 # tried cabal2spec-2.6.3, but its *library* requires Cabal ==3.6.* and the snapshot contains Cabal-3.8.1.0
         - cairo < 0 # tried cairo-0.13.8.2, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
         - cairo < 0 # tried cairo-0.13.8.2, but its *library* requires text >=1.0.0.0 && < 1.3 and the snapshot contains text-2.0.1
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.1.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
