### PR TITLE
Re-enable with-utf8

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7703,8 +7703,6 @@ packages:
         - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.0.0
         - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - wire-streams < 0 # tried wire-streams-0.1.1.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.3.1
-        - with-utf8 < 0 # tried with-utf8-1.0.2.3, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
-        - with-utf8 < 0 # tried with-utf8-1.0.2.3, but its *library* requires text >=0.7 && < 1.3 and the snapshot contains text-2.0.1
         - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires bytestring >=0.10.2 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.6


### PR DESCRIPTION
Version 1.0.2.4 supports the latest `base` and `text` packages.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] ~If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)~ Not applicable
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
