### PR TITLE
Reinstated streaming-bytestring and some dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5772,7 +5772,6 @@ packages:
     "Library and exe bounds failures":
         - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
-        - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: streaming-bytestring
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.2.7
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: Taxonomy
         - BiobaseNewick < 0 # tried BiobaseNewick-0.0.0.2, but its *library* requires ForestStructures ==0.0.0.* and the snapshot contains ForestStructures-0.0.1.0
@@ -5784,7 +5783,6 @@ packages:
         - Chart < 0 # tried Chart-1.9.4, but its *library* requires lens >=3.9 && < 5.2 and the snapshot contains lens-5.2
         - Chart-cairo < 0 # tried Chart-cairo-1.9.3, but its *library* requires lens >=3.9 && < 5.2 and the snapshot contains lens-5.2
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.4, but its *library* requires lens >=3.9 && < 5.2 and the snapshot contains lens-5.2
-        - DPutils < 0 # tried DPutils-0.1.1.0, but its *library* requires the disabled package: streaming-bytestring
         - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
         - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.17.0.0
         - Frames < 0 # tried Frames-0.7.3, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.0.0
@@ -7450,8 +7448,6 @@ packages:
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires free >=4.9 && < 5.1 and the snapshot contains free-5.1.10
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.1
         - stm-supply < 0 # tried stm-supply-0.2.0.0, but its *library* requires the disabled package: concurrent-supply
-        - streaming-attoparsec < 0 # tried streaming-attoparsec-1.0.0.1, but its *library* requires the disabled package: streaming-bytestring
-        - streaming-bytestring < 0 # tried streaming-bytestring-0.2.4, but its *library* requires ghc-prim >=0.4 && < 0.9 and the snapshot contains ghc-prim-0.9.0
         - streaming-cassava < 0 # tried streaming-cassava-0.2.0.0, but its *library* requires the disabled package: streaming-bytestring
         - streamly-bytestring < 0 # tried streamly-bytestring-0.1.4, but its *library* requires streamly ==0.8.1.* || ==0.8.2.* and the snapshot contains streamly-0.8.3
         - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.17.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
