### PR TITLE
Re-enable proto-lens-optparse

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7192,7 +7192,6 @@ packages:
         - prometheus < 0 # tried prometheus-2.2.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.1
         - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
-        - proto-lens-optparse < 0 # tried proto-lens-optparse-0.1.1.9, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.1.2, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
         - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.4.4
         - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.0.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

Verified using

    ./verify-package proto-lens-optparse-0.1.1.10
