### PR TITLE
Re-enable hoauth2 and yesod-auth-oauth2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6664,8 +6664,6 @@ packages:
         - hmm-lapack < 0 # tried hmm-lapack-0.5.0.1, but its *library* requires the disabled package: lapack
         - hnix-store-core < 0 # tried hnix-store-core-0.6.1.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
-        - hoauth2 < 0 # tried hoauth2-2.7.0, but its *library* requires memory ^>=0.17 and the snapshot contains memory-0.18.0
-        - hoauth2 < 0 # tried hoauth2-2.7.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires MissingH < =1.4.3.0 and the snapshot contains MissingH-1.6.0.0
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires parsec < =3.1.14.0 and the snapshot contains parsec-3.1.15.0
@@ -7732,7 +7730,6 @@ packages:
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-auth >=1.4.18 && < 1.5 and the snapshot contains yesod-auth-1.6.11
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.0
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-form >=1.4 && < 1.5 and the snapshot contains yesod-form-1.7.3
-        - yesod-auth-oauth2 < 0 # tried yesod-auth-oauth2-0.7.0.2, but its *library* requires the disabled package: hoauth2
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.0
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-form >=1.4.4.1 && < 1.5 and the snapshot contains yesod-form-1.7.3
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* requires yesod >=1.2 && < 1.5 and the snapshot contains yesod-1.6.2.1


### PR DESCRIPTION
[hoauth2-2.8.0][hoauth2] seems to have corrected the upper bounds on
memory and text that caused this package to be disabled. It was blocking
our package, yesod-auth-oauth2 which compiles fine with the following
stack.yaml:

```yaml
resolver: nightly-2023-04-05
extra-deps:
  - hoauth2-2.8.0
```

[hoauth2]: https://hackage.haskell.org/package/hoauth2-2.8.0

**Side-note**: how is a situation like this meant to be resolved? If I hadn't noticed and investigated, yesod-auth-oauth2 would've probably dropped out in the next LTS, which is a bigger deal to get corrected (I think). I try to stay on top of these things, but I can't keep track of what automation exists. For example, once hoauth2-2.8.0 came out, I (naively) thought some process would check to see if it worked now. I've also lost track of how/when maintainers are supposed to be notified. I searched and couldn't find any Issue on this or my repository about when this happened originally. I see [this one](https://github.com/commercialhaskell/stackage/issues/6486), but that says 2021-12-30 and we're still present in 2022-11-17, so I think it's unrelated. Is there any documentation I'm missing?