### PR TITLE
Restore linear-generics and its codependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4821,7 +4821,7 @@ packages:
 
     "Arnaud Spiwack <arnaud.spiwack@tweag.io> @aspiwack":
         - linear-base
-        - linear-generics
+        - linear-generics < 0.2.2 # 0.2.2 depends on th-abstraction 5.0.0. See https://github.com/commercialhaskell/stackage/issues/6897
 
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":
         - reactive-banana
@@ -6884,8 +6884,6 @@ packages:
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.8.1.0
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.17.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2
-        - linear-base < 0 # tried linear-base-0.3.0, but its *library* requires the disabled package: linear-generics
-        - linear-generics < 0 # tried linear-generics-0.2, but its *library* requires template-haskell >=2.16 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.1
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.6
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.3.0
@@ -7065,8 +7063,6 @@ packages:
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires bytestring >=0.10.10.1 && < 0.11 and the snapshot contains bytestring-0.11.3.1
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires template-haskell >=2.16.0.0 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires text >=1.2.4.0 && < 1.3 and the snapshot contains text-2.0.1
-        - one-liner < 0 # tried one-liner-2.1, but its *library* requires the disabled package: linear-base
-        - one-liner-instances < 0 # tried one-liner-instances-0.1.3.0, but its *library* requires the disabled package: one-liner
         - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.17.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.8.1.0
@@ -8217,7 +8213,6 @@ skipped-tests:
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires integer-gmp >=1.0.2 && < 1.1 and the snapshot contains integer-gmp-1.1
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires semirings >=0.5 && < 0.6 and the snapshot contains semirings-0.6
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires tasty >=1.2 && < 1.3 and the snapshot contains tasty-1.4.3
-    - generic-data # tried generic-data-1.0.0.0, but its *test-suite* requires the disabled package: one-liner
     - generic-xmlpickler # tried generic-xmlpickler-0.1.0.6, but its *test-suite* requires tasty >=0.10 && < 1.3 and the snapshot contains tasty-1.4.3
     - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec >=2.4.4 && < 2.10 and the snapshot contains hspec-2.10.8
     - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.10 and the snapshot contains hspec-discover-2.10.8


### PR DESCRIPTION
They were disabled in nightly because of now-solved bound issues.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
