### PR TITLE
vector-0.13, disable dawg-ord, lrucaching

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6148,6 +6148,7 @@ packages:
         - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.17.1.0
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - compactmap < 0 # tried compactmap-0.1.4.2.1, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.0.0
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires aeson >=1.1.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires lens >=4.15.4 && < 5.2 and the snapshot contains lens-5.2.2
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
@@ -6218,6 +6219,7 @@ packages:
         - data-default-instances-text < 0 # tried data-default-instances-text-0.0.1, but its *library* requires text >=0.2 && < 2 and the snapshot contains text-2.0.2
         - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
         - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming-cassava
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
         - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
         - dependent-sum-template < 0 # tried dependent-sum-template-0.1.1.1, but its *library* requires the disabled package: th-extras
@@ -6862,6 +6864,7 @@ packages:
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires text ^>=1.2.2.0 and the snapshot contains text-2.0.2
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires universum ^>=1.6.0 and the snapshot contains universum-1.8.1.1
         - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.4.5
+        - lrucaching < 0 # tried lrucaching-0.3.3, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.1.2.1
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.1.2.8
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.19.1
@@ -7123,6 +7126,7 @@ packages:
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.7
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires lens >=4.10 && < 4.16 and the snapshot contains lens-5.2.2
+        - profiteur < 0 # tried profiteur-0.4.6.1, but its *executable* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - prometheus < 0 # tried prometheus-2.2.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
         - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
@@ -7368,6 +7372,7 @@ packages:
         - stack < 0 # tried stack-2.9.3, but its *library* requires persistent >=2.13.3.5 && < 2.14 and the snapshot contains persistent-2.14.5.0
         - stack < 0 # tried stack-2.9.3, but its *library* requires unix-compat < 0.7 and the snapshot contains unix-compat-0.7
         - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires base >=4.12.0.0 && < 4.16 and the snapshot contains base-4.17.1.0
+        - stb-image-redux < 0 # tried stb-image-redux-0.2.1.2, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.0.0
         - stm-supply < 0 # tried stm-supply-0.2.0.0, but its *library* requires the disabled package: concurrent-supply
         - streaming-cassava < 0 # tried streaming-cassava-0.2.0.0, but its *library* requires streaming-bytestring ==0.2.* and the snapshot contains streaming-bytestring-0.3.0
         - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.17.1.0
@@ -7430,6 +7435,7 @@ packages:
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.2.8
         - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: telegram-bot-api
         - template < 0 # tried template-0.2.0.10, but its *library* requires text >=0.7.2 && < 1.3 and the snapshot contains text-2.0.2
+        - tensors < 0 # tried tensors-0.1.5, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
         - termbox-banana < 0 # tried termbox-banana-1.0.0, but its *library* requires the disabled package: reactive-banana
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
@@ -7649,10 +7655,6 @@ packages:
     # End of Library and exe bounds failures
 
     "Stackage upper bounds":
-        # https://github.com/commercialhaskell/stackage/issues/6624
-        - vector < 0.13
-        - JuicyPixels < 3.3.8
-
         # https://github.com/commercialhaskell/stackage/issues/6744
         - resourcet < 1.3.0
 


### PR DESCRIPTION
See #6624.

All of the packages that needed disabling seem to have a low count of reverse dependencies, and their reverse dependencies are not in Stackage.

@juhp [mentioned that cassava-megaparsec was the blocker](https://github.com/commercialhaskell/stackage/issues/6624#issuecomment-1365948950).

Since that is no longer blocking, I presume this means that there are no blockers left?

vector-0.13 was released last summer, so I think it should be mature enough now.

Since the new LTS would be supported for some time, it would be nice to use a
series that is still receiving upstream updates. The vector-0.12 series last
got an upload in 2021.
