### PR TITLE
relude: re-enable at 1.2.0.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7268,8 +7268,6 @@ packages:
         - relational-query-HDBC < 0 # tried relational-query-HDBC-0.7.2.0, but its *library* requires the disabled package: product-isomorphic
         - relational-record < 0 # tried relational-record-0.2.2.0, but its *library* requires the disabled package: product-isomorphic
         - relational-schemas < 0 # tried relational-schemas-0.1.8.0, but its *library* requires the disabled package: relational-query
-        - relude < 0 # tried relude-1.1.0.0, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
-        - relude < 0 # tried relude-1.1.0.0, but its *library* requires ghc-prim >=0.4.0.0 && < 0.9 and the snapshot contains ghc-prim-0.9.0
         - reorder-expression < 0 # tried reorder-expression-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.0.0
         - repa < 0 # tried repa-3.4.1.5, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.0.0
         - repa-algorithms < 0 # tried repa-algorithms-3.4.1.5, but its *library* requires the disabled package: repa
@@ -8339,7 +8337,6 @@ skipped-tests:
     - registry # tried registry-0.6.0.0, but its *test-suite* requires MonadRandom < 0.6 and the snapshot contains MonadRandom-0.6
     - registry # tried registry-0.6.0.0, but its *test-suite* requires tasty-discover < 4.3 and the snapshot contains tasty-discover-5.0.0
     - rel8 # tried rel8-1.4.1.0, but its *test-suite* requires hedgehog ^>=1.0 || ^>=1.1 and the snapshot contains hedgehog-1.2
-    - relude # tried relude-1.1.0.0, but its *test-suite* requires hedgehog >=1.0 && < 1.2 and the snapshot contains hedgehog-1.2
     - req-url-extra # tried req-url-extra-0.1.1.0, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.10.8
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-th
     - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.14.2


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
  - It's not compatible with `base-4.18.0.0`, which corresponds to GHC 9.6
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
