### PR TITLE
primitive-0.8, disable vector-sized, etc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6242,6 +6242,7 @@ packages:
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.8.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
+        - discrimination < 0 # tried discrimination-0.5, but its *library* requires primitive >=0.7.1.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires hashable >=1.2.0.5 && < 1.3 and the snapshot contains hashable-1.4.2.0
@@ -6723,6 +6724,7 @@ packages:
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.4.5
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
+        - inline-r < 0 # tried inline-r-1.0.0, but its *library* requires primitive >=0.5 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - inliterate < 0 # tried inliterate-0.1.0, but its *library* requires the disabled package: cheapskate
         - int-cast < 0 # tried int-cast-0.2.0.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -7027,6 +7029,7 @@ packages:
         - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires bytestring >=0.10 && < 0.11.4 and the snapshot contains bytestring-0.11.4.0
         - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires memory >=0.16 && < 0.18 and the snapshot contains memory-0.18.0
         - path-formatting < 0 # tried path-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - pcg-random < 0 # tried pcg-random-0.1.3.7, but its *library* requires primitive >=0.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.8
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires hashtables ==1.0.* and the snapshot contains hashtables-1.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires monad-control ==0.3.* and the snapshot contains monad-control-1.0.3.1
@@ -7070,6 +7073,7 @@ packages:
         - pipes-category < 0 # tried pipes-category-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
         - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
         - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: pipes-network
+        - pipes-safe < 0 # tried pipes-safe-2.3.4, but its *library* requires primitive >=0.7.0.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: cairo
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
@@ -7131,6 +7135,7 @@ packages:
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.0.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires bytestring >=0.10.0.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128
+        - qrcode-core < 0 # tried qrcode-core-0.9.7, but its *library* requires primitive >=0.6.1.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-0.11.5
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires the disabled package: ginger
@@ -7509,6 +7514,7 @@ packages:
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires template-haskell >=2.12 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.17.1.0
+        - vector-sized < 0 # tried vector-sized-1.5.0, but its *library* requires primitive >=0.5 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires the disabled package: protocol-buffers
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires aeson >=1.2 && < 2.0 and the snapshot contains aeson-2.1.2.1
@@ -7653,9 +7659,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/6883
         - pandoc < 3.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6887
-        - primitive < 0.8
 
         # https://github.com/commercialhaskell/stackage/issues/6897
         - th-abstraction < 0.5.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7073,7 +7073,6 @@ packages:
         - pipes-category < 0 # tried pipes-category-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
         - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
         - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: pipes-network
-        - pipes-safe < 0 # tried pipes-safe-2.3.4, but its *library* requires primitive >=0.7.0.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: cairo
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5788,6 +5788,7 @@ packages:
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.22
         - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
+        - H < 0 # tried H-1.0.0, but its *executable* requires the disabled package: inline-r
         - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires base >=4.11.0 && < 4.17 and the snapshot contains base-4.17.1.0
         - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - Hoed < 0 # tried Hoed-0.5.1, but its *library* requires the disabled package: regex-tdfa-text
@@ -6020,6 +6021,8 @@ packages:
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.4.0
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.2
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - beam-core < 0 # tried beam-core-0.10.0.0, but its *library* requires the disabled package: vector-sized
+        - beam-migrate < 0 # tried beam-migrate-0.5.2.0, but its *library* requires the disabled package: beam-core
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires beam-core >=0.8 && < 0.9 and the snapshot contains beam-core-0.10.0.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -6027,6 +6030,8 @@ packages:
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mysql >=0.1 && < 0.2 and the snapshot contains mysql-0.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.0, but its *library* requires the disabled package: beam-core
+        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires the disabled package: beam-core
         - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
         - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.17.1.0
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
@@ -6317,6 +6322,8 @@ packages:
         - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.17.1.0
         - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
         - forma < 0 # tried forma-1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
+        - fortran-src < 0 # tried fortran-src-0.13.0, but its *library* requires the disabled package: vector-sized
+        - fortran-src-extras < 0 # tried fortran-src-extras-0.4.1, but its *library* requires the disabled package: fortran-src
         - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
         - friday < 0 # tried friday-0.2.3.1, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
         - friday-juicypixels < 0 # tried friday-juicypixels-0.1.2.4, but its *library* requires the disabled package: friday
@@ -6636,6 +6643,7 @@ packages:
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
+        - hmatrix-vector-sized < 0 # tried hmatrix-vector-sized-0.1.3.0, but its *library* requires the disabled package: vector-sized
         - hnix-store-core < 0 # tried hnix-store-core-0.6.1.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.2
         - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -7078,6 +7086,7 @@ packages:
         - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.17.1.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires haskell-src-exts-simple >=1.18 && < 1.21 || ^>=1.21 and the snapshot contains haskell-src-exts-simple-1.23.0.0
+        - poly < 0 # tried poly-0.5.1.0, but its *library* requires the disabled package: vector-sized
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires aeson >=1.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.0
@@ -7135,6 +7144,7 @@ packages:
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires bytestring >=0.10.0.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128
         - qrcode-core < 0 # tried qrcode-core-0.9.7, but its *library* requires primitive >=0.6.1.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - qrcode-juicypixels < 0 # tried qrcode-juicypixels-0.8.5, but its *library* requires the disabled package: qrcode-core
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-0.11.5
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires the disabled package: ginger
@@ -7151,6 +7161,7 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.2.2
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - random-bytestring < 0 # tried random-bytestring-0.1.4, but its *library* requires the disabled package: pcg-random
         - random-source < 0 # tried random-source-0.3.0.12, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.17.1.0
         - rank2classes < 0 # tried rank2classes-1.5.1, but its *library* requires the disabled package: data-functor-logistic
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.1.2.1
@@ -7197,6 +7208,7 @@ packages:
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires resource-pool ==0.2.* and the snapshot contains resource-pool-0.4.0.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires time >=1.4.2 && < 1.10 and the snapshot contains time-1.12.2
+        - roc-id < 0 # tried roc-id-0.2.0.0, but its *library* requires the disabled package: vector-sized
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.13.1
@@ -7389,6 +7401,7 @@ packages:
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable ==1.3.* and the snapshot contains hashable-1.4.2.0
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - strongweak < 0 # tried strongweak-0.4.1, but its *library* requires the disabled package: vector-sized
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
         - sv < 0 # tried sv-1.4.0.1, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
@@ -8053,6 +8066,8 @@ skipped-tests:
     - asif # tried asif-6.0.4, but its *test-suite* requires doctest >=0.16.2 && < 0.17 and the snapshot contains doctest-0.20.1
     - barrier # tried barrier-0.1.1, but its *test-suite* requires lens-family-core >=1.2 && < 1.3 and the snapshot contains lens-family-core-2.1.2
     - barrier # tried barrier-0.1.1, but its *test-suite* requires tasty >=0.10 && < 0.12 and the snapshot contains tasty-1.4.3
+    - base16 # tried base16-0.3.2.1, but its *test-suite* requires the disabled package: random-bytestring
+    - base64 # tried base64-0.4.2.4, but its *test-suite* requires the disabled package: random-bytestring
     - bloodhound # tried bloodhound-0.21.0.0, but its *test-suite* requires the disabled package: quickcheck-properties
     - boolean-normal-forms # tried boolean-normal-forms-0.0.1.1, but its *test-suite* requires QuickCheck >=2.10 && < 2.14 and the snapshot contains QuickCheck-2.14.2
     - brittany # tried brittany-0.14.0.2, but its *test-suite* requires hspec ^>=2.8.3 and the snapshot contains hspec-2.10.10
@@ -8874,6 +8889,8 @@ skipped-benchmarks:
     - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires accelerate-llvm-native >=1.1 && < 1.2 and the snapshot contains accelerate-llvm-native-1.3.0.0
     - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires criterion >=1.0 && < 1.5 and the snapshot contains criterion-1.6.0.0
     - avers # tried avers-0.0.17.1, but its *benchmarks* requires criterion >=1.1.4.0 && < 1.6 and the snapshot contains criterion-1.6.0.0
+    - base16 # tried base16-0.3.2.1, but its *benchmarks* requires the disabled package: random-bytestring
+    - base64 # tried base64-0.4.2.4, but its *benchmarks* requires the disabled package: random-bytestring
     - binary-parsers # tried binary-parsers-0.2.4.0, but its *benchmarks* requires criterion ==1.1.* and the snapshot contains criterion-1.6.0.0
     - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: json-builder
     - cborg-json # tried cborg-json-0.2.5.0, but its *benchmarks* requires criterion >=1.0 && < 1.6 and the snapshot contains criterion-1.6.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6247,7 +6247,6 @@ packages:
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.8.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
-        - discrimination < 0 # tried discrimination-0.5, but its *library* requires primitive >=0.7.1.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires hashable >=1.2.0.5 && < 1.3 and the snapshot contains hashable-1.4.2.0


### PR DESCRIPTION
I generated this using the `commenter`. Primitive-0.8 has been out for a while now, so I think it is ok to disable these.

See #6887

Beam seems unmaintained, judging by e.g. https://github.com/haskell-beam/beam/issues/665#issuecomment-1500617330 It would also be broken by upgrading either of these, so might as well get it over with now:
* https://github.com/commercialhaskell/stackage/issues/6624
* https://github.com/commercialhaskell/stackage/issues/6912