### PR TITLE
Re-enable tensors

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7435,7 +7435,6 @@ packages:
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.2.8
         - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: telegram-bot-api
         - template < 0 # tried template-0.2.0.10, but its *library* requires text >=0.7.2 && < 1.3 and the snapshot contains text-2.0.2
-        - tensors < 0 # tried tensors-0.1.5, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract


### PR DESCRIPTION
It was [recently revised](https://hackage.haskell.org/package/tensors-0.1.5/revisions/)