### PR TITLE
Re-activate reactive-banana and termbox-banana

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4825,7 +4825,7 @@ packages:
         - linear-generics < 0.2.2 # 0.2.2 depends on th-abstraction 5.0.0. See https://github.com/commercialhaskell/stackage/issues/6897
 
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":
-        - reactive-banana < 0 # 1.3.2.0 not compatible with these-1.2 https://github.com/HeinrichApfelmus/reactive-banana/issues/285
+        - reactive-banana
         - rel8
         - logging-effect
 
@@ -7436,7 +7436,6 @@ packages:
         - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: telegram-bot-api
         - template < 0 # tried template-0.2.0.10, but its *library* requires text >=0.7.2 && < 1.3 and the snapshot contains text-2.0.2
         - tensors < 0 # tried tensors-0.1.5, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - termbox-banana < 0 # tried termbox-banana-1.0.0, but its *library* requires the disabled package: reactive-banana
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)


Verified using

```
./verify-package reactive-banana-1.3.2.0@rev:1
```

and using `./etc/check.sh`
