### PR TITLE
Re-enable arithmoi, cyclotomic, integer-roots and quadratic-irrational

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5978,7 +5978,6 @@ packages:
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires optparse-applicative >=0.14 && < 0.16 and the snapshot contains optparse-applicative-0.17.0.0
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
         - arbtt < 0 # tried arbtt-0.12.0.1, but its *executable* requires the disabled package: bytestring-progress
-        - arithmoi < 0 # tried arithmoi-0.12.0.2, but its *library* requires the disabled package: integer-roots
         - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires haskell-src-exts >=1.22.0 && < 1.23 and the snapshot contains haskell-src-exts-1.23.1
         - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires template-haskell >=2.14.0 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.1
@@ -6213,7 +6212,6 @@ packages:
         - currencies < 0 # tried currencies-0.2.0.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - cusolver < 0 # tried cusolver-0.3.0.0, but its *library* requires the disabled package: cuda
         - cusparse < 0 # tried cusparse-0.3.0.0, but its *library* requires the disabled package: cuda
-        - cyclotomic < 0 # tried cyclotomic-1.1.1, but its *library* requires the disabled package: arithmoi
         - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.0.0
         - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires template-haskell >=2.9 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.8.1.0
@@ -6764,7 +6762,6 @@ packages:
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
         - inliterate < 0 # tried inliterate-0.1.0, but its *library* requires the disabled package: cheapskate
         - int-cast < 0 # tried int-cast-0.2.0.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.0.0
-        - integer-roots < 0 # tried integer-roots-1.0.2.0, but its *library* requires ghc-bignum < 1.3 and the snapshot contains ghc-bignum-1.3
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires template-haskell >=2.14.0.0 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.1
@@ -7208,7 +7205,6 @@ packages:
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128
         - qrcode-core < 0 # tried qrcode-core-0.9.5, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
         - qrcode-juicypixels < 0 # tried qrcode-juicypixels-0.8.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.1
-        - quadratic-irrational < 0 # tried quadratic-irrational-0.1.1, but its *library* requires the disabled package: integer-roots
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-0.11.4
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires the disabled package: ginger
@@ -9123,9 +9119,6 @@ github-users:
         - klappvisor
     fpinsight:
         - thierry-b
-    arithmoi:
-        - Bodigrim
-        - cartazio
     IxpertaSolutions:
         - Siprj
         - liskin


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
