### PR TITLE
Move unix-compat to Mitchell Rosen

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -442,7 +442,6 @@ packages:
         - hedgehog
         - hedgehog-quickcheck
         - transformers-bifunctors
-        - unix-compat
 
     "Walter Schulze <awalterschulze@gmail.com> @awalterschulze":
         - katydid
@@ -2257,6 +2256,7 @@ packages:
         - termbox-tea
         - text-ansi
         - timer-wheel
+        - unix-compat
 
     "QBayLogic B.V. <devops@qbaylogic.com> @martijnbastiaan":
         - ghc-tcplugins-extra


### PR DESCRIPTION
Move `unix-compat` to Mitchell Rosen @mitchellwrosen who took over the package.

Mitchell, I think this would be in your sense.  If this is not in your intention, feel free to open another PR that makes me stackage maintainer of `unix-compat`.

Re:
- https://github.com/commercialhaskell/stackage/issues/6918
