### PR TITLE
Claim grandfathered ansi-terminal and add ansi-terminal-types

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4956,6 +4956,10 @@ packages:
     "Eugen Wissner <belka@caraus.de> @belka-ew":
         - graphql
 
+    "Mike Pilgrem <public@pilgrem.com> @mpilgrem":
+        - ansi-terminal
+        - ansi-terminal-types
+
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean
@@ -4989,7 +4993,6 @@ packages:
         - aeson-optics
         - alsa-mixer
         - animalcase
-        - ansi-terminal
         - appar
         - arrows
         - asn1-encoding


### PR DESCRIPTION
I am the co-maintainer (with Roman Cheplyaka) of the ansi-terminal package, so I am moving it out of grandfathered dependencies. I am also adding new ansi-terminal-types.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
