### PR TITLE
reactivated lapack and hyper and depending packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6670,7 +6670,6 @@ packages:
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.1
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
-        - hmm-lapack < 0 # tried hmm-lapack-0.5.0.1, but its *library* requires the disabled package: lapack
         - hnix-store-core < 0 # tried hnix-store-core-0.6.1.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.1
         - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.3.1
@@ -6732,8 +6731,6 @@ packages:
         - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires text >=1.2.3.2 && < 2 and the snapshot contains text-2.0.1
         - hwk < 0 # tried hwk-0.6, but its *executable* requires the disabled package: hint
         - hxt-expat < 0 # tried hxt-expat-9.1.1, but its *library* requires the disabled package: hexpat
-        - hyper < 0 # tried hyper-0.2.1.1, but its *library* requires base >=4.5 && < 4.16 and the snapshot contains base-4.17.0.0
-        - hyper < 0 # tried hyper-0.2.1.1, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - hyraxAbif < 0 # tried hyraxAbif-0.2.4.2, but its *library* requires text >=1.2.4 && < 1.3 and the snapshot contains text-2.0.1
         - iconv < 0 # tried iconv-0.4.1.3, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.8.1.0
@@ -6864,8 +6861,6 @@ packages:
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant >=0.9 && < 0.18 and the snapshot contains servant-0.19.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant-client >=0.9 && < 0.18 and the snapshot contains servant-client-0.19
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
-        - lapack < 0 # tried lapack-0.5.0.2, but its *library* requires the disabled package: hyper
-        - lapack-hmatrix < 0 # tried lapack-hmatrix-0.0.0.2, but its *library* requires the disabled package: lapack
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires the disabled package: utf8-light
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens ==4.* and the snapshot contains lens-5.2
@@ -6891,7 +6886,6 @@ packages:
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.17.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2
         - linear-base < 0 # tried linear-base-0.3.0, but its *library* requires the disabled package: linear-generics
-        - linear-circuit < 0 # tried linear-circuit-0.1.0.4, but its *library* requires the disabled package: lapack
         - linear-generics < 0 # tried linear-generics-0.2, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.6
@@ -6920,7 +6914,6 @@ packages:
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: monad-metrics
-        - magico < 0 # tried magico-0.0.2.3, but its *executable* requires the disabled package: lapack
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.1
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.3.0
@@ -7262,7 +7255,6 @@ packages:
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires req >=2.0.0 && < 2.1.0 and the snapshot contains req-3.13.0
         - require < 0 # tried require-0.4.11, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.3.1
         - require < 0 # tried require-0.4.11, but its *library* requires text >=1.2.3.0 && < 2 and the snapshot contains text-2.0.1
-        - resistor-cube < 0 # tried resistor-cube-0.0.1.4, but its *executable* requires the disabled package: lapack
         - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* requires base < 4.15 and the snapshot contains base-4.17.0.0
         - rhine < 0 # tried rhine-0.8.1, but its *library* requires base >=4.13 && < 4.17 and the snapshot contains base-4.17.0.0
         - rhine-gloss < 0 # tried rhine-gloss-0.8.1, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
