### PR TITLE
Fix #6989, take over alex and happy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -12,7 +12,7 @@ packages:
 
     "Dominick Samperi <djsamperi@gmail.com> @djsamperi":
         - mathlist
-        
+
     "Alexey Tochin <Alexey.Tochin@gmail.com> @alexeytochin":
         - simple-expr
         - inf-backprop
@@ -89,6 +89,8 @@ packages:
         - java-adt
         - Sit
 
+        - alex > 3.2.7
+        - happy < 1.20.1 || > 1.21.0
         - haskell-src
         - ListLike
         - MissingH
@@ -824,7 +826,6 @@ packages:
         - cryptonite-conduit
         - streaming-commons
 
-        - alex > 3.2.7 && < 3.3.0.0     # https://github.com/commercialhaskell/stackage/issues/6989
         - async
         - base16-bytestring
         - csv-conduit
@@ -833,7 +834,6 @@ packages:
         - foreign-store
         - formatting
         - gtk2hs-buildtools
-        - happy < 1.20.1 || > 1.21.0
         - hybrid-vectors
         - indents
         - language-c


### PR DESCRIPTION
Fixes #6989: The blocker (microaeson) for alex-3.3.0.0 has been resolved by revision.

Taking over alex and happy which I am co-maintaining.

