### PR TITLE
Reenable shelly-1.11 after c2hs revision

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7786,9 +7786,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/6857
         - deriving-trans < 0.6
 
-        # https://github.com/commercialhaskell/stackage/issues/6865
-        - shelly < 1.11
-
         # https://github.com/commercialhaskell/stackage/issues/6871
         - Agda < 2.6.3
 


### PR DESCRIPTION
`c2hs` now allows shelly-1.11, so the bound shelly < 1.11 can be dropped.

~~I wonder a bit why~~ stackage sees a dependency of `c2hs` on `shelly`.
- `shelly` is needed for the executable "regression-tests" but only if default-off flag `regression` is turned on
- `shelly` is needed for the testsuites ~~but tests are disabled~~ ; tests are only marked as "expected to fail"
https://github.com/commercialhaskell/stackage/blob/358abb4150175b39d6fd818172cf8066051fea8d/build-constraints.yaml#L8581

Closes #6865.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage 
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
