### PR TITLE
Reenable Agda-2.6.3 after vector-hashtables has been added

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7789,9 +7789,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/6865
         - shelly < 1.11
 
-        # https://github.com/commercialhaskell/stackage/issues/6871
-        - Agda < 2.6.3
-
 # end of packages
 
 # Package flags are applied to individual packages, and override the values of


### PR DESCRIPTION
Closes #6871

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
