### PR TITLE
Re-enable hsinstall, closes #6763

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3554,7 +3554,7 @@ packages:
 
     "Dino Morelli <dino@ui3.info> @dino-":
         - epub-metadata
-        - hsinstall < 0 # 2.7 https://github.com/commercialhaskell/stackage/issues/6763
+        - hsinstall
         - tce-conf
 
     "Jonathan Fischoff <jonathangfischoff@gmail.com> @jfischoff":


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
