### PR TITLE
upgrade to ghc-9.6 and refresh bounds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -617,7 +617,7 @@ packages:
         - resistor-cube
         - linear-circuit
         # Not a maintainer
-        - cabal-plan < 0 # 0.7.3.0, which is the release compatible with semialign-1.3, requires base-compat-0.13 which we don't have yet, see #6906
+        - cabal-plan
         - topograph
         - ix-shapable
         - hsshellscript < 0 # 3.5.0 compile fail https://github.com/commercialhaskell/stackage/issues/6762
@@ -675,7 +675,7 @@ packages:
         - test-fun
 
     "Solomon Bothwell <ssbothwell@gmail.com> @solomon-b":
-        - monoidal-functors < 0 # 0.2.1.0 not compatible with semialign-1.3 https://github.com/solomon-b/monoidal-functors/issues/29
+        - monoidal-functors
 
     "Tobias Dammers <tdammers@gmail.com> @tdammers":
         - ginger
@@ -1316,7 +1316,7 @@ packages:
         - sorted-list
 
     "Gabriella Gonzalez <GenuineGabriella@gmail.com> @Gabriella439":
-        - optparse-generic < 1.5.0 # https://github.com/commercialhaskell/stackage/issues/6968
+        - optparse-generic
         - pipes
         - pipes-extras
         - pipes-http
@@ -2159,7 +2159,7 @@ packages:
         - text-manipulate
 
     "Nick Partridge <nkpart@gmail.com> @nkpart":
-        - cabal-file-th < 0 # 0.2.7 compile fail https://github.com/nkpart/cabal-file-th/issues/13
+        - cabal-file-th
 
     "Gershom Bazerman <gershomb@gmail.com> @gbaz":
         - jmacro
@@ -2381,7 +2381,7 @@ packages:
         - configurator-export
         - decidable
         - emd
-        - functor-products < 0 # 0.1.1.0 compilation failure https://github.com/mstksg/functor-products/issues/1
+        - functor-products
         - hamilton
         - hmatrix-backprop
         - hmatrix-vector-sized
@@ -2561,7 +2561,7 @@ packages:
         # Test suite needs a running neo4j server with auth disabled
         # unfortunately the cabal package name and the github repo don't have the exact same name
         # package name is haskell-neo4j-client github name is haskell-neo4j-rest-client
-        - haskell-neo4j-client < 0 # 0.3.2.4 compile fail with GHC 8.4 https://github.com/asilvestre/haskell-neo4j-rest-client/issues/32
+        - haskell-neo4j-client
 
     "Anton Kholomiov <anton.kholomiov@gmail.com>":
         - data-fix
@@ -2583,7 +2583,7 @@ packages:
         - chaselev-deque
         - code-page
         - constraint-tuples
-        - criterion  < 1.6.2.0 # https://github.com/commercialhaskell/stackage/issues/6986
+        - criterion
         - criterion-measurement
         - data-reify
         - deriving-compat
@@ -2745,7 +2745,7 @@ packages:
     "Jonas Carpay <jonascarpay@gmail.com> @jonascarpay":
         - apecs
         - apecs-gloss
-        - apecs-physics < 0 # 0.4.5 compile fail https://github.com/jonascarpay/apecs/issues/95
+        - apecs-physics
         - aeson-commit
         - calligraphy
         - js-chart
@@ -3239,7 +3239,7 @@ packages:
         - irc-dcc
 
     "Alexey Raga <alexey.raga@gmail.com> @AlexeyRaga":
-        - hw-kafka-client < 4.0.4 # https://github.com/commercialhaskell/stackage/issues/6388
+        - hw-kafka-client
 
     "John Ky newhoggy@gmail.com @newhoggy":
         - aeson-lens
@@ -4349,7 +4349,7 @@ packages:
 
     "Sergey Vinokurov <serg.foo@gmail.com> @sergv":
         - bencoding
-        - emacs-module < 0.2 # 0.2 (presumably) needs GHC 9.6 https://github.com/commercialhaskell/stackage/issues/6971
+        - emacs-module
         - tasty-ant-xml
         - prettyprinter-combinators
         - htoml-parse
@@ -4439,7 +4439,7 @@ packages:
         - natural-sort
 
     "John Biesnecker <jbiesnecker@gmail.com> @biesnecker":
-        - async-pool < 0 # 0.9.1 compile fail https://github.com/jwiegley/async-pool/issues/28
+        - async-pool
 
     "Zoltan Kelemen <kelemzol@elte.hu> @kelemzol":
         - fswatch
@@ -4542,7 +4542,7 @@ packages:
         - smallcheck-series
 
     "Taisuke Hikawa <23.prime.37@gmail.com> @23prime":
-        - oeis2 < 0 # 1.0.7 compile fail https://github.com/commercialhaskell/stackage/issues/6498
+        - oeis2
 
     "David Himmelstrup <lemmih@gmail.com> @lemmih":
         - chiphunk
@@ -4848,7 +4848,7 @@ packages:
 
     "Arnaud Spiwack <arnaud.spiwack@tweag.io> @aspiwack":
         - linear-base
-        - linear-generics < 0.2.2 # 0.2.2 depends on th-abstraction 5.0.0. See https://github.com/commercialhaskell/stackage/issues/6897
+        - linear-generics
 
     "Ollie Charles <ollie@ocharles.org.up> @ocharles":
         - reactive-banana
@@ -4922,7 +4922,7 @@ packages:
         - wai-middleware-delegate
 
     "Francisco Vallarino <fjvallarino@gmail.com> @fjvallarino":
-        - monomer < 0
+        - monomer
         - nanovg
 
     "Ghais Issa <0x47@0x49.dev> @ghais":
@@ -6055,7 +6055,9 @@ packages:
         - antiope-sqs < 0 # tried antiope-sqs-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-sqs < 0 # tried antiope-sqs-7.5.3, but its *library* requires the disabled package: amazonka-core
         - apecs < 0 # tried apecs-0.9.5, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - apecs-gloss < 0 # tried apecs-gloss-0.2.4, but its *library* requires the disabled package: apecs-physics
+        - apecs-gloss < 0 # tried apecs-gloss-0.2.4, but its *library* requires the disabled package: apecs
+        - apecs-physics < 0 # tried apecs-physics-0.4.5, but its *library* requires the disabled package: apecs
+        - apecs-physics < 0 # tried apecs-physics-0.4.5, but its *library* requires the disabled package: inline-c
         - api-maker < 0 # tried api-maker-0.1.0.6, but its *library* requires the disabled package: req
         - app-settings < 0 # tried app-settings-0.2.0.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -6237,7 +6239,8 @@ packages:
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires base >=4.3 && < 4.16 and the snapshot contains base-4.18.0.0
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
-        - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires the disabled package: cabal-plan
+        - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *executable* requires ansi-terminal ^>=0.11 and the snapshot contains ansi-terminal-1.0
+        - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *executable* requires optparse-applicative ^>=0.17.0.0 and the snapshot contains optparse-applicative-0.18.1.0
         - cabal2nix < 0 # tried cabal2nix-2.19.1, but its *executable* requires the disabled package: monad-par
         - cache < 0 # tried cache-0.1.3.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - capability < 0 # tried capability-0.5.0.1, but its *library* requires the disabled package: streaming
@@ -6327,7 +6330,6 @@ packages:
         - cmark < 0 # tried cmark-0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark ==0.5.* and the snapshot contains cmark-0.6
         - cmark-lucid < 0 # tried cmark-lucid-0.1.0.0, but its *library* requires the disabled package: cmark
-        - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires base >=4.10.1.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
         - cointracking-imports < 0 # tried cointracking-imports-0.1.0.2, but its *library* requires the disabled package: xlsx
         - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
@@ -6392,7 +6394,7 @@ packages:
         - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.7
         - country < 0 # tried country-0.2.3.1, but its *library* requires the disabled package: bytebuild
         - covariance < 0 # tried covariance-0.2.0.1, but its *library* requires the disabled package: statistics
-        - criterion < 0 # tried criterion-1.6.1.0, but its *library* requires the disabled package: statistics
+        - criterion < 0 # tried criterion-1.6.2.0, but its *library* requires the disabled package: statistics
         - crypt-sha512 < 0 # tried crypt-sha512-0, but its *library* requires the disabled package: cryptohash-sha512
         - crypto-api-tests < 0 # tried crypto-api-tests-0.3, but its *library* requires the disabled package: test-framework
         - crypto-cipher-tests < 0 # tried crypto-cipher-tests-0.0.11, but its *library* requires the disabled package: test-framework
@@ -6452,7 +6454,6 @@ packages:
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
         - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - dejafu < 0 # tried dejafu-2.4.0.4, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dense-linear-algebra < 0 # tried dense-linear-algebra-0.1.0.0, but its *library* requires the disabled package: vector-binary-instances
@@ -6469,6 +6470,7 @@ packages:
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires lsp >=1.2.0.0 && < 1.5 and the snapshot contains lsp-1.6.0.0
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires transformers >=0.5.5.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *executable* requires optparse-generic >=1.1.1 && < 1.5 and the snapshot contains optparse-generic-1.5.0
         - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires the disabled package: hnix
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *executable* requires ansi-terminal >=0.6.3.1 && < 0.12 and the snapshot contains ansi-terminal-1.0
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
@@ -6493,7 +6495,7 @@ packages:
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.18.0.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.1.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.2.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires attoparsec >=0.10.4.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.18.0.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -6565,7 +6567,7 @@ packages:
         - elynx < 0 # tried elynx-0.7.2.1, but its *executable* requires the disabled package: tlynx
         - elynx-markov < 0 # tried elynx-markov-0.7.2.1, but its *library* requires the disabled package: statistics
         - elynx-tree < 0 # tried elynx-tree-0.7.2.1, but its *library* requires the disabled package: statistics
-        - emacs-module < 0 # tried emacs-module-0.1.1.1, but its *library* requires the disabled package: safe-exceptions-checked
+        - emacs-module < 0 # tried emacs-module-0.2, but its *library* requires the disabled package: monad-interleave
         - email-validate < 0 # tried email-validate-2.3.2.18, but its *library* requires template-haskell >=2.10.0.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: typelits-witnesses
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
@@ -6907,7 +6909,7 @@ packages:
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.1.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.2.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
@@ -7355,15 +7357,11 @@ packages:
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.1.0
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
-        - linear-base < 0 # tried linear-base-0.3.1, but its *library* requires the disabled package: linear-generics
-        - linear-generics < 0 # tried linear-generics-0.2.1, but its *library* requires template-haskell >=2.16 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
-        - linear-generics < 0 # tried linear-generics-0.2.1, but its *library* requires th-abstraction >=0.4 && < 0.5 and the snapshot contains th-abstraction-0.5.0.0
         - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.3.1
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.1
         - list-transformer < 0 # tried list-transformer-1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - list-witnesses < 0 # tried list-witnesses-0.1.3.2, but its *library* requires the disabled package: functor-products
         - literatex < 0 # tried literatex-0.3.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - little-logger < 0 # tried little-logger-1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - little-rio < 0 # tried little-rio-2.0.0, but its *library* requires the disabled package: little-logger
@@ -7499,6 +7497,11 @@ packages:
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
         - monadic-arrays < 0 # tried monadic-arrays-0.2.2, but its *library* requires transformers >=0.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - monads-tf < 0 # tried monads-tf-0.1.0.3, but its *library* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monoidal-functors < 0 # tried monoidal-functors-0.2.1.0, but its *library* requires bifunctors >=5.5.11 && < 5.6 and the snapshot contains bifunctors-5.6.1
+        - monoidal-functors < 0 # tried monoidal-functors-0.2.1.0, but its *library* requires semialign >=1.2.0 && < 1.3 and the snapshot contains semialign-1.3
+        - monoidal-functors < 0 # tried monoidal-functors-0.2.1.0, but its *library* requires semigroupoids >=5.3.6 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - monoidal-functors < 0 # tried monoidal-functors-0.2.1.0, but its *library* requires these >=1.1.1 && < 1.2 and the snapshot contains these-1.2
+        - monomer < 0 # tried monomer-1.5.1.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - morpheus-graphql < 0 # tried morpheus-graphql-0.27.3, but its *library* requires the disabled package: morpheus-graphql-code-gen
         - morpheus-graphql < 0 # tried morpheus-graphql-0.27.3, but its *library* requires the disabled package: relude
         - morpheus-graphql-app < 0 # tried morpheus-graphql-app-0.27.3, but its *library* requires the disabled package: relude
@@ -7570,6 +7573,7 @@ packages:
         - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires the disabled package: nri-prelude
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires hw-kafka-client >=4.0.3 && < 5.0 and the snapshot contains hw-kafka-client-5.0.0
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires the disabled package: nri-prelude
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires unix >=2.7.2.2 && < 2.8.0.0 and the snapshot contains unix-2.8.1.0
         - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
@@ -7599,16 +7603,17 @@ packages:
         - nvvm < 0 # tried nvvm-0.10.0.0, but its *library* requires the disabled package: cuda
         - ochintin-daicho < 0 # tried ochintin-daicho-0.3.4.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - oeis < 0 # tried oeis-0.3.10, but its *library* requires HTTP >=4000.2 && < 4000.4 and the snapshot contains HTTP-4000.4.1
+        - oeis2 < 0 # tried oeis2-1.0.7, but its *library* requires aeson >=1.1 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - oeis2 < 0 # tried oeis2-1.0.7, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - oeis2 < 0 # tried oeis2-1.0.7, but its *library* requires vector ==0.12.* and the snapshot contains vector-0.13.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires Cabal >=3.2.1.0 && < 3.3 and the snapshot contains Cabal-3.10.1.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires base >=4.14 && < 4.15 and the snapshot contains base-4.18.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires bytestring >=0.10.10.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires template-haskell >=2.16.0.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires text >=1.2.4.0 && < 1.3 and the snapshot contains text-2.0.2
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires unix >=2.7.2.2 && < 2.8 and the snapshot contains unix-2.8.1.0
-        - one-liner < 0 # tried one-liner-2.1, but its *library* requires the disabled package: linear-base
-        - one-liner-instances < 0 # tried one-liner-instances-0.1.3.0, but its *library* requires the disabled package: one-liner
         - options < 0 # tried options-1.2.1.1, but its *library* requires the disabled package: monads-tf
-        - optparse-generic < 0 # tried optparse-generic-1.4.9, but its *library* requires optparse-applicative >=0.16.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - optparse-generic < 0 # tried optparse-generic-1.5.0, but its *library* requires optparse-applicative >=0.16.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.1.0
@@ -8559,7 +8564,6 @@ packages:
         - ws < 0 # tried ws-0.0.5, but its *library* requires the disabled package: attoparsec-uri
         - xdg-desktop-entry < 0 # tried xdg-desktop-entry-0.1.1.1, but its *library* requires the disabled package: ConfigFile
         - xlsx < 0 # tried xlsx-1.1.0.1, but its *library* requires the disabled package: zip
-        - xlsx-tabular < 0 # tried xlsx-tabular-0.2.2.1, but its *library* requires the disabled package: xlsx
         - xml-parser < 0 # tried xml-parser-0.1.1.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
         - xmonad-contrib < 0 # tried xmonad-contrib-0.17.1, but its *library* requires mtl >=1 && < 2.3 and the snapshot contains mtl-2.3.1
         - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: libmpd
@@ -9110,7 +9114,6 @@ skipped-tests:
     - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: tasty-hedgehog
     - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog
     - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog-fn
-    - generic-data # tried generic-data-1.1.0.0, but its *test-suite* requires the disabled package: one-liner
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9128,6 +9131,10 @@ skipped-tests:
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - haskell-neo4j-client # tried haskell-neo4j-client-0.3.2.4, but its *test-suite* requires the disabled package: test-framework
+    - haskell-neo4j-client # tried haskell-neo4j-client-0.3.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
+    - haskell-neo4j-client # tried haskell-neo4j-client-0.3.2.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - haskell-neo4j-client # tried haskell-neo4j-client-0.3.2.4, but its *test-suite* requires the disabled package: test-framework-th
     - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework
     - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - hedn # tried hedn-0.3.0.4, but its *test-suite* requires the disabled package: hedgehog
@@ -9192,6 +9199,8 @@ skipped-tests:
     - lifted-base # tried lifted-base-0.2.3.12, but its *test-suite* requires the disabled package: test-framework-hunit
     - linear # tried linear-1.22, but its *test-suite* requires the disabled package: test-framework
     - linear # tried linear-1.22, but its *test-suite* requires the disabled package: test-framework-hunit
+    - linear-base # tried linear-base-0.3.1, but its *test-suite* requires the disabled package: hedgehog
+    - linear-base # tried linear-base-0.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: abstract-deque-tests
     - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework
     - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
@@ -9947,12 +9956,10 @@ skipped-benchmarks:
     - base64 # tried base64-0.4.2.4, but its *benchmarks* requires the disabled package: criterion
     - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *benchmarks* requires the disabled package: criterion
     - bencoding # tried bencoding-0.4.5.4, but its *benchmarks* requires the disabled package: criterion
-    - binary-tagged # tried binary-tagged-0.3.1, but its *benchmarks* requires the disabled package: binary-instances
     - binary-tagged # tried binary-tagged-0.3.1, but its *benchmarks* requires the disabled package: criterion
     - bitset-word8 # tried bitset-word8-0.1.1.2, but its *benchmarks* requires the disabled package: criterion
     - blake2 # tried blake2-0.3.0, but its *benchmarks* requires the disabled package: criterion
     - broadcast-chan # tried broadcast-chan-0.2.1.2, but its *benchmarks* requires the disabled package: criterion
-    - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: criterion
     - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: json-builder
     - bytestring-trie # tried bytestring-trie-0.2.7.2, but its *benchmarks* requires the disabled package: criterion
     - bz2 # tried bz2-1.0.1.0, but its *benchmarks* requires the disabled package: criterion
@@ -9992,10 +9999,6 @@ skipped-benchmarks:
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires the disabled package: criterion
     - edit-distance # tried edit-distance-0.2.2.1, but its *benchmarks* requires the disabled package: criterion
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: criterion
-    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework
-    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-hunit
-    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-quickcheck2
-    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
     - fmt # tried fmt-0.6.3.0, but its *benchmarks* requires the disabled package: criterion
     - foldl # tried foldl-1.4.14, but its *benchmarks* requires the disabled package: criterion
     - formatting # tried formatting-7.2.0, but its *benchmarks* requires the disabled package: criterion
@@ -10027,8 +10030,6 @@ skipped-benchmarks:
     - glob-posix # tried glob-posix-0.2.0.1, but its *benchmarks* requires the disabled package: criterion
     - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: criterion
     - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: statistics
-    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework
-    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework-hunit
     - hindent # tried hindent-6.1.0, but its *benchmarks* requires the disabled package: criterion
     - histogram-fill # tried histogram-fill-0.9.1.0, but its *benchmarks* requires the disabled package: criterion
     - hledger # tried hledger-1.30.1, but its *benchmarks* requires the disabled package: criterion
@@ -10107,7 +10108,6 @@ skipped-benchmarks:
     - scotty # tried scotty-0.12.1, but its *benchmarks* requires the disabled package: weigh
     - search-algorithms # tried search-algorithms-0.3.2, but its *benchmarks* requires the disabled package: criterion
     - semver # tried semver-0.4.0.1, but its *benchmarks* requires the disabled package: criterion
-    - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
     - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires ghc-prim >=0.3.1.0 && < 0.10 and the snapshot contains ghc-prim-0.10.0
     - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires the disabled package: criterion
     - sexp-grammar # tried sexp-grammar-2.3.4.1, but its *benchmarks* requires the disabled package: criterion

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6219,7 +6219,7 @@ packages:
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires text ^>=1.2.5 and the snapshot contains text-2.0.2
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires transformers ^>=0.5.6 and the snapshot contains transformers-0.6.1.0
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
-        - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.1, but its *library* requires the disabled package: connection
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
         - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
@@ -6236,8 +6236,6 @@ packages:
         - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires base >=4.3 && < 4.16 and the snapshot contains base-4.18.0.0
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - cabal-appimage < 0 # tried cabal-appimage-0.4.0.0, but its *library* requires Cabal >=2.4.1.0 && < 3.9 and the snapshot contains Cabal-3.10.1.0
-        - cabal-appimage < 0 # tried cabal-appimage-0.4.0.0, but its *library* requires base >=4.11.0.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires the disabled package: cabal-plan
         - cabal2nix < 0 # tried cabal2nix-2.19.1, but its *executable* requires the disabled package: monad-par

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6078,7 +6078,6 @@ packages:
         - ascii-th < 0 # tried ascii-th-1.2.0.0, but its *library* requires template-haskell ^>=2.16 || ^>=2.17 || ^>=2.18 || ^>=2.19 and the snapshot contains template-haskell-2.20.0.0
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - assert-failure < 0 # tried assert-failure-0.1.2.6, but its *library* requires the disabled package: pretty-show
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* requires unliftio-core >=0.1.1.0 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
         - atom-conduit < 0 # tried atom-conduit-0.9.0.1, but its *library* requires the disabled package: relude
         - aur < 0 # tried aur-7.0.7, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
@@ -6340,8 +6339,6 @@ packages:
         - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.18.0.0
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - componentm < 0 # tried componentm-0.0.0.2, but its *library* requires the disabled package: pretty-show
-        - componentm-devel < 0 # tried componentm-devel-0.0.0.2, but its *library* requires the disabled package: componentm
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires aeson >=1.1.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires lens >=4.15.4 && < 5.2 and the snapshot contains lens-5.2.2
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
@@ -6659,22 +6656,8 @@ packages:
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires generic-deriving >=1.6 && < 1.14 and the snapshot contains generic-deriving-1.14.4
         - geniplate-mirror < 0 # tried geniplate-mirror-0.7.9, but its *library* requires template-haskell < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - genvalidity-criterion < 0 # tried genvalidity-criterion-1.1.0.0, but its *library* requires the disabled package: criterion
-        - genvalidity-hspec < 0 # tried genvalidity-hspec-1.0.0.2, but its *library* requires the disabled package: genvalidity-property
-        - genvalidity-hspec-aeson < 0 # tried genvalidity-hspec-aeson-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
-        - genvalidity-hspec-binary < 0 # tried genvalidity-hspec-binary-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
-        - genvalidity-hspec-cereal < 0 # tried genvalidity-hspec-cereal-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
-        - genvalidity-hspec-hashable < 0 # tried genvalidity-hspec-hashable-1.0.0.0, but its *library* requires the disabled package: genvalidity-property
-        - genvalidity-hspec-optics < 0 # tried genvalidity-hspec-optics-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
         - genvalidity-hspec-persistent < 0 # tried genvalidity-hspec-persistent-1.0.0.0, but its *library* requires the disabled package: persistent
         - genvalidity-persistent < 0 # tried genvalidity-persistent-1.0.0.1, but its *library* requires the disabled package: persistent
-        - genvalidity-property < 0 # tried genvalidity-property-1.0.0.0, but its *library* requires the disabled package: pretty-show
-        - genvalidity-sydtest < 0 # tried genvalidity-sydtest-1.0.0.0, but its *library* requires the disabled package: pretty-show
-        - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
-        - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-hashable < 0 # tried genvalidity-sydtest-hashable-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
-        - genvalidity-sydtest-hashable < 0 # tried genvalidity-sydtest-hashable-1.0.0.0, but its *library* requires the disabled package: sydtest
-        - genvalidity-sydtest-lens < 0 # tried genvalidity-sydtest-lens-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
-        - genvalidity-sydtest-lens < 0 # tried genvalidity-sydtest-lens-1.0.0.0, but its *library* requires the disabled package: sydtest
         - genvalidity-sydtest-persistent < 0 # tried genvalidity-sydtest-persistent-1.0.0.0, but its *library* requires the disabled package: persistent
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires the disabled package: validation
         - ghc-bignum-orphans < 0 # tried ghc-bignum-orphans-0.1.1, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
@@ -6689,31 +6672,9 @@ packages:
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
-        - gi-atk < 0 # tried gi-atk-2.0.27, but its *library* requires the disabled package: haskell-gi
-        - gi-cairo < 0 # tried gi-cairo-1.0.29, but its *library* requires the disabled package: haskell-gi
         - gi-cairo-connector < 0 # tried gi-cairo-connector-0.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - gi-dbusmenu < 0 # tried gi-dbusmenu-0.4.13, but its *library* requires the disabled package: haskell-gi
-        - gi-dbusmenugtk3 < 0 # tried gi-dbusmenugtk3-0.4.14, but its *library* requires the disabled package: haskell-gi
-        - gi-freetype2 < 0 # tried gi-freetype2-2.0.4, but its *library* requires the disabled package: haskell-gi
-        - gi-gdk < 0 # tried gi-gdk-3.0.28, but its *library* requires the disabled package: haskell-gi
-        - gi-gdkpixbuf < 0 # tried gi-gdkpixbuf-2.0.31, but its *library* requires the disabled package: haskell-gi
-        - gi-gdkx11 < 0 # tried gi-gdkx11-3.0.15, but its *library* requires the disabled package: haskell-gi
-        - gi-gio < 0 # tried gi-gio-2.0.32, but its *library* requires the disabled package: haskell-gi
-        - gi-glib < 0 # tried gi-glib-2.0.29, but its *library* requires the disabled package: haskell-gi
-        - gi-gmodule < 0 # tried gi-gmodule-2.0.5, but its *library* requires the disabled package: haskell-gi
-        - gi-gobject < 0 # tried gi-gobject-2.0.30, but its *library* requires the disabled package: haskell-gi
-        - gi-graphene < 0 # tried gi-graphene-1.0.7, but its *library* requires the disabled package: haskell-gi
         - gi-gsk < 0 # tried gi-gsk-4.0.7, but its *library* requires gi-gdk ==4.0.* and the snapshot contains gi-gdk-3.0.28
-        - gi-gtk < 0 # tried gi-gtk-3.0.41, but its *library* requires the disabled package: haskell-gi
         - gi-gtk-hs < 0 # tried gi-gtk-hs-0.3.15, but its *library* requires base-compat >=0.9.0 && < 0.13 and the snapshot contains base-compat-0.13.0
-        - gi-gtksource < 0 # tried gi-gtksource-3.0.28, but its *library* requires the disabled package: haskell-gi
-        - gi-harfbuzz < 0 # tried gi-harfbuzz-0.0.9, but its *library* requires the disabled package: haskell-gi
-        - gi-javascriptcore < 0 # tried gi-javascriptcore-4.0.27, but its *library* requires the disabled package: haskell-gi
-        - gi-pango < 0 # tried gi-pango-1.0.29, but its *library* requires the disabled package: haskell-gi
-        - gi-soup < 0 # tried gi-soup-2.4.28, but its *library* requires the disabled package: haskell-gi
-        - gi-vte < 0 # tried gi-vte-2.91.31, but its *library* requires the disabled package: haskell-gi
-        - gi-webkit2 < 0 # tried gi-webkit2-4.0.30, but its *library* requires the disabled package: haskell-gi
-        - gi-xlib < 0 # tried gi-xlib-2.0.13, but its *library* requires the disabled package: haskell-gi
         - ginger < 0 # tried ginger-0.10.4.0, but its *executable* requires optparse-applicative >=0.14.3.0 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - ginger < 0 # tried ginger-0.10.4.0, but its *executable* requires transformers >=0.5.6.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires aeson >=1.4.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
@@ -6873,8 +6834,6 @@ packages:
         - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires the disabled package: groundhog
         - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
         - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: gi-cairo-connector
-        - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gdk
-        - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gtk
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: incremental-parser
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
@@ -6902,7 +6861,6 @@ packages:
         - hasbolt < 0 # tried hasbolt-0.1.6.2, but its *library* requires the disabled package: connection
         - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
         - hashids < 0 # tried hashids-1.0.2.7, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
-        - haskell-gi < 0 # tried haskell-gi-0.26.6, but its *library* requires the disabled package: pretty-show
         - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.0.0
         - haskell-lsp-client < 0 # tried haskell-lsp-client-1.0.0.1, but its *library* requires the disabled package: haskell-lsp
@@ -7144,7 +7102,6 @@ packages:
         - htaglib < 0 # tried htaglib-1.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.0.2
-        - htoml-parse < 0 # tried htoml-parse-0.1.0.1, but its *library* requires the disabled package: prettyprinter-combinators
         - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - http-client-restricted < 0 # tried http-client-restricted-0.0.5, but its *library* requires the disabled package: connection
         - hunit-dejafu < 0 # tried hunit-dejafu-2.0.0.6, but its *library* requires the disabled package: dejafu
@@ -7604,7 +7561,6 @@ packages:
         - network-msgpack-rpc < 0 # tried network-msgpack-rpc-0.0.6, but its *library* requires network < 3 and the snapshot contains network-3.1.4.0
         - network-transport < 0 # tried network-transport-0.5.6, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - next-ref < 0 # tried next-ref-0.1.0.2, but its *library* requires stm >=2.2 && < 2.5 and the snapshot contains stm-2.5.1.0
-        - nix-derivation < 0 # tried nix-derivation-1.1.2, but its *executable* requires the disabled package: pretty-show
         - nonemptymap < 0 # tried nonemptymap-0.0.6.0, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
         - normalization-insensitive < 0 # tried normalization-insensitive-2.0.2, but its *library* requires text >=1.1.1 && < 1.3 and the snapshot contains text-2.0.2
         - not-gloss < 0 # tried not-gloss-0.7.7.0, but its *library* requires the disabled package: GLUT
@@ -7759,8 +7715,6 @@ packages:
         - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
         - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: pipes-network
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
-        - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: cairo
-        - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.18.0.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires haskell-src-exts-simple >=1.18 && < 1.21 || ^>=1.21 and the snapshot contains haskell-src-exts-simple-1.23.0.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires mtl >=2 && < 2.2 || ^>=2.2 and the snapshot contains mtl-2.3.1
@@ -7811,8 +7765,6 @@ packages:
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: pred-set
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - pretty-sop < 0 # tried pretty-sop-0.2.0.3, but its *library* requires the disabled package: pretty-show
-        - prettyprinter-combinators < 0 # tried prettyprinter-combinators-0.1.1.1, but its *library* requires the disabled package: pretty-show
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.7
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires lens >=4.10 && < 4.16 and the snapshot contains lens-5.2.2
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7843,14 +7795,12 @@ packages:
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - quickbench < 0 # tried quickbench-1.0.1, but its *library* requires the disabled package: docopt
         - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
-        - quickcheck-assertions < 0 # tried quickcheck-assertions-0.3.0, but its *library* requires the disabled package: pretty-show
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.5, but its *library* requires the disabled package: unfoldable-restricted
         - quickcheck-groups < 0 # tried quickcheck-groups-0.0.0.0, but its *library* requires base >=4.14.3.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - quickcheck-groups < 0 # tried quickcheck-groups-0.0.0.0, but its *library* requires semigroupoids >=5.3.7 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - quickcheck-monoid-subclasses < 0 # tried quickcheck-monoid-subclasses-0.1.0.0, but its *library* requires base >=4.14.3.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - quickcheck-monoid-subclasses < 0 # tried quickcheck-monoid-subclasses-0.1.0.0, but its *library* requires semigroupoids >=5.3.7 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.3, but its *library* requires the disabled package: graphviz
-        - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.3, but its *library* requires the disabled package: pretty-show
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
@@ -7957,11 +7907,8 @@ packages:
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires the disabled package: tomland
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.12.2
         - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
-        - sandwich < 0 # tried sandwich-0.1.4.0, but its *library* requires the disabled package: pretty-show
         - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.3.0, but its *library* requires the disabled package: hedgehog
-        - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.7, but its *library* requires the disabled package: sandwich
         - sandwich-slack < 0 # tried sandwich-slack-0.1.1.0, but its *library* requires the disabled package: wreq
-        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.2.1.0, but its *library* requires the disabled package: sandwich
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
@@ -8179,7 +8126,6 @@ packages:
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
-        - skylighting < 0 # tried skylighting-0.13.2.1, but its *executable* requires the disabled package: pretty-show
         - slack-progressbar < 0 # tried slack-progressbar-0.1.0.1, but its *library* requires the disabled package: wreq
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
         - slick < 0 # tried slick-1.2.1.0, but its *library* requires the disabled package: pandoc
@@ -8331,31 +8277,15 @@ packages:
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.0.0
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.1.0
         - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
-        - sydtest < 0 # tried sydtest-0.15.0.0, but its *library* requires the disabled package: pretty-show
-        - sydtest-aeson < 0 # tried sydtest-aeson-0.1.0.0, but its *library* requires the disabled package: sydtest
         - sydtest-amqp < 0 # tried sydtest-amqp-0.1.0.0, but its *library* requires the disabled package: amqp
-        - sydtest-autodocodec < 0 # tried sydtest-autodocodec-0.0.0.0, but its *library* requires the disabled package: sydtest
         - sydtest-hedgehog < 0 # tried sydtest-hedgehog-0.4.0.0, but its *library* requires the disabled package: hedgehog
-        - sydtest-hedis < 0 # tried sydtest-hedis-0.0.0.0, but its *library* requires the disabled package: sydtest
-        - sydtest-mongo < 0 # tried sydtest-mongo-0.0.0.0, but its *library* requires the disabled package: sydtest
         - sydtest-persistent < 0 # tried sydtest-persistent-0.0.0.1, but its *library* requires the disabled package: persistent
         - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.2, but its *library* requires the disabled package: persistent
         - sydtest-persistent-sqlite < 0 # tried sydtest-persistent-sqlite-0.2.0.2, but its *library* requires the disabled package: persistent
-        - sydtest-process < 0 # tried sydtest-process-0.0.0.0, but its *library* requires the disabled package: sydtest
         - sydtest-rabbitmq < 0 # tried sydtest-rabbitmq-0.1.0.0, but its *library* requires the disabled package: amqp
         - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-client
         - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-server
-        - sydtest-typed-process < 0 # tried sydtest-typed-process-0.0.0.0, but its *library* requires the disabled package: sydtest
-        - sydtest-wai < 0 # tried sydtest-wai-0.2.0.0, but its *library* requires the disabled package: pretty-show
-        - sydtest-webdriver < 0 # tried sydtest-webdriver-0.0.0.1, but its *library* requires the disabled package: sydtest
-        - sydtest-webdriver < 0 # tried sydtest-webdriver-0.0.0.1, but its *library* requires the disabled package: sydtest-wai
-        - sydtest-webdriver-screenshot < 0 # tried sydtest-webdriver-screenshot-0.0.0.1, but its *library* requires the disabled package: sydtest
-        - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: sydtest
-        - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: sydtest-wai
         - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: yesod
-        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: sydtest
-        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: sydtest-wai
-        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: yesod-test
         - taffybar < 0 # tried taffybar-4.0.0, but its *library* requires scotty >=0.11.0 && < 0.12.0 and the snapshot contains scotty-0.12.1
         - tagged-identity < 0 # tried tagged-identity-0.1.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - tasty-dejafu < 0 # tried tasty-dejafu-2.1.0.0, but its *library* requires the disabled package: dejafu
@@ -8409,7 +8339,6 @@ packages:
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: amqp
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: tmp-proc
         - tmp-proc-redis < 0 # tried tmp-proc-redis-0.5.1.2, but its *library* requires the disabled package: tmp-proc
-        - toml-reader-parse < 0 # tried toml-reader-parse-0.1.1.1, but its *library* requires the disabled package: prettyprinter-combinators
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
@@ -8668,11 +8597,9 @@ packages:
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-core >=1.2 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-static >=1.2.1 && < 1.6 and the snapshot contains yesod-static-1.6.1.0
-        - yesod-test < 0 # tried yesod-test-1.6.15, but its *library* requires the disabled package: pretty-show
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires aeson >=0.7 && < 2.0 and the snapshot contains aeson-2.1.2.1
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
         - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
-        - zenacy-html < 0 # tried zenacy-html-2.1.0, but its *library* requires the disabled package: pretty-show
         - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
         - zigzag < 0 # tried zigzag-0.0.1.0, but its *library* requires base >=4.11.1 && < 4.18 and the snapshot contains base-4.18.0.0
         - zio < 0 # tried zio-0.1.0.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -9060,11 +8987,9 @@ skipped-tests:
     - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework
     - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - base58-bytestring # tried base58-bytestring-0.1.0, but its *test-suite* requires the disabled package: quickcheck-assertions
     - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework
     - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - binary-conduit # tried binary-conduit-1.3.1, but its *test-suite* requires the disabled package: quickcheck-assertions
     - binary-tagged # tried binary-tagged-0.3.1, but its *test-suite* requires the disabled package: binary-instances
     - bindings-GLFW # tried bindings-GLFW-3.3.2.0, but its *test-suite* requires the disabled package: test-framework
     - bindings-GLFW # tried bindings-GLFW-3.3.2.0, but its *test-suite* requires the disabled package: test-framework-hunit
@@ -9097,7 +9022,6 @@ skipped-tests:
     - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-QuickCheck
     - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-described
     - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-tree-diff
-    - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: pretty-show
     - cacophony # tried cacophony-0.10.1, but its *test-suite* requires the disabled package: hlint
     - cereal # tried cereal-0.5.8.3, but its *test-suite* requires the disabled package: test-framework
     - cereal # tried cereal-0.5.8.3, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9133,9 +9057,6 @@ skipped-tests:
     - cron # tried cron-0.7.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - ctrie # tried ctrie-0.2, but its *test-suite* requires the disabled package: test-framework
     - ctrie # tried ctrie-0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-optics
-    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: pretty-show
     - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework
     - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9143,7 +9064,6 @@ skipped-tests:
     - data-hash # tried data-hash-0.2.0.1, but its *test-suite* requires the disabled package: test-framework
     - data-hash # tried data-hash-0.2.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - data-interval # tried data-interval-2.1.1, but its *test-suite* requires the disabled package: ChasingBottoms
-    - data-sketches # tried data-sketches-0.3.1.0, but its *test-suite* requires the disabled package: pretty-show
     - data-sketches # tried data-sketches-0.3.1.0, but its *test-suite* requires the disabled package: statistics
     - data-textual # tried data-textual-0.3.0.3, but its *test-suite* requires the disabled package: test-framework
     - data-textual # tried data-textual-0.3.0.3, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9159,7 +9079,6 @@ skipped-tests:
     - double-conversion # tried double-conversion-2.0.4.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - double-conversion # tried double-conversion-2.0.4.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - dublincore-xml-conduit # tried dublincore-xml-conduit-0.1.0.2, but its *test-suite* requires the disabled package: hlint
-    - easy-logger # tried easy-logger-0.1.0.7, but its *test-suite* requires the disabled package: quickcheck-assertions
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires QuickCheck >=2.4 && < 2.9 and the snapshot contains QuickCheck-2.14.3
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires directory >=1.0 && < 1.3 and the snapshot contains directory-1.3.8.1
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires doctest >=0.10 && < 0.12 and the snapshot contains doctest-0.21.1
@@ -9184,42 +9103,16 @@ skipped-tests:
     - fingertree # tried fingertree-0.1.5.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - fixed-vector-hetero # tried fixed-vector-hetero-0.6.1.1, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.21.1
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires genvalidity < 1.0.0.0 and the snapshot contains genvalidity-1.1.0.0
-    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: genvalidity-hspec
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: hedgehog
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires validity < 0.12.0.0 and the snapshot contains validity-0.12.0.1
     - friday # tried friday-0.2.3.2, but its *test-suite* requires the disabled package: test-framework
     - friday # tried friday-0.2.3.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - fsnotify # tried fsnotify-0.4.1.0, but its *test-suite* requires the disabled package: sandwich
     - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: hedgehog
     - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: tasty-hedgehog
     - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog
     - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog-fn
     - generic-data # tried generic-data-1.1.0.0, but its *test-suite* requires the disabled package: one-liner
-    - genvalidity-aeson # tried genvalidity-aeson-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest
-    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest-aeson
-    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: pretty-show
-    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: sydtest
-    - genvalidity-bytestring # tried genvalidity-bytestring-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-case-insensitive # tried genvalidity-case-insensitive-0.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-property
-    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
-    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: pretty-show
-    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
-    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: pretty-show
-    - genvalidity-path # tried genvalidity-path-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-scientific # tried genvalidity-scientific-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-text # tried genvalidity-text-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-time # tried genvalidity-time-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
-    - genvalidity-unordered-containers # tried genvalidity-unordered-containers-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-uuid # tried genvalidity-uuid-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - genvalidity-vector # tried genvalidity-vector-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9237,7 +9130,6 @@ skipped-tests:
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - haskell-src-exts # tried haskell-src-exts-1.23.1, but its *test-suite* requires the disabled package: pretty-show
     - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework
     - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - hedn # tried hedn-0.3.0.4, but its *test-suite* requires the disabled package: hedgehog
@@ -9306,7 +9198,6 @@ skipped-tests:
     - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework
     - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
     - map-syntax # tried map-syntax-0.3, but its *test-suite* requires hspec >=2.2.3 && < 2.11 and the snapshot contains hspec-2.11.1
-    - massiv-test # tried massiv-test-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
     - math-extras # tried math-extras-0.1.1.0, but its *test-suite* requires the disabled package: hedgehog
     - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *test-suite* requires the disabled package: hedgehog
     - minimorph # tried minimorph-0.3.0.1, but its *test-suite* requires the disabled package: test-framework
@@ -9351,8 +9242,6 @@ skipped-tests:
     - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework
     - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - path # tried path-0.9.2, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - path # tried path-0.9.2, but its *test-suite* requires the disabled package: genvalidity-property
     - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework
     - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
     - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9367,7 +9256,6 @@ skipped-tests:
     - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework
     - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - pretty-relative-time # tried pretty-relative-time-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
     - ptr-poker # tried ptr-poker-0.1.2.13, but its *test-suite* requires the disabled package: hedgehog
     - pureMD5 # tried pureMD5-2.1.4, but its *test-suite* requires the disabled package: crypto-api-tests
     - pureMD5 # tried pureMD5-2.1.4, but its *test-suite* requires the disabled package: test-framework
@@ -9386,17 +9274,11 @@ skipped-tests:
     - retry # tried retry-0.9.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - rng-utils # tried rng-utils-0.3.1, but its *test-suite* requires the disabled package: hedgehog
     - rng-utils # tried rng-utils-0.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
-    - safe-coloured-text-gen # tried safe-coloured-text-gen-0.0.0.1, but its *test-suite* requires the disabled package: genvalidity-sydtest
-    - safe-coloured-text-gen # tried safe-coloured-text-gen-0.0.0.1, but its *test-suite* requires the disabled package: sydtest
-    - safe-coloured-text-layout # tried safe-coloured-text-layout-0.0.0.0, but its *test-suite* requires the disabled package: sydtest
-    - safe-coloured-text-layout-gen # tried safe-coloured-text-layout-gen-0.0.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest
-    - safe-coloured-text-layout-gen # tried safe-coloured-text-layout-gen-0.0.0.0, but its *test-suite* requires the disabled package: sydtest
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-th
     - saltine # tried saltine-0.2.1.0, but its *test-suite* requires the disabled package: test-framework
     - saltine # tried saltine-0.2.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
-    - scheduler # tried scheduler-2.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
     - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework
     - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9405,7 +9287,6 @@ skipped-tests:
     - siggy-chardust # tried siggy-chardust-1.0.0, but its *test-suite* requires the disabled package: hlint
     - simple-affine-space # tried simple-affine-space-0.2.1, but its *test-suite* requires the disabled package: hlint
     - singletons-base # tried singletons-base-3.2, but its *test-suite* requires the disabled package: turtle
-    - skylighting-core # tried skylighting-core-0.13.2.1, but its *test-suite* requires the disabled package: pretty-show
     - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework
     - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9417,6 +9298,10 @@ skipped-tests:
     - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.11.1
     - swish # tried swish-0.10.4.0, but its *test-suite* requires the disabled package: test-framework
     - swish # tried swish-0.10.4.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - sydtest-yesod # tried sydtest-yesod-0.3.0.1, but its *test-suite* requires the disabled package: persistent
+    - sydtest-yesod # tried sydtest-yesod-0.3.0.1, but its *test-suite* requires the disabled package: persistent-sqlite
+    - sydtest-yesod # tried sydtest-yesod-0.3.0.1, but its *test-suite* requires the disabled package: sydtest-persistent-sqlite
+    - sydtest-yesod # tried sydtest-yesod-0.3.0.1, but its *test-suite* requires the disabled package: yesod
     - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell-quickcheck
@@ -9432,7 +9317,6 @@ skipped-tests:
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.3
     - terminal-progress-bar # tried terminal-progress-bar-0.4.2, but its *test-suite* requires the disabled package: test-framework
     - terminal-progress-bar # tried terminal-progress-bar-0.4.2, but its *test-suite* requires the disabled package: test-framework-hunit
-    - texmath # tried texmath-0.12.8, but its *test-suite* requires the disabled package: pretty-show
     - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework
     - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
@@ -9445,18 +9329,14 @@ skipped-tests:
     - ttrie # tried ttrie-0.1.2.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - type-map # tried type-map-0.1.7.0, but its *test-suite* requires the disabled package: test-framework
     - type-map # tried type-map-0.1.7.0, but its *test-suite* requires the disabled package: test-framework-hunit
-    - typst # tried typst-0.1.0.0, but its *test-suite* requires the disabled package: pretty-show
     - unexceptionalio # tried unexceptionalio-0.5.1, but its *test-suite* requires the disabled package: test-framework
     - unexceptionalio # tried unexceptionalio-0.5.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - unicode-data # tried unicode-data-0.4.0.1, but its *test-suite* requires hspec >=2.0 && < 2.11 and the snapshot contains hspec-2.11.1
     - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *test-suite* requires the disabled package: hedgehog
     - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
     - utf8-light # tried utf8-light-0.4.4.0, but its *test-suite* requires hspec >=2.3 && < 2.11 and the snapshot contains hspec-2.11.1
-    - validity-case-insensitive # tried validity-case-insensitive-0.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
-    - validity-path # tried validity-path-0.4.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
     - wai-middleware-delegate # tried wai-middleware-delegate-0.1.3.1, but its *test-suite* requires the disabled package: connection
     - wai-rate-limit-redis # tried wai-rate-limit-redis-0.2.0.1, but its *test-suite* requires the disabled package: tasty-hedgehog
-    - wai-saml2 # tried wai-saml2-0.4, but its *test-suite* requires the disabled package: pretty-show
     - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.11.1
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
@@ -9470,8 +9350,9 @@ skipped-tests:
     - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: persistent
     - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: persistent-sqlite
     - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod
-    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod-test
-    - yesod-static # tried yesod-static-1.6.1.0, but its *test-suite* requires the disabled package: yesod-test
+    - yesod-test # tried yesod-test-1.6.15, but its *test-suite* requires the disabled package: yesod-form
+    - zenacy-html # tried zenacy-html-2.1.0, but its *test-suite* requires the disabled package: test-framework
+    - zenacy-html # tried zenacy-html-2.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - zenacy-unicode # tried zenacy-unicode-1.0.2, but its *test-suite* requires the disabled package: test-framework
     - zenacy-unicode # tried zenacy-unicode-1.0.2, but its *test-suite* requires the disabled package: test-framework-hunit
     - zstd # tried zstd-0.1.3.0, but its *test-suite* requires the disabled package: test-framework
@@ -10194,6 +10075,7 @@ skipped-benchmarks:
     - monoid-extras # tried monoid-extras-0.6.2, but its *benchmarks* requires the disabled package: criterion
     - netpbm # tried netpbm-1.0.4, but its *benchmarks* requires the disabled package: criterion
     - network-uri # tried network-uri-2.6.4.2, but its *benchmarks* requires the disabled package: criterion
+    - nix-derivation # tried nix-derivation-1.1.2, but its *benchmarks* requires the disabled package: criterion
     - o-clock # tried o-clock-1.3.0, but its *benchmarks* requires the disabled package: tiempo
     - openpgp-asciiarmor # tried openpgp-asciiarmor-0.1.2, but its *benchmarks* requires the disabled package: criterion
     - pandoc-types # tried pandoc-types-1.23, but its *benchmarks* requires the disabled package: criterion
@@ -10281,6 +10163,7 @@ skipped-benchmarks:
     - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: criterion
     - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: xxhash
     - yi-rope # tried yi-rope-0.11, but its *benchmarks* requires the disabled package: criterion
+    - zenacy-html # tried zenacy-html-2.1.0, but its *benchmarks* requires the disabled package: criterion
     - zippers # tried zippers-0.3.2, but its *benchmarks* requires the disabled package: criterion
     - zstd # tried zstd-0.1.3.0, but its *benchmarks* requires the disabled package: criterion
     # End of Benchmark bounds issues

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -90,7 +90,7 @@ packages:
         - Sit
 
         - alex > 3.2.7
-        - happy < 1.20.1 || > 1.21.0
+        - happy < 1.21.0 || > 1.21.0
         - haskell-src
         - ListLike
         - MissingH
@@ -5199,7 +5199,6 @@ packages:
         - generically
         - generics-sop-lens
         - ghc-byteorder
-        - ghc-compact
         - ghc-paths
         - ghc-prof
         - ghcjs-dom-jsaddle
@@ -5805,7 +5804,6 @@ packages:
         - ALUT < 0 # tried ALUT-2.4.0.3, but its *library* requires the disabled package: OpenAL
         - ALUT < 0 # tried ALUT-2.4.0.3, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - Allure < 0 # tried Allure-0.11.0.0, but its *library* requires the disabled package: hsini
-        - BNFC < 0 # tried BNFC-2.9.4.1, but its *library* requires the disabled package: happy
         - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: streaming
@@ -6245,7 +6243,6 @@ packages:
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires the disabled package: cabal-plan
         - cabal2nix < 0 # tried cabal2nix-2.19.1, but its *executable* requires the disabled package: monad-par
         - cache < 0 # tried cache-0.1.3.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - cairo < 0 # tried cairo-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
         - capability < 0 # tried capability-0.5.0.1, but its *library* requires the disabled package: streaming
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
@@ -6641,7 +6638,6 @@ packages:
         - fortran-src < 0 # tried fortran-src-0.15.0, but its *library* requires singletons-base >=3.0 && < 3.2 and the snapshot contains singletons-base-3.2
         - fortran-src < 0 # tried fortran-src-0.15.0, but its *library* requires singletons-th >=3.0 && < 3.2 and the snapshot contains singletons-th-3.2
         - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
-        - fourmolu < 0 # tried fourmolu-0.13.0.0, but its *library* requires the disabled package: ghc-lib-parser
         - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2.1
@@ -6686,16 +6682,10 @@ packages:
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.6.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text >=1.2.3.2 && < 1.3 and the snapshot contains text-2.0.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.2
-        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.18.0.0
-        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires ghc-prim >=0.5.3 && < 0.9 and the snapshot contains ghc-prim-0.10.0
-        - ghc-lib < 0 # tried ghc-lib-9.6.2.20230523, but its *library* requires the disabled package: happy
-        - ghc-lib-parser < 0 # tried ghc-lib-parser-9.6.2.20230523, but its *library* requires the disabled package: happy
-        - ghc-lib-parser-ex < 0 # tried ghc-lib-parser-ex-9.6.0.0, but its *library* requires the disabled package: ghc-lib-parser
         - ghc-parser < 0 # tried ghc-parser-0.2.4.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.6.2
         - ghc-prof < 0 # tried ghc-prof-1.4.1.12, but its *library* requires base >=4.6 && < 4.18 and the snapshot contains base-4.18.0.0
         - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.6.2
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.6.2
-        - ghc-syntax-highlighter < 0 # tried ghc-syntax-highlighter-0.0.10.0, but its *library* requires the disabled package: ghc-lib-parser
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
@@ -6730,7 +6720,6 @@ packages:
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - gio < 0 # tried gio-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
         - git-annex < 0 # tried git-annex-10.20230407, but its *executable* requires unix-compat (< 0.7 and the snapshot contains unix-compat-0.7
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires aeson >=1.3 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
@@ -6747,7 +6736,6 @@ packages:
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
-        - glib < 0 # tried glib-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
         - gloss < 0 # tried gloss-1.13.2.2, but its *library* requires the disabled package: GLUT
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: linear-accelerate
@@ -6884,12 +6872,9 @@ packages:
         - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires aeson >=0.7 && < 2 and the snapshot contains aeson-2.1.2.1
         - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires the disabled package: groundhog
         - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
-        - gtk < 0 # tried gtk-0.15.8, but its *library* requires the disabled package: gtk2hs-buildtools
         - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: gi-cairo-connector
         - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gdk
         - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gtk
-        - gtk2hs-buildtools < 0 # tried gtk2hs-buildtools-0.13.10.0, but its *library* requires the disabled package: happy
-        - gtk3 < 0 # tried gtk3-0.15.8, but its *library* requires the disabled package: gtk2hs-buildtools
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: incremental-parser
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
@@ -6913,7 +6898,6 @@ packages:
         - happstack-hsp < 0 # tried happstack-hsp-7.3.7.7, but its *library* requires the disabled package: harp
         - happstack-hsp < 0 # tried happstack-hsp-7.3.7.7, but its *library* requires the disabled package: hsx2hs
         - happstack-jmacro < 0 # tried happstack-jmacro-7.0.12.5, but its *library* requires the disabled package: wl-pprint-text
-        - happy < 0 # tried happy-1.20.0, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - harp < 0 # tried harp-0.4.3.6, but its *library* requires base < 4.18 and the snapshot contains base-4.18.0.0
         - hasbolt < 0 # tried hasbolt-0.1.6.2, but its *library* requires the disabled package: connection
         - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
@@ -7056,7 +7040,6 @@ packages:
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
-        - hindent < 0 # tried hindent-6.1.0, but its *library* requires the disabled package: ghc-lib-parser
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
@@ -7092,7 +7075,6 @@ packages:
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires split < =0.2.3.4 and the snapshot contains split-0.2.3.5
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hoogle < 0 # tried hoogle-5.0.18.3, but its *library* requires the disabled package: connection
-        - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.7, but its *executable* requires the disabled package: happy
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.7, but its *executable* requires the disabled package: ixset-typed
         - horizontal-rule < 0 # tried horizontal-rule-0.6.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires the disabled package: dhall
@@ -7364,7 +7346,6 @@ packages:
         - lame < 0 # tried lame-0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - language-avro < 0 # tried language-avro-0.1.4.0, but its *library* requires the disabled package: avro
         - language-bash < 0 # tried language-bash-0.9.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - language-c-quote < 0 # tried language-c-quote-0.13.0.1, but its *library* requires the disabled package: happy
         - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* requires template-haskell < 2.16 and the snapshot contains template-haskell-2.20.0.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires base16-bytestring ==0.1.* and the snapshot contains base16-bytestring-1.0.2.0
@@ -7674,7 +7655,6 @@ packages:
         - one-liner-instances < 0 # tried one-liner-instances-0.1.3.0, but its *library* requires the disabled package: one-liner
         - options < 0 # tried options-1.2.1.1, but its *library* requires the disabled package: monads-tf
         - optparse-generic < 0 # tried optparse-generic-1.4.9, but its *library* requires optparse-applicative >=0.16.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
-        - ormolu < 0 # tried ormolu-0.7.1.0, but its *library* requires the disabled package: ghc-lib-parser
         - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.1.0
@@ -7691,7 +7671,6 @@ packages:
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.0.0, but its *library* requires mtl ==2.2.* and the snapshot contains mtl-2.3.1
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.0.0, but its *library* requires optparse-applicative ==0.17.* and the snapshot contains optparse-applicative-0.18.1.0
         - pandoc-throw < 0 # tried pandoc-throw-0.1.0.0, but its *library* requires the disabled package: pandoc
-        - pango < 0 # tried pango-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
         - pantry < 0 # tried pantry-0.8.2.2, but its *library* requires the disabled package: persistent
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell ==2.15.* and the snapshot contains template-haskell-2.20.0.0
@@ -7832,7 +7811,6 @@ packages:
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: pred-set
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - pretty-show < 0 # tried pretty-show-1.10, but its *library* requires the disabled package: happy
         - pretty-sop < 0 # tried pretty-sop-0.2.0.3, but its *library* requires the disabled package: pretty-show
         - prettyprinter-combinators < 0 # tried prettyprinter-combinators-0.1.1.1, but its *library* requires the disabled package: pretty-show
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.7
@@ -9309,6 +9287,8 @@ skipped-tests:
     - jsonifier # tried jsonifier-0.2.1.2, but its *test-suite* requires the disabled package: hedgehog
     - keyed-vals-redis # tried keyed-vals-redis-0.2.0.0, but its *test-suite* requires the disabled package: hspec-tmp-proc
     - keyed-vals-redis # tried keyed-vals-redis-0.2.0.0, but its *test-suite* requires the disabled package: tmp-proc-redis
+    - language-c-quote # tried language-c-quote-0.13.0.1, but its *test-suite* requires the disabled package: test-framework
+    - language-c-quote # tried language-c-quote-0.13.0.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - language-glsl # tried language-glsl-0.3.0, but its *test-suite* requires the disabled package: test-framework
     - language-glsl # tried language-glsl-0.3.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - lapack # tried lapack-0.5.1, but its *test-suite* requires the disabled package: ChasingBottoms
@@ -10170,6 +10150,7 @@ skipped-benchmarks:
     - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: statistics
     - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework
     - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework-hunit
+    - hindent # tried hindent-6.1.0, but its *benchmarks* requires the disabled package: criterion
     - histogram-fill # tried histogram-fill-0.9.1.0, but its *benchmarks* requires the disabled package: criterion
     - hledger # tried hledger-1.30.1, but its *benchmarks* requires the disabled package: criterion
     - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *benchmarks* requires the disabled package: criterion

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1,6 +1,6 @@
-ghc-major-version: "9.4"
+ghc-major-version: "9.6"
 # new curator is supposed to use exact GHC version
-ghc-version: "9.4.5"
+ghc-version: "9.6.2"
 
 # This affects which version of the Cabal file format we allow. We
 # should ensure that this is always no greater than the version
@@ -331,7 +331,7 @@ packages:
 
         # @ghorn
         - not-gloss
-        - spatial-math < 0.3 # Need older version for GHC 9.4. Looks like it can be upgraded for GHC 9.6.
+        - spatial-math
 
     "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
         - siggy-chardust
@@ -1149,13 +1149,14 @@ packages:
 
     "Simon Hengel <sol@typeful.net> @sol":
         - hspec
+        - hspec-api
         - hspec-core
         - hspec-discover
         - hspec-wai
         - hspec-wai-json
         - aeson-qq
         - interpolate
-        - doctest < 0.21.0      # https://github.com/commercialhaskell/stackage/issues/6875
+        - doctest
         - base-compat
 
     "Mario Blazevic <blamario@protonmail.com> @blamario":
@@ -1537,7 +1538,7 @@ packages:
         - breakpoint
 
     "Mihai Maruseac <mihai.maruseac@gmail.com> @mihaimaruseac":
-        - hindent < 6.1 # https://github.com/commercialhaskell/stackage/issues/6982
+        - hindent
         - io-manager
 
     "Dimitri Sabadie <dimitri.sabadie@gmail.com> @phaazon":
@@ -2850,7 +2851,7 @@ packages:
         - flac
         - flac-picture
         - forma
-        - ghc-syntax-highlighter < 0.0.10.0 # https://github.com/commercialhaskell/stackage/issues/6987
+        - ghc-syntax-highlighter
         - hspec-megaparsec
         - htaglib
         - html-entity-map
@@ -3137,6 +3138,7 @@ packages:
         - skylighting-format-blaze-html
         - skylighting-format-context
         - skylighting-format-latex
+        - typst
         - typst-symbols #used by texmath
 
     "Karun Ramakrishnan <karun012@gmail.com> @karun012":
@@ -3584,7 +3586,7 @@ packages:
         - HDBC-mysql
 
     "Tony Morris <haskell@tmorris.net> @tonymorris":
-        - validation < 0 # 1.1.2 https://github.com/commercialhaskell/stackage/issues/6915
+        - validation #< 0 # 1.1.2 https://github.com/commercialhaskell/stackage/issues/6915
 
     "Tony Day <tonyday567@gmail.com> @tonyday567":
         - numhask
@@ -4598,7 +4600,7 @@ packages:
 
     "Brandon Chinn <brandonchinn178@gmail.com> @brandonchinn178":
         - aeson-schemas
-        - fourmolu < 0.12 # https://github.com/commercialhaskell/stackage/issues/6949
+        - fourmolu
         - github-rest
         - graphql-client
         - hpc-lcov
@@ -5035,6 +5037,7 @@ packages:
         - QuickCheck
         - RSA
         - Stream
+        - TypeCompose
         - Yampa
         - accelerate-io-bmp
         - accelerate-io-bytestring
@@ -5237,7 +5240,7 @@ packages:
         - hsp
         - hspec-attoparsec
         - hspec-contrib
-        - hspec-expectations < 0.8.3  # https://github.com/commercialhaskell/stackage/issues/6991
+        - hspec-expectations
         - hspec-expectations-lifted
         - hspec-meta
         - hspec-smallcheck
@@ -5342,7 +5345,7 @@ packages:
         - operational
         - optional-args
         - options
-        - optparse-applicative < 0.18.0.0 # https://github.com/commercialhaskell/stackage/issues/6986
+        - optparse-applicative
         - parallel
         - path-pieces
         - pcg-random
@@ -5799,8 +5802,14 @@ packages:
     # for compilation failures as we need to build those packages to
     # verify if they have been fixeq.
     "Library and exe bounds failures":
+        - ALUT < 0 # tried ALUT-2.4.0.3, but its *library* requires the disabled package: OpenAL
+        - ALUT < 0 # tried ALUT-2.4.0.3, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - Allure < 0 # tried Allure-0.11.0.0, but its *library* requires the disabled package: hsini
+        - BNFC < 0 # tried BNFC-2.9.4.1, but its *library* requires the disabled package: happy
         - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
+        - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: streaming
+        - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: streaming-bytestring
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.4.0
         - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: Taxonomy
         - BiobaseNewick < 0 # tried BiobaseNewick-0.0.0.2, but its *library* requires ForestStructures ==0.0.0.* and the snapshot contains ForestStructures-0.0.1.1
@@ -5808,50 +5817,80 @@ packages:
         - BiobaseXNA < 0 # tried BiobaseXNA-0.11.1.1, but its *library* requires the disabled package: PrimitiveArray
         - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires network ==2.8.0.0 and the snapshot contains network-3.1.4.0
         - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseBlast
-        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseFasta
         - ChannelT < 0 # tried ChannelT-0.0.0.7, but its *library* requires mmorph >=1.0.5 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - ChannelT < 0 # tried ChannelT-0.0.0.7, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - Chart < 0 # tried Chart-1.9.4, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - Chart-cairo < 0 # tried Chart-cairo-1.9.3, but its *library* requires lens >=3.9 && < 5.2 and the snapshot contains lens-5.2.2
+        - Chart-diagrams < 0 # tried Chart-diagrams-1.9.4, but its *library* requires the disabled package: Chart
+        - Chart-diagrams < 0 # tried Chart-diagrams-1.9.4, but its *library* requires the disabled package: diagrams-postscript
+        - ChasingBottoms < 0 # tried ChasingBottoms-1.3.1.12, but its *library* requires mtl >=2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - DPutils < 0 # tried DPutils-0.1.1.0, but its *library* requires the disabled package: streaming
+        - DPutils < 0 # tried DPutils-0.1.1.0, but its *library* requires the disabled package: streaming-bytestring
         - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
-        - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.17.1.0
-        - Frames < 0 # tried Frames-0.7.3, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
-        - Frames < 0 # tried Frames-0.7.3, but its *library* requires ghc-prim >=0.3 && < 0.9 and the snapshot contains ghc-prim-0.9.0
+        - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.18.0.0
+        - Frames < 0 # tried Frames-0.7.3, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
+        - Frames < 0 # tried Frames-0.7.3, but its *library* requires ghc-prim >=0.3 && < 0.9 and the snapshot contains ghc-prim-0.10.0
         - Frames < 0 # tried Frames-0.7.3, but its *library* requires primitive >=0.6 && < 0.8 and the snapshot contains primitive-0.8.0.0
+        - GLUT < 0 # tried GLUT-2.7.0.16, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.22
+        - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
-        - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires base >=4.11.0 && < 4.17 and the snapshot contains base-4.17.1.0
-        - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - H < 0 # tried H-1.0.0, but its *executable* requires the disabled package: inline-r
+        - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires base >=4.11.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - HMock < 0 # tried HMock-0.5.1.0, but its *library* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - HasBigDecimal < 0 # tried HasBigDecimal-0.2.0.0, but its *executable* requires the disabled package: criterion
+        - HaskellNet < 0 # tried HaskellNet-0.6.1.2, but its *library* requires base >=4.3 && < 4.18 and the snapshot contains base-4.18.0.0
+        - HaskellNet < 0 # tried HaskellNet-0.6.1.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - HaskellNet-SSL < 0 # tried HaskellNet-SSL-0.3.4.4, but its *library* requires the disabled package: HaskellNet
+        - HaskellNet-SSL < 0 # tried HaskellNet-SSL-0.3.4.4, but its *library* requires the disabled package: connection
         - Hoed < 0 # tried Hoed-0.5.1, but its *library* requires the disabled package: regex-tdfa-text
         - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires fast-logger >=2.4.8 && < 3.1 and the snapshot contains fast-logger-3.2.1
-        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *executable* requires wai-logger >=2.2.7 && < 2.4 and the snapshot contains wai-logger-2.4.0
         - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires aeson ==2.0.* and the snapshot contains aeson-2.1.2.1
+        - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - IPv6DB < 0 # tried IPv6DB-0.3.3, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.0.0
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.2.0
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires text-show >=3.7 && < 3.9 and the snapshot contains text-show-3.10.3
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *executable* requires optparse-applicative >=0.14.3 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - LambdaHack < 0 # tried LambdaHack-0.11.0.0, but its *library* requires the disabled package: hsini
+        - LambdaHack < 0 # tried LambdaHack-0.11.0.0, but its *library* requires the disabled package: vector-binary-instances
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: TCache
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: Workflow
-        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* requires base >=4.9.1 && < 4.15 and the snapshot contains base-4.17.1.0
-        - NanoID < 0 # tried NanoID-3.3.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.1.0
-        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.1.0
+        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* requires base >=4.9.1 && < 4.15 and the snapshot contains base-4.18.0.0
+        - NanoID < 0 # tried NanoID-3.3.0, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - NanoID < 0 # tried NanoID-3.3.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.0.0
+        - Network-NineP < 0 # tried Network-NineP-0.4.7.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - Network-NineP < 0 # tried Network-NineP-0.4.7.2, but its *library* requires transformers >=0.3.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.0.0
+        - OpenAL < 0 # tried OpenAL-1.7.0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseFasta ==0.3.0.* and the snapshot contains BiobaseFasta-0.4.0.1
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseHTTP ==1.1.0 and the snapshot contains BiobaseHTTP-1.2.0
+        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseTypes ==0.2.0.* and the snapshot contains BiobaseTypes-0.2.1.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires aeson < =1.4.2.0 and the snapshot contains aeson-2.1.2.1
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.1.4.0
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseFasta
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseHTTP
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseTypes
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: hierarchical-clustering
+        - SciBaseTypes < 0 # tried SciBaseTypes-0.1.1.0, but its *library* requires the disabled package: DPutils
+        - ShellCheck < 0 # tried ShellCheck-0.9.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ShellCheck < 0 # tried ShellCheck-0.9.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
-        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* requires base >4.4 && < 4.14 and the snapshot contains base-4.17.1.0
-        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
+        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* requires base >4.4 && < 4.14 and the snapshot contains base-4.18.0.0
+        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires lens >=4.16 && < 4.20 and the snapshot contains lens-5.2.2
-        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* requires base >=4.12 && < 4.15 and the snapshot contains base-4.17.1.0
+        - TypeCompose < 0 # tried TypeCompose-0.9.14, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.0.0
+        - abstract-deque-tests < 0 # tried abstract-deque-tests-0.3, but its *library* requires the disabled package: test-framework
+        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* requires base >=4.12 && < 4.15 and the snapshot contains base-4.18.0.0
         - accelerate-arithmetic < 0 # tried accelerate-arithmetic-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
         - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate
         - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm
@@ -5868,11 +5907,13 @@ packages:
         - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-native
         - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-ptx
         - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: fclabels
+        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: test-framework
         - accelerate-fft < 0 # tried accelerate-fft-1.3.0.0, but its *library* requires the disabled package: cuda
         - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
         - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate-io >=1.0 && < 1.1 and the snapshot contains accelerate-io-1.3.0.0
         - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
         - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
+        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - accelerate-io < 0 # tried accelerate-io-1.3.0.0, but its *library* requires the disabled package: accelerate
         - accelerate-io-bmp < 0 # tried accelerate-io-bmp-0.1.0.0, but its *library* requires the disabled package: accelerate
         - accelerate-io-bytestring < 0 # tried accelerate-io-bytestring-0.1.0.0, but its *library* requires the disabled package: accelerate
@@ -5885,16 +5926,25 @@ packages:
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: cuda
         - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
         - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
+        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.4, but its *library* requires the disabled package: servant
+        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.4, but its *library* requires the disabled package: servant-client
+        - advent-of-code-api < 0 # tried advent-of-code-api-0.2.8.4, but its *library* requires the disabled package: servant-client-core
         - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires aeson >=0.7 && < 1.6 || >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - aeson-default < 0 # tried aeson-default-0.9.1.0, but its *library* requires aeson >=1.2 && < 2 and the snapshot contains aeson-2.1.2.1
         - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires aeson >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.1.0
+        - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.0.0
         - aeson-injector < 0 # tried aeson-injector-1.2.0.0, but its *library* requires lens >=4.13 && < 5.2 and the snapshot contains lens-5.2.2
         - airship < 0 # tried airship-0.9.5, but its *library* requires mime-types >=0.1.0 && < 0.1.1 and the snapshot contains mime-types-0.1.1.0
+        - airship < 0 # tried airship-0.9.5, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - al < 0 # tried al-0.1.4.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - alerts < 0 # tried alerts-0.1.2.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
-        - alg < 0 # tried alg-0.2.13.1, but its *library* requires base >=4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - alg < 0 # tried alg-0.2.13.1, but its *library* requires base >=4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: util
+        - algebra < 0 # tried algebra-4.3.1, but its *library* requires mtl >=2.0.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - algebra < 0 # tried algebra-4.3.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - algebra < 0 # tried algebra-4.3.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - amazonka < 0 # tried amazonka-1.6.1, but its *library* requires http-client >=0.4 && < 0.7 and the snapshot contains http-client-0.7.13.1
         - amazonka < 0 # tried amazonka-1.6.1, but its *library* requires unliftio-core >=0.1 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
         - amazonka-apigateway < 0 # tried amazonka-apigateway-1.6.1, but its *library* requires the disabled package: amazonka-core
@@ -5987,10 +6037,13 @@ packages:
         - amazonka-waf < 0 # tried amazonka-waf-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-workspaces < 0 # tried amazonka-workspaces-1.6.1, but its *library* requires the disabled package: amazonka-core
         - amazonka-xray < 0 # tried amazonka-xray-1.6.1, but its *library* requires the disabled package: amazonka-core
+        - amqp < 0 # tried amqp-0.22.1, but its *library* requires the disabled package: connection
+        - amqp-utils < 0 # tried amqp-utils-0.6.3.2, but its *executable* requires the disabled package: connection
+        - amqp-utils < 0 # tried amqp-utils-0.6.3.2, but its *executable* requires the disabled package: filepath-bytestring
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-0.11.5
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.17.1.0
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-1.0
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.0.0
         - antiope-core < 0 # tried antiope-core-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-core < 0 # tried antiope-core-7.5.3, but its *library* requires the disabled package: amazonka-core
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka
@@ -6003,47 +6056,78 @@ packages:
         - antiope-sns < 0 # tried antiope-sns-7.5.3, but its *library* requires the disabled package: amazonka-core
         - antiope-sqs < 0 # tried antiope-sqs-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-sqs < 0 # tried antiope-sqs-7.5.3, but its *library* requires the disabled package: amazonka-core
+        - apecs < 0 # tried apecs-0.9.5, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - apecs-gloss < 0 # tried apecs-gloss-0.2.4, but its *library* requires the disabled package: apecs-physics
+        - api-maker < 0 # tried api-maker-0.1.0.6, but its *library* requires the disabled package: req
+        - app-settings < 0 # tried app-settings-0.2.0.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires lens >=4.16 && < 5 and the snapshot contains lens-5.2.2
-        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires optparse-applicative >=0.14 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
+        - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires optparse-applicative >=0.14 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - arbor-postgres < 0 # tried arbor-postgres-0.0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - arbtt < 0 # tried arbtt-0.12.0.1, but its *executable* requires the disabled package: bytestring-progress
+        - arbtt < 0 # tried arbtt-0.12.0.1, but its *executable* requires the disabled package: tz
         - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires haskell-src-exts >=1.22.0 && < 1.23 and the snapshot contains haskell-src-exts-1.23.1
-        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires template-haskell >=2.14.0 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires template-haskell >=2.14.0 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - arrowp-qq < 0 # tried arrowp-qq-0.3.0, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - ascii < 0 # tried ascii-1.7.0.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-case < 0 # tried ascii-case-1.0.1.2, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-caseless < 0 # tried ascii-caseless-0.0.0.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-group < 0 # tried ascii-group-1.0.0.15, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-numbers < 0 # tried ascii-numbers-1.2.0.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-predicates < 0 # tried ascii-predicates-1.0.1.2, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-superset < 0 # tried ascii-superset-1.3.0.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-th < 0 # tried ascii-th-1.2.0.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ascii-th < 0 # tried ascii-th-1.2.0.0, but its *library* requires template-haskell ^>=2.16 || ^>=2.17 || ^>=2.18 || ^>=2.19 and the snapshot contains template-haskell-2.20.0.0
+        - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - assert-failure < 0 # tried assert-failure-0.1.2.6, but its *library* requires the disabled package: pretty-show
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* requires unliftio-core >=0.1.1.0 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
+        - atom-conduit < 0 # tried atom-conduit-0.9.0.1, but its *library* requires the disabled package: relude
         - aur < 0 # tried aur-7.0.7, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - aura < 0 # tried aura-3.2.9, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - aura < 0 # tried aura-3.2.9, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.1.2.1
         - aura < 0 # tried aura-3.2.9, but its *library* requires algebraic-graphs >=0.1 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - aura < 0 # tried aura-3.2.9, but its *library* requires time >=1.8 && < 1.12 and the snapshot contains time-1.12.2
+        - aura < 0 # tried aura-3.2.9, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - aura < 0 # tried aura-3.2.9, but its *library* requires unix ^>=2.7.2.2 and the snapshot contains unix-2.8.1.0
         - aura < 0 # tried aura-3.2.9, but its *library* requires versions ^>=5 and the snapshot contains versions-6.0.1
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires MonadRandom >=0.4.2.3 && < 0.6 and the snapshot contains MonadRandom-0.6
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires aeson >=1.1.2.1 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - avers < 0 # tried avers-0.0.17.1, but its *library* requires base >=4.9.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires base >=4.9.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires cryptonite >=0.21 && < 0.29 and the snapshot contains cryptonite-0.30
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires memory >=0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
-        - avers < 0 # tried avers-0.0.17.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - avers < 0 # tried avers-0.0.17.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
         - avers < 0 # tried avers-0.0.17.1, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.0.0
         - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: avers
+        - avers-api < 0 # tried avers-api-0.1.0, but its *library* requires the disabled package: servant
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: avers
         - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: bytestring-conversion
+        - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: servant
+        - avers-server < 0 # tried avers-server-0.1.0.1, but its *library* requires the disabled package: servant-server
+        - avro < 0 # tried avro-0.6.1.2, but its *library* requires the disabled package: HasBigDecimal
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires lens >=4.1 && < 5 and the snapshot contains lens-5.2.2
         - avwx < 0 # tried avwx-0.3.0.3, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
-        - axel < 0 # tried axel-0.0.12, but its *library* requires base >=4.12 && < 4.13 and the snapshot contains base-4.17.1.0
+        - aws < 0 # tried aws-0.24, but its *library* requires resourcet >=1.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - aws < 0 # tried aws-0.24, but its *library* requires transformers >=0.2.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - aws-lambda-haskell-runtime < 0 # tried aws-lambda-haskell-runtime-4.1.2, but its *library* requires the disabled package: safe-exceptions-checked
+        - aws-lambda-haskell-runtime-wai < 0 # tried aws-lambda-haskell-runtime-wai-2.0.2, but its *library* requires the disabled package: aws-lambda-haskell-runtime
+        - aws-xray-client-persistent < 0 # tried aws-xray-client-persistent-0.1.0.5, but its *library* requires the disabled package: persistent
+        - axel < 0 # tried axel-0.0.12, but its *library* requires base >=4.12 && < 4.13 and the snapshot contains base-4.18.0.0
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient-universe
         - b9 < 0 # tried b9-3.2.3, but its *library* requires aeson ==1.4.* and the snapshot contains aeson-2.1.2.1
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires hspec ==2.7.* and the snapshot contains hspec-2.10.10
+        - b9 < 0 # tried b9-3.2.3, but its *library* requires hspec ==2.7.* and the snapshot contains hspec-2.11.1
         - b9 < 0 # tried b9-3.2.3, but its *library* requires lens ==4.* and the snapshot contains lens-5.2.2
         - b9 < 0 # tried b9-3.2.3, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
         - barrier < 0 # tried barrier-0.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - barrier < 0 # tried barrier-0.1.1, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
-        - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* requires base ==4.13.0.0 and the snapshot contains base-4.17.1.0
+        - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* requires base ==4.13.0.0 and the snapshot contains base-4.18.0.0
+        - base16 < 0 # tried base16-0.3.2.1, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.0.0
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.4.0
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires lens >=4 && < 5.1 and the snapshot contains lens-5.2.2
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
@@ -6051,29 +6135,52 @@ packages:
         - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.4.0
         - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.2
         - base32-lens < 0 # tried base32-lens-0.1.1.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
-        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires base >=4.14 && < 4.17 and the snapshot contains base-4.17.1.0
+        - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires base >=4.14 && < 4.17 and the snapshot contains base-4.18.0.0
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires bytestring ^>=0.10 and the snapshot contains bytestring-0.11.4.0
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.2
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
+        - bcp47 < 0 # tried bcp47-0.2.0.6, but its *library* requires the disabled package: country
+        - bcp47-orphans < 0 # tried bcp47-orphans-0.1.0.6, but its *library* requires the disabled package: persistent
+        - beam-core < 0 # tried beam-core-0.10.0.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
+        - beam-core < 0 # tried beam-core-0.10.0.0, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - beam-core < 0 # tried beam-core-0.10.0.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - beam-core < 0 # tried beam-core-0.10.0.0, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - beam-migrate < 0 # tried beam-migrate-0.5.2.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
+        - beam-migrate < 0 # tried beam-migrate-0.5.2.0, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - beam-migrate < 0 # tried beam-migrate-0.5.2.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - beam-migrate < 0 # tried beam-migrate-0.5.2.0, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires beam-core >=0.8 && < 0.9 and the snapshot contains beam-core-0.10.0.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires hashable >=1.1 && < 1.3 and the snapshot contains hashable-1.4.2.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mysql >=0.1 && < 0.2 and the snapshot contains mysql-0.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
+        - beam-postgres < 0 # tried beam-postgres-0.5.3.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - beam-postgres < 0 # tried beam-postgres-0.5.3.0, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires the disabled package: beam-core
-        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires the disabled package: beam-migrate
-        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
+        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
+        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - beam-sqlite < 0 # tried beam-sqlite-0.5.2.0, but its *library* requires unix >=2.0 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - bech32 < 0 # tried bech32-1.1.3, but its *executable* requires optparse-applicative >=0.17.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bech32-th < 0 # tried bech32-th-1.1.1, but its *library* requires the disabled package: bech32
+        - bench < 0 # tried bench-1.0.12, but its *executable* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires optparse-applicative >=0.14.2 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.17.1.0
+        - bhoogle < 0 # tried bhoogle-0.1.4.2, but its *executable* requires the disabled package: hoogle
+        - bimaps < 0 # tried bimaps-0.1.0.2, but its *library* requires the disabled package: vector-binary-instances
+        - binance-exports < 0 # tried binance-exports-0.1.1.0, but its *library* requires the disabled package: req
+        - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.18.0.0
+        - binary-instances < 0 # tried binary-instances-1.0.4, but its *library* requires the disabled package: vector-binary-instances
+        - binary-list < 0 # tried binary-list-1.1.1.2, but its *library* requires the disabled package: phantom-state
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
         - bioalign < 0 # tried bioalign-0.0.5, but its *library* requires the disabled package: biocore
-        - biocore < 0 # tried biocore-0.3.1, but its *library* requires base >=3 && < 4.11 and the snapshot contains base-4.17.1.0
+        - biocore < 0 # tried biocore-0.3.1, but its *library* requires base >=3 && < 4.11 and the snapshot contains base-4.18.0.0
         - biofasta < 0 # tried biofasta-0.0.3, but its *library* requires the disabled package: biocore
         - biofastq < 0 # tried biofastq-0.1, but its *library* requires the disabled package: biocore
         - biopsl < 0 # tried biopsl-0.4, but its *library* requires the disabled package: biocore
@@ -6082,121 +6189,180 @@ packages:
         - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-api
         - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-block
         - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-tx
+        - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: stm-conduit
         - bitcoin-block < 0 # tried bitcoin-block-0.13.1, but its *library* requires the disabled package: hexstring
         - bitcoin-tx < 0 # tried bitcoin-tx-0.13.1, but its *library* requires the disabled package: bitcoin-script
         - bitcoin-tx < 0 # tried bitcoin-tx-0.13.1, but its *library* requires the disabled package: hexstring
         - bitcoin-types < 0 # tried bitcoin-types-0.9.2, but its *library* requires the disabled package: hexstring
+        - bits-extra < 0 # tried bits-extra-0.0.2.3, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
         - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
-        - bloomfilter < 0 # tried bloomfilter-2.0.1.0, but its *library* requires base >=4.4 && < 4.16 and the snapshot contains base-4.17.1.0
+        - bloomfilter < 0 # tried bloomfilter-2.0.1.0, but its *library* requires base >=4.4 && < 4.16 and the snapshot contains base-4.18.0.0
+        - bm < 0 # tried bm-0.2.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - bnb-staking-csvs < 0 # tried bnb-staking-csvs-0.2.1.0, but its *library* requires the disabled package: req
+        - board-games < 0 # tried board-games-0.4, but its *library* requires the disabled package: cgi
         - bookkeeping < 0 # tried bookkeeping-0.4.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
-        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.17.1.0
+        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.18.0.0
+        - boots < 0 # tried boots-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - both < 0 # tried both-0.1.1.2, but its *library* requires the disabled package: zero
         - bower-json < 0 # tried bower-json-1.1.0.0, but its *library* requires the disabled package: aeson-better-errors
+        - box < 0 # tried box-0.9.1, but its *library* requires semigroupoids ^>=5.3 and the snapshot contains semigroupoids-6.0.0.1
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires box ^>=0.8 and the snapshot contains box-0.9.1
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
         - box-csv < 0 # tried box-csv-0.2.0, but its *library* requires time ^>=1.9 and the snapshot contains time-1.12.2
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires aeson ^>=2.0.1 and the snapshot contains aeson-2.1.2.1
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires base ^>=4.15.0 and the snapshot contains base-4.17.1.0
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires base ^>=4.15.0 and the snapshot contains base-4.18.0.0
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires bytestring ^>=0.10.12 and the snapshot contains bytestring-0.11.4.0
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc ^>=9.0.1 and the snapshot contains ghc-9.4.5
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot ^>=9.0.1 and the snapshot contains ghc-boot-9.4.5
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot-th ^>=9.0.1 and the snapshot contains ghc-boot-th-9.4.5
-        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-exactprint ^>=0.6.4 and the snapshot contains ghc-exactprint-1.6.1.3
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc ^>=9.0.1 and the snapshot contains ghc-9.6.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot ^>=9.0.1 and the snapshot contains ghc-boot-9.6.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-boot-th ^>=9.0.1 and the snapshot contains ghc-boot-th-9.6.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires ghc-exactprint ^>=0.6.4 and the snapshot contains ghc-exactprint-1.7.0.1
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires semigroups ^>=0.19.2 and the snapshot contains semigroups-0.20
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires strict ^>=0.4.0 and the snapshot contains strict-0.5
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires text ^>=1.2.5 and the snapshot contains text-2.0.2
+        - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires transformers ^>=0.5.6 and the snapshot contains transformers-0.6.1.0
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
+        - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
-        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires bifunctors < 5.6 and the snapshot contains bifunctors-5.6.1
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires free < 5.2 and the snapshot contains free-5.2
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - butcher < 0 # tried butcher-1.3.3.2, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires aeson >=1.5.5.1 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
-        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.3
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.4
+        - bytebuild < 0 # tried bytebuild-0.3.13.0, but its *library* requires base >=4.12.0.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - bytestring-conversion < 0 # tried bytestring-conversion-0.3.2, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
         - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
-        - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires base >=4.3 && < 4.16 and the snapshot contains base-4.17.1.0
+        - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires base >=4.3 && < 4.16 and the snapshot contains base-4.18.0.0
         - bzlib < 0 # tried bzlib-0.5.1.0, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.4.0
+        - cabal-appimage < 0 # tried cabal-appimage-0.4.0.0, but its *library* requires Cabal >=2.4.1.0 && < 3.9 and the snapshot contains Cabal-3.10.1.0
+        - cabal-appimage < 0 # tried cabal-appimage-0.4.0.0, but its *library* requires base >=4.11.0.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.0.4, but its *executable* requires the disabled package: cabal-plan
+        - cabal2nix < 0 # tried cabal2nix-2.19.1, but its *executable* requires the disabled package: monad-par
+        - cache < 0 # tried cache-0.1.3.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - cairo < 0 # tried cairo-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
+        - capability < 0 # tried capability-0.5.0.1, but its *library* requires the disabled package: streaming
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.2
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.2
+        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.3.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.2
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.2
+        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.3.0
         - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.2
+        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.3.0
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.0.2
+        - casa-client < 0 # tried casa-client-0.0.1, but its *library* requires the disabled package: casa-types
+        - casa-types < 0 # tried casa-types-0.0.2, but its *library* requires the disabled package: persistent
+        - cassava-conduit < 0 # tried cassava-conduit-0.6.2, but its *library* requires mtl ==2.2.* and the snapshot contains mtl-2.3.1
         - caster < 0 # tried caster-0.0.3.0, but its *library* requires the disabled package: fast-builder
-        - category < 0 # tried category-0.2.5.0, but its *library* requires base >=4.10 && < 4.15 and the snapshot contains base-4.17.1.0
+        - category < 0 # tried category-0.2.5.0, but its *library* requires base >=4.10 && < 4.15 and the snapshot contains base-4.18.0.0
+        - category < 0 # tried category-0.2.5.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - cayley-client < 0 # tried cayley-client-0.4.19.2, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - cborg-json < 0 # tried cborg-json-0.2.5.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
+        - cereal-conduit < 0 # tried cereal-conduit-0.8.0, but its *library* requires resourcet >=1.2 && < 1.3 and the snapshot contains resourcet-1.3.0
         - cereal-time < 0 # tried cereal-time-0.1.0.0, but its *library* requires time >=1.5 && < 1.8.1 and the snapshot contains time-1.12.2
+        - cgi < 0 # tried cgi-3001.5.0.1, but its *library* requires mtl >2.2.0.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - chart-svg < 0 # tried chart-svg-0.4.0, but its *library* requires the disabled package: cubicbezier
         - chart-svg < 0 # tried chart-svg-0.4.0, but its *library* requires the disabled package: numhask-space
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson-casing >=0.1.0.5 && < 0.2 and the snapshot contains aeson-casing-0.2.0.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5.1
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires req >=1.0.0 && < 1.3.0 and the snapshot contains req-3.13.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
+        - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires text >=0.9 && < 1.3 and the snapshot contains text-2.0.2
         - cheapskate-highlight < 0 # tried cheapskate-highlight-0.1.0.0, but its *library* requires the disabled package: cheapskate
         - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
+        - check-email < 0 # tried check-email-1.0.2, but its *library* requires the disabled package: email-validate
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.2.0
-        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.17.1.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.5
+        - chronos < 0 # tried chronos-1.1.5, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.0.0
+        - chronos-bench < 0 # tried chronos-bench-0.2.0.2, but its *library* requires the disabled package: chronos
+        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.18.0.0
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.6.2
         - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-boot >=8.6.0 && < 9.1 and the snapshot contains ghc-boot-9.4.5
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-prim >=0.3.1.0 && < 0.8 and the snapshot contains ghc-prim-0.9.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghci >=8.6.0 && < 9.1 and the snapshot contains ghci-9.4.5
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-boot >=8.6.0 && < 9.1 and the snapshot contains ghc-boot-9.6.2
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghc-prim >=0.3.1.0 && < 0.8 and the snapshot contains ghc-prim-0.10.0
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires ghci >=8.6.0 && < 9.1 and the snapshot contains ghci-9.6.2
         - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires lens >=4.10 && < 5.2.0 and the snapshot contains lens-5.2.2
-        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires mtl >=2.1.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - clash-ghc < 0 # tried clash-ghc-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires aeson >=0.6.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.4.5
+        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ansi-terminal >=0.8.0.0 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.6.2
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
         - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires lens >=4.10 && < 5.2.0 and the snapshot contains lens-5.2.2
-        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - clash-lib < 0 # tried clash-lib-1.6.4, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
         - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires ghc-prim >=0.5.1.0 && < 0.8 and the snapshot contains ghc-prim-0.9.0
+        - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires ghc-prim >=0.5.1.0 && < 0.8 and the snapshot contains ghc-prim-0.10.0
         - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires lens >=4.10 && < 5.2.0 and the snapshot contains lens-5.2.2
-        - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires template-haskell >=2.12.0.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
-        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.17.1.0
-        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
-        - clay < 0 # tried clay-0.14.0, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.17.1.0
-        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
-        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.4.5
+        - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires template-haskell >=2.12.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
+        - clash-prelude < 0 # tried clash-prelude-1.6.4, but its *library* requires th-abstraction >=0.2.10 && < 0.5.0 and the snapshot contains th-abstraction-0.5.0.0
+        - classy-prelude-yesod < 0 # tried classy-prelude-yesod-1.5.0, but its *library* requires the disabled package: persistent
+        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.0.0
+        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - clay < 0 # tried clay-0.14.0, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.18.0.0
+        - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires base >=4.12 && < 4.18 and the snapshot contains base-4.18.0.0
+        - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
+        - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.6.2
         - climb < 0 # tried climb-0.4.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* requires clock >=0.4.6 && < 0.8.0 and the snapshot contains clock-0.8.3
+        - closed < 0 # tried closed-0.2.0.2, but its *library* requires the disabled package: persistent
         - cmark < 0 # tried cmark-0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark ==0.5.* and the snapshot contains cmark-0.6
         - cmark-lucid < 0 # tried cmark-lucid-0.1.0.0, but its *library* requires the disabled package: cmark
+        - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires base >=4.10.1.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
+        - cointracking-imports < 0 # tried cointracking-imports-0.1.0.2, but its *library* requires the disabled package: xlsx
         - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
-        - compact < 0 # tried compact-0.2.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.17.1.0
+        - colourista < 0 # tried colourista-0.1.0.2, but its *library* requires ansi-terminal >=0.10 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - colourista < 0 # tried colourista-0.1.0.2, but its *library* requires base >=4.10.1.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - compact < 0 # tried compact-0.2.0.0, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.18.0.0
         - compact < 0 # tried compact-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - componentm < 0 # tried componentm-0.0.0.2, but its *library* requires the disabled package: pretty-show
+        - componentm-devel < 0 # tried componentm-devel-0.0.0.2, but its *library* requires the disabled package: componentm
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires aeson >=1.1.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires lens >=4.15.4 && < 5.2 and the snapshot contains lens-5.2.2
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires time >=1.6.0.1 && < 1.12 and the snapshot contains time-1.12.2
         - composite-aeson < 0 # tried composite-aeson-0.8.2.1, but its *library* requires vector >=0.12.0.1 && < 0.13 and the snapshot contains vector-0.13.0.0
         - composite-aeson-path < 0 # tried composite-aeson-path-0.8.2.1, but its *library* requires path >=0.6 && < 0.9 and the snapshot contains path-0.9.2
+        - composite-aeson-refined < 0 # tried composite-aeson-refined-0.8.2.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - composite-aeson-refined < 0 # tried composite-aeson-refined-0.8.2.1, but its *library* requires refined >=0.1.2.1 && < 0.7 and the snapshot contains refined-0.8.1
         - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: aeson-better-errors
         - composite-aeson-throw < 0 # tried composite-aeson-throw-0.1.0.0, but its *library* requires the disabled package: composite-aeson
         - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires lens >=4.15.4 && < 5.2 and the snapshot contains lens-5.2.2
-        - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires template-haskell >=2.11.1.0 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
+        - composite-base < 0 # tried composite-base-0.8.2.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - composite-binary < 0 # tried composite-binary-0.8.2.1, but its *library* requires the disabled package: composite-base
         - composite-ekg < 0 # tried composite-ekg-0.8.2.1, but its *library* requires lens >=4.15.4 && < 5.2 and the snapshot contains lens-5.2.2
         - composite-ekg < 0 # tried composite-ekg-0.8.2.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
@@ -6205,124 +6371,214 @@ packages:
         - composite-xstep < 0 # tried composite-xstep-0.1.0.0, but its *library* requires the disabled package: composite-base
         - compressed < 0 # tried compressed-3.11, but its *library* requires containers >=0.3 && < 0.6 and the snapshot contains containers-0.6.7
         - compressed < 0 # tried compressed-3.11, but its *library* requires hashable >=1.1.2.1 && < 1.3 and the snapshot contains hashable-1.4.2.0
+        - compressed < 0 # tried compressed-3.11, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - concurrency < 0 # tried concurrency-1.11.0.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - concurrency < 0 # tried concurrency-1.11.0.2, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - concurrent-supply < 0 # tried concurrent-supply-0.1.8, but its *library* requires hashable >=1.1 && < 1.4 and the snapshot contains hashable-1.4.2.0
+        - conduino < 0 # tried conduino-0.2.2.0, but its *library* requires the disabled package: list-transformer
+        - conduit-algorithms < 0 # tried conduit-algorithms-0.0.13.0, but its *library* requires the disabled package: lzma-conduit
+        - conduit-algorithms < 0 # tried conduit-algorithms-0.0.13.0, but its *library* requires the disabled package: stm-conduit
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - conduit-throttle < 0 # tried conduit-throttle-0.3.1.0, but its *library* requires the disabled package: throttle-io-stream
         - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - confcrypt < 0 # tried confcrypt-0.2.3.3, but its *library* requires the disabled package: crypto-pubkey-openssh
-        - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* requires hspec-core >=2.0.0 && < 2.8.0 and the snapshot contains hspec-core-2.10.10
+        - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* requires hspec-core >=2.0.0 && < 2.8.0 and the snapshot contains hspec-core-2.11.1
         - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires conferer >=1.0.0.0 && < 1.1.0.0 and the snapshot contains conferer-1.1.0.0
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires the disabled package: snap-server
+        - configurator-pg < 0 # tried configurator-pg-0.2.7, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
         - configurator-pg < 0 # tried configurator-pg-0.2.7, but its *library* requires megaparsec >=7.0.0 && < 9.3 and the snapshot contains megaparsec-9.3.1
+        - connection < 0 # tried connection-0.3.1, but its *library* requires tls >=1.4 && < 1.7 and the snapshot contains tls-1.7.0
+        - console-style < 0 # tried console-style-0.0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
         - construct < 0 # tried construct-0.3.1.1, but its *library* requires rank2classes >=1 && < 1.5 and the snapshot contains rank2classes-1.5.1
         - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.7
+        - country < 0 # tried country-0.2.3.1, but its *library* requires the disabled package: bytebuild
+        - covariance < 0 # tried covariance-0.2.0.1, but its *library* requires the disabled package: statistics
+        - criterion < 0 # tried criterion-1.6.1.0, but its *library* requires the disabled package: statistics
+        - crypt-sha512 < 0 # tried crypt-sha512-0, but its *library* requires the disabled package: cryptohash-sha512
+        - crypto-api-tests < 0 # tried crypto-api-tests-0.3, but its *library* requires the disabled package: test-framework
+        - crypto-cipher-tests < 0 # tried crypto-cipher-tests-0.0.11, but its *library* requires the disabled package: test-framework
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-des
+        - cryptohash-sha512 < 0 # tried cryptohash-sha512-0.11.102.0, but its *library* requires base >=4.5 && < 4.18 and the snapshot contains base-4.18.0.0
         - csg < 0 # tried csg-0.1.0.6, but its *executable* requires turtle < 1.6 and the snapshot contains turtle-1.6.1
         - csg < 0 # tried csg-0.1.0.6, but its *library* requires QuickCheck < 2.13 and the snapshot contains QuickCheck-2.14.3
         - csg < 0 # tried csg-0.1.0.6, but its *library* requires attoparsec < 0.14 and the snapshot contains attoparsec-0.14.4
         - csg < 0 # tried csg-0.1.0.6, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.4.0
         - csg < 0 # tried csg-0.1.0.6, but its *library* requires simple-vec3 ==0.4.* and the snapshot contains simple-vec3-0.6.0.1
         - csg < 0 # tried csg-0.1.0.6, but its *library* requires strict < 0.4 and the snapshot contains strict-0.5
+        - csg < 0 # tried csg-0.1.0.6, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
+        - csv-conduit < 0 # tried csv-conduit-0.7.3.0, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - cubicbezier < 0 # tried cubicbezier-0.6.0.6, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - cublas < 0 # tried cublas-0.6.0.0, but its *library* requires the disabled package: cuda
         - cufft < 0 # tried cufft-0.10.0.0, but its *library* requires the disabled package: cuda
+        - curl-runnings < 0 # tried curl-runnings-0.17.0, but its *library* requires the disabled package: connection
+        - curl-runnings < 0 # tried curl-runnings-0.17.0, but its *library* requires the disabled package: dhall
+        - curl-runnings < 0 # tried curl-runnings-0.17.0, but its *library* requires the disabled package: dhall-json
         - currencies < 0 # tried currencies-0.2.0.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - currycarbon < 0 # tried currycarbon-0.2.1.1, but its *executable* requires optparse-applicative >=0.16 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - cusolver < 0 # tried cusolver-0.3.0.0, but its *library* requires the disabled package: cuda
         - cusparse < 0 # tried cusparse-0.3.0.0, but its *library* requires the disabled package: cuda
-        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
-        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires template-haskell >=2.9 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - darcs < 0 # tried darcs-2.16.5, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.8.1.0
+        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
+        - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires template-haskell >=2.9 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - d10 < 0 # tried d10-1.0.1.2, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - d10 < 0 # tried d10-1.0.1.2, but its *library* requires template-haskell ^>=2.16 || ^>=2.17 || ^>=2.18 || ^>=2.19 and the snapshot contains template-haskell-2.20.0.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.10.1.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires attoparsec >=0.13.0.1 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - darcs < 0 # tried darcs-2.16.5, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.17.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires base >=4.10 && < 4.16 and the snapshot contains base-4.18.0.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires bytestring >=0.10.6 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires constraints >=0.11 && < 0.13 and the snapshot contains constraints-0.13.4
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires cryptonite >=0.24 && < 0.30 and the snapshot contains cryptonite-0.30
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires fgl >=5.5.2.3 && < 5.8 and the snapshot contains fgl-5.8.0.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires hashable >=1.2.3.3 && < 1.4 and the snapshot contains hashable-1.4.2.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires memory >=0.14 && < 0.17 and the snapshot contains memory-0.18.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires regex-tdfa >=1.3.1.0 && < 1.3.2 and the snapshot contains regex-tdfa-1.3.2.1
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires text >=1.2.1.3 && < 1.3 and the snapshot contains text-2.0.2
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - darcs < 0 # tried darcs-2.16.5, but its *library* requires unix >=2.7.1.0 && < 2.8 and the snapshot contains unix-2.8.1.0
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires unix-compat >=0.5 && < 0.6 and the snapshot contains unix-compat-0.7
         - darcs < 0 # tried darcs-2.16.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - data-accessor-template < 0 # tried data-accessor-template-0.2.1.16, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - data-accessor-template < 0 # tried data-accessor-template-0.2.1.16, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - data-compat < 0 # tried data-compat-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.18 and the snapshot contains base-4.18.0.0
         - data-default-extra < 0 # tried data-default-extra-0.1.0, but its *library* requires the disabled package: data-default-instances-new-base
         - data-default-instances-text < 0 # tried data-default-instances-text-0.0.1, but its *library* requires text >=0.2 && < 2 and the snapshot contains text-2.0.2
-        - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
+        - data-forest < 0 # tried data-forest-0.1.0.10, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
+        - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: req
+        - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming
+        - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming-bytestring
         - datasets < 0 # tried datasets-0.4.0, but its *library* requires the disabled package: streaming-cassava
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - decidable < 0 # tried decidable-0.3.0.0, but its *library* requires the disabled package: functor-products
-        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
+        - dejafu < 0 # tried dejafu-2.4.0.4, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - dense-linear-algebra < 0 # tried dense-linear-algebra-0.1.0.0, but its *library* requires the disabled package: vector-binary-instances
         - dependent-sum-template < 0 # tried dependent-sum-template-0.1.1.1, but its *library* requires the disabled package: th-extras
+        - dhall < 0 # tried dhall-1.42.0, but its *library* requires ansi-terminal >=0.6.3.1 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - dhall < 0 # tried dhall-1.42.0, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - dhall < 0 # tried dhall-1.42.0, but its *library* requires template-haskell >=2.13.0.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - dhall < 0 # tried dhall-1.42.0, but its *library* requires unix-compat >=0.4.2 && < 0.7 and the snapshot contains unix-compat-0.7
+        - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *executable* requires the disabled package: optparse-generic
+        - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires the disabled package: dhall
+        - dhall-json < 0 # tried dhall-json-1.7.12, but its *executable* requires ansi-terminal >=0.6.3.1 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2.2
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires lsp >=1.2.0.0 && < 1.5 and the snapshot contains lsp-1.6.0.0
-        - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires dhall >=1.42 && < 1.43 and the snapshot contains dhall-1.41.2
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires transformers >=0.5.5.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires the disabled package: hnix
-        - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
+        - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *executable* requires ansi-terminal >=0.6.3.1 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - diagrams < 0 # tried diagrams-1.4.0.1, but its *library* requires the disabled package: diagrams-contrib
+        - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
         - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires base-orphans >=0.3 && < 0.9 and the snapshot contains base-orphans-0.9.0
-        - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires base >=4.2 && < 4.17 and the snapshot contains base-4.17.1.0
-        - diagrams-gtk < 0 # tried diagrams-gtk-1.4, but its *library* requires base >=4.2 && < 4.17 and the snapshot contains base-4.17.1.0
+        - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - diagrams-builder < 0 # tried diagrams-builder-0.8.0.5, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires base >=4.2 && < 4.17 and the snapshot contains base-4.18.0.0
+        - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - diagrams-cairo < 0 # tried diagrams-cairo-1.4.2, but its *library* requires unix >=2.4 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - diagrams-canvas < 0 # tried diagrams-canvas-1.4.1.1, but its *library* requires base >=4.6 && < 4.18 and the snapshot contains base-4.18.0.0
+        - diagrams-canvas < 0 # tried diagrams-canvas-1.4.1.1, but its *library* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - diagrams-contrib < 0 # tried diagrams-contrib-1.4.5, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.18.0.0
+        - diagrams-contrib < 0 # tried diagrams-contrib-1.4.5, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - diagrams-gtk < 0 # tried diagrams-gtk-1.4, but its *library* requires base >=4.2 && < 4.17 and the snapshot contains base-4.18.0.0
+        - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.0.0
+        - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires optparse-applicative >=0.10 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - diagrams-postscript < 0 # tried diagrams-postscript-1.5.1.1, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.18.0.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.17.1.0
+        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.18.0.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.1.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires attoparsec >=0.10.4.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.17.1.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.18.0.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires containers >=0.5.6.2 && < 0.6 and the snapshot contains containers-0.6.7
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires exceptions >=0.8.3 && < 0.9 and the snapshot contains exceptions-0.10.5
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires exceptions >=0.8.3 && < 0.9 and the snapshot contains exceptions-0.10.7
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
-        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.8.1.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires hashable >=1.2.0.5 && < 1.3 and the snapshot contains hashable-1.4.2.0
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
         - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires stm >=2.4 && < 2.5 and the snapshot contains stm-2.5.1.0
-        - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires the disabled package: distributed-process
+        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
+        - distribution-opensuse < 0 # tried distribution-opensuse-1.1.4, but its *library* requires the disabled package: turtle
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires text >=1.0.0 && < 2.0.0 and the snapshot contains text-2.0.2
+        - docker < 0 # tried docker-0.7.0.1, but its *library* requires tls >=1.3.7 && < 1.7.0 and the snapshot contains tls-1.7.0
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-12.1.0
-        - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
+        - dotenv < 0 # tried dotenv-0.11.0.0, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - download < 0 # tried download-0.3.2.7, but its *library* requires the disabled package: feed
+        - download-curl < 0 # tried download-curl-0.1.4, but its *library* requires the disabled package: feed
         - drawille < 0 # tried drawille-0.1.2.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
-        - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.17.1.0
+        - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.0.0
         - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.2
         - edit < 0 # tried edit-1.0.1.0, but its *library* requires QuickCheck >=2.10 && < 2.13 and the snapshot contains QuickCheck-2.14.3
-        - edit < 0 # tried edit-1.0.1.0, but its *library* requires base >=4.9 && < 4.12 and the snapshot contains base-4.17.1.0
-        - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* requires free >=4.9 && < 5 and the snapshot contains free-5.1.10
+        - edit < 0 # tried edit-1.0.1.0, but its *library* requires base >=4.9 && < 4.12 and the snapshot contains base-4.18.0.0
+        - edit < 0 # tried edit-1.0.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* requires free >=4.9 && < 5 and the snapshot contains free-5.2
         - egison < 0 # tried egison-4.1.3, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
+        - egison < 0 # tried egison-4.1.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - egison < 0 # tried egison-4.1.3, but its *library* requires vector ==0.12.* and the snapshot contains vector-0.13.0.0
+        - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* requires free >=5.0.1 && < 5.2 and the snapshot contains free-5.2
+        - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
         - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* requires parser-combinators >=1.0.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
         - egison-pattern-src < 0 # tried egison-pattern-src-0.2.1.2, but its *library* requires text >=0.1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires template-haskell >=2.2.0 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
+        - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires template-haskell >=2.2.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires text >=0.1.0 && < 1.3 and the snapshot contains text-2.0.2
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires aeson >=0.4 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.17.1.0
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.0.0
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires the disabled package: snap-server
         - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - ekg < 0 # tried ekg-0.4.0.15, but its *library* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.0
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: amazonka
         - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: amazonka-core
+        - ekg-cloudwatch < 0 # tried ekg-cloudwatch-0.0.1.6, but its *library* requires the disabled package: ekg-core
+        - ekg-core < 0 # tried ekg-core-0.1.1.7, but its *library* requires ghc-prim < 0.10 and the snapshot contains ghc-prim-0.10.0
         - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires aeson >=0.4 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.17.1.0
+        - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.0.0
         - ekg-json < 0 # tried ekg-json-0.1.0.6, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
-        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.17.1.0
+        - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.18.0.0
         - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
         - ekg-statsd < 0 # tried ekg-statsd-0.2.5.0, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - ekg-wai < 0 # tried ekg-wai-0.1.1.0, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - elliptic-curve < 0 # tried elliptic-curve-0.3.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
+        - elm-export < 0 # tried elm-export-0.6.0.1, but its *library* requires the disabled package: wl-pprint-text
+        - elm2nix < 0 # tried elm2nix-0.3.0, but its *library* requires the disabled package: here
+        - elm2nix < 0 # tried elm2nix-0.3.0, but its *library* requires the disabled package: req
+        - elynx < 0 # tried elynx-0.7.2.1, but its *executable* requires the disabled package: slynx
+        - elynx < 0 # tried elynx-0.7.2.1, but its *executable* requires the disabled package: tlynx
+        - elynx-markov < 0 # tried elynx-markov-0.7.2.1, but its *library* requires the disabled package: statistics
+        - elynx-tree < 0 # tried elynx-tree-0.7.2.1, but its *library* requires the disabled package: statistics
+        - emacs-module < 0 # tried emacs-module-0.1.1.1, but its *library* requires the disabled package: safe-exceptions-checked
+        - email-validate < 0 # tried email-validate-2.3.2.18, but its *library* requires template-haskell >=2.10.0.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: typelits-witnesses
         - epub-metadata < 0 # tried epub-metadata-4.5, but its *library* requires the disabled package: regex-compat-tdfa
-        - errata < 0 # tried errata-0.4.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
+        - errata < 0 # tried errata-0.4.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
+        - esqueleto < 0 # tried esqueleto-3.5.10.0, but its *library* requires the disabled package: persistent
         - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
         - essence-of-live-coding-pulse < 0 # tried essence-of-live-coding-pulse-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
         - essence-of-live-coding-quickcheck < 0 # tried essence-of-live-coding-quickcheck-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
@@ -6330,37 +6586,67 @@ packages:
         - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
         - event < 0 # tried event-0.1.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - event < 0 # tried event-0.1.4, but its *library* requires semigroups >=0.16 && < 0.19 and the snapshot contains semigroups-0.20
+        - event < 0 # tried event-0.1.4, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - eventful-core < 0 # tried eventful-core-0.2.0, but its *library* requires the disabled package: sum-type-boilerplate
         - eventful-dynamodb < 0 # tried eventful-dynamodb-0.2.0, but its *library* requires the disabled package: amazonka
         - eventful-dynamodb < 0 # tried eventful-dynamodb-0.2.0, but its *library* requires the disabled package: eventful-core
         - eventful-memory < 0 # tried eventful-memory-0.2.0, but its *library* requires the disabled package: eventful-core
         - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: eventful-core
         - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: eventful-sql-common
+        - eventful-postgresql < 0 # tried eventful-postgresql-0.2.0, but its *library* requires the disabled package: persistent
         - eventful-sql-common < 0 # tried eventful-sql-common-0.2.0, but its *library* requires persistent-template < 2.7 and the snapshot contains persistent-template-2.12.0.0
         - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: eventful-core
         - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: eventful-sql-common
+        - eventful-sqlite < 0 # tried eventful-sqlite-0.2.0, but its *library* requires the disabled package: persistent
         - eventful-test-helpers < 0 # tried eventful-test-helpers-0.2.0, but its *library* requires the disabled package: eventful-core
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-api
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
         - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
-        - fast-builder < 0 # tried fast-builder-0.1.3.0, but its *library* requires base >=4.8 && < 4.16 and the snapshot contains base-4.17.1.0
-        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.17.1.0
+        - eventstore < 0 # tried eventstore-1.4.2, but its *library* requires the disabled package: connection
+        - eventstore < 0 # tried eventstore-1.4.2, but its *library* requires the disabled package: streaming
+        - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.8, but its *library* requires template-haskell >=2.18 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - experimenter < 0 # tried experimenter-0.1.0.14, but its *library* requires the disabled package: persistent
+        - explainable-predicates < 0 # tried explainable-predicates-0.1.2.3, but its *library* requires base >=4.12.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - explainable-predicates < 0 # tried explainable-predicates-0.1.2.3, but its *library* requires template-haskell >=2.13.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - failable < 0 # tried failable-1.2.4.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - failable < 0 # tried failable-1.2.4.0, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - faktory < 0 # tried faktory-1.1.2.4, but its *library* requires the disabled package: connection
+        - fast-builder < 0 # tried fast-builder-0.1.3.0, but its *library* requires base >=4.8 && < 4.16 and the snapshot contains base-4.18.0.0
+        - fastmemo < 0 # tried fastmemo-0.1.1, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.0.0
+        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.18.0.0
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base-orphans >=0.8.2 && < 0.9 and the snapshot contains base-orphans-0.9.0
-        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires template-haskell >=2.2 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires mtl >=1.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires template-haskell >=2.2 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - feed < 0 # tried feed-1.3.2.1, but its *library* requires base >=4 && < 4.18 and the snapshot contains base-4.18.0.0
+        - feed < 0 # tried feed-1.3.2.1, but its *library* requires base-compat >=0.9 && < 0.13 and the snapshot contains base-compat-0.13.0
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires fsnotify ==0.3.* and the snapshot contains fsnotify-0.4.1.0
-        - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: BiobaseNewick
+        - filecache < 0 # tried filecache-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - filepath-bytestring < 0 # tried filepath-bytestring-1.4.2.1.12, but its *library* requires base >=4 && < 4.18 and the snapshot contains base-4.18.0.0
+        - filtrable < 0 # tried filtrable-0.1.6.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - find-clumpiness < 0 # tried find-clumpiness-0.2.3.2, but its *library* requires the disabled package: hierarchical-clustering
+        - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - flac < 0 # tried flac-0.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - flac-picture < 0 # tried flac-picture-0.1.2, but its *library* requires the disabled package: flac
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - flexible-defaults < 0 # tried flexible-defaults-0.0.3, but its *library* requires the disabled package: th-extras
-        - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
+        - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - force-layout < 0 # tried force-layout-0.4.0.6, but its *library* requires base >=4.2 && < 4.18 and the snapshot contains base-4.18.0.0
         - forma < 0 # tried forma-1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
-        - fortran-src < 0 # tried fortran-src-0.15.0, but its *library* requires the disabled package: vector-sized
-        - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires the disabled package: fortran-src
-        - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
-        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2
+        - fortran-src < 0 # tried fortran-src-0.15.0, but its *library* requires singletons-base >=3.0 && < 3.2 and the snapshot contains singletons-base-3.2
+        - fortran-src < 0 # tried fortran-src-0.15.0, but its *library* requires singletons-th >=3.0 && < 3.2 and the snapshot contains singletons-th-3.2
+        - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - fourmolu < 0 # tried fourmolu-0.13.0.0, but its *library* requires the disabled package: ghc-lib-parser
+        - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
+        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2.1
+        - ftp-client < 0 # tried ftp-client-0.5.1.4, but its *library* requires the disabled package: connection
+        - fusion-plugin < 0 # tried fusion-plugin-0.2.6, but its *library* requires ghc >=7.10.3 && < 9.5 and the snapshot contains ghc-9.6.2
         - fuzzyset < 0 # tried fuzzyset-0.2.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - fuzzyset < 0 # tried fuzzyset-0.2.3, but its *library* requires vector >=0.12.0.3 && < 0.13 and the snapshot contains vector-0.13.0.0
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
@@ -6369,34 +6655,91 @@ packages:
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires vector >=0.12.0 && < 0.13 and the snapshot contains vector-0.13.0.0
         - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: regex-tdfa-text
-        - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.17.1.0
+        - gdax < 0 # tried gdax-0.6.0.0, but its *library* requires the disabled package: wreq
+        - gemini-exports < 0 # tried gemini-exports-0.1.0.0, but its *library* requires the disabled package: req
+        - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.18.0.0
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.17.1.0
+        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.18.0.0
         - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires generic-deriving >=1.6 && < 1.14 and the snapshot contains generic-deriving-1.14.4
+        - geniplate-mirror < 0 # tried geniplate-mirror-0.7.9, but its *library* requires template-haskell < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - genvalidity-criterion < 0 # tried genvalidity-criterion-1.1.0.0, but its *library* requires the disabled package: criterion
+        - genvalidity-hspec < 0 # tried genvalidity-hspec-1.0.0.2, but its *library* requires the disabled package: genvalidity-property
+        - genvalidity-hspec-aeson < 0 # tried genvalidity-hspec-aeson-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
+        - genvalidity-hspec-binary < 0 # tried genvalidity-hspec-binary-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
+        - genvalidity-hspec-cereal < 0 # tried genvalidity-hspec-cereal-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
+        - genvalidity-hspec-hashable < 0 # tried genvalidity-hspec-hashable-1.0.0.0, but its *library* requires the disabled package: genvalidity-property
+        - genvalidity-hspec-optics < 0 # tried genvalidity-hspec-optics-1.0.0.0, but its *library* requires the disabled package: genvalidity-hspec
+        - genvalidity-hspec-persistent < 0 # tried genvalidity-hspec-persistent-1.0.0.0, but its *library* requires the disabled package: persistent
+        - genvalidity-persistent < 0 # tried genvalidity-persistent-1.0.0.1, but its *library* requires the disabled package: persistent
+        - genvalidity-property < 0 # tried genvalidity-property-1.0.0.0, but its *library* requires the disabled package: pretty-show
+        - genvalidity-sydtest < 0 # tried genvalidity-sydtest-1.0.0.0, but its *library* requires the disabled package: pretty-show
+        - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
+        - genvalidity-sydtest-aeson < 0 # tried genvalidity-sydtest-aeson-1.0.0.0, but its *library* requires the disabled package: sydtest
+        - genvalidity-sydtest-hashable < 0 # tried genvalidity-sydtest-hashable-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
+        - genvalidity-sydtest-hashable < 0 # tried genvalidity-sydtest-hashable-1.0.0.0, but its *library* requires the disabled package: sydtest
+        - genvalidity-sydtest-lens < 0 # tried genvalidity-sydtest-lens-1.0.0.0, but its *library* requires the disabled package: genvalidity-sydtest
+        - genvalidity-sydtest-lens < 0 # tried genvalidity-sydtest-lens-1.0.0.0, but its *library* requires the disabled package: sydtest
+        - genvalidity-sydtest-persistent < 0 # tried genvalidity-sydtest-persistent-1.0.0.0, but its *library* requires the disabled package: persistent
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires the disabled package: validation
         - ghc-bignum-orphans < 0 # tried ghc-bignum-orphans-0.1.1, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.41.2
-        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.4.5
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.42.0
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.6.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text >=1.2.3.2 && < 1.3 and the snapshot contains text-2.0.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.2
-        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.17.1.0
-        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires ghc-prim >=0.5.3 && < 0.9 and the snapshot contains ghc-prim-0.9.0
-        - ghc-parser < 0 # tried ghc-parser-0.2.4.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.5
-        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.4.5
-        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.4.5
+        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires ghc-prim >=0.5.3 && < 0.9 and the snapshot contains ghc-prim-0.10.0
+        - ghc-lib < 0 # tried ghc-lib-9.6.2.20230523, but its *library* requires the disabled package: happy
+        - ghc-lib-parser < 0 # tried ghc-lib-parser-9.6.2.20230523, but its *library* requires the disabled package: happy
+        - ghc-lib-parser-ex < 0 # tried ghc-lib-parser-ex-9.6.0.0, but its *library* requires the disabled package: ghc-lib-parser
+        - ghc-parser < 0 # tried ghc-parser-0.2.4.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.6.2
+        - ghc-prof < 0 # tried ghc-prof-1.4.1.12, but its *library* requires base >=4.6 && < 4.18 and the snapshot contains base-4.18.0.0
+        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.3.0, but its *library* requires ghc >=8.4 && < 9.3 and the snapshot contains ghc-9.6.2
+        - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.6.2
+        - ghc-syntax-highlighter < 0 # tried ghc-syntax-highlighter-0.0.10.0, but its *library* requires the disabled package: ghc-lib-parser
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
+        - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
+        - gi-atk < 0 # tried gi-atk-2.0.27, but its *library* requires the disabled package: haskell-gi
+        - gi-cairo < 0 # tried gi-cairo-1.0.29, but its *library* requires the disabled package: haskell-gi
+        - gi-cairo-connector < 0 # tried gi-cairo-connector-0.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - gi-dbusmenu < 0 # tried gi-dbusmenu-0.4.13, but its *library* requires the disabled package: haskell-gi
+        - gi-dbusmenugtk3 < 0 # tried gi-dbusmenugtk3-0.4.14, but its *library* requires the disabled package: haskell-gi
+        - gi-freetype2 < 0 # tried gi-freetype2-2.0.4, but its *library* requires the disabled package: haskell-gi
+        - gi-gdk < 0 # tried gi-gdk-3.0.28, but its *library* requires the disabled package: haskell-gi
+        - gi-gdkpixbuf < 0 # tried gi-gdkpixbuf-2.0.31, but its *library* requires the disabled package: haskell-gi
+        - gi-gdkx11 < 0 # tried gi-gdkx11-3.0.15, but its *library* requires the disabled package: haskell-gi
+        - gi-gio < 0 # tried gi-gio-2.0.32, but its *library* requires the disabled package: haskell-gi
+        - gi-glib < 0 # tried gi-glib-2.0.29, but its *library* requires the disabled package: haskell-gi
+        - gi-gmodule < 0 # tried gi-gmodule-2.0.5, but its *library* requires the disabled package: haskell-gi
+        - gi-gobject < 0 # tried gi-gobject-2.0.30, but its *library* requires the disabled package: haskell-gi
+        - gi-graphene < 0 # tried gi-graphene-1.0.7, but its *library* requires the disabled package: haskell-gi
         - gi-gsk < 0 # tried gi-gsk-4.0.7, but its *library* requires gi-gdk ==4.0.* and the snapshot contains gi-gdk-3.0.28
-        - ginger < 0 # tried ginger-0.10.4.0, but its *executable* requires optparse-applicative >=0.14.3.0 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
+        - gi-gtk < 0 # tried gi-gtk-3.0.41, but its *library* requires the disabled package: haskell-gi
+        - gi-gtk-hs < 0 # tried gi-gtk-hs-0.3.15, but its *library* requires base-compat >=0.9.0 && < 0.13 and the snapshot contains base-compat-0.13.0
+        - gi-gtksource < 0 # tried gi-gtksource-3.0.28, but its *library* requires the disabled package: haskell-gi
+        - gi-harfbuzz < 0 # tried gi-harfbuzz-0.0.9, but its *library* requires the disabled package: haskell-gi
+        - gi-javascriptcore < 0 # tried gi-javascriptcore-4.0.27, but its *library* requires the disabled package: haskell-gi
+        - gi-pango < 0 # tried gi-pango-1.0.29, but its *library* requires the disabled package: haskell-gi
+        - gi-soup < 0 # tried gi-soup-2.4.28, but its *library* requires the disabled package: haskell-gi
+        - gi-vte < 0 # tried gi-vte-2.91.31, but its *library* requires the disabled package: haskell-gi
+        - gi-webkit2 < 0 # tried gi-webkit2-4.0.30, but its *library* requires the disabled package: haskell-gi
+        - gi-xlib < 0 # tried gi-xlib-2.0.13, but its *library* requires the disabled package: haskell-gi
+        - ginger < 0 # tried ginger-0.10.4.0, but its *executable* requires optparse-applicative >=0.14.3.0 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - ginger < 0 # tried ginger-0.10.4.0, but its *executable* requires transformers >=0.5.6.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires aeson >=1.4.2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - ginger < 0 # tried ginger-0.10.4.0, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - gio < 0 # tried gio-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
         - git-annex < 0 # tried git-annex-10.20230407, but its *executable* requires unix-compat (< 0.7 and the snapshot contains unix-compat-0.7
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires aeson >=1.3 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - git-lfs < 0 # tried git-lfs-1.2.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.17.1.0
-        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.17.1.0
+        - github < 0 # tried github-0.28.0.1, but its *library* requires the disabled package: binary-instances
+        - github-release < 0 # tried github-release-2.0.0.6, but its *library* requires the disabled package: optparse-generic
+        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.0.0
+        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.0.0
+        - gitlab-haskell < 0 # tried gitlab-haskell-1.0.0.1, but its *library* requires the disabled package: connection
+        - gl < 0 # tried gl-0.9, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - glaze < 0 # tried glaze-0.3.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
@@ -6404,11 +6747,15 @@ packages:
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
+        - glib < 0 # tried glib-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
+        - gloss < 0 # tried gloss-1.13.2.2, but its *library* requires the disabled package: GLUT
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
         - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: linear-accelerate
+        - gloss-algorithms < 0 # tried gloss-algorithms-1.13.0.3, but its *library* requires the disabled package: gloss
         - gloss-examples < 0 # tried gloss-examples-1.13.0.4, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - gloss-raster < 0 # tried gloss-raster-1.13.1.2, but its *library* requires the disabled package: repa
         - gloss-raster-accelerate < 0 # tried gloss-raster-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
+        - gloss-rendering < 0 # tried gloss-rendering-1.13.1.2, but its *library* requires the disabled package: GLUT
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-adexchange-buyer < 0 # tried gogol-adexchange-buyer-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-adexchange-seller < 0 # tried gogol-adexchange-seller-0.5.0, but its *library* requires the disabled package: gogol-core
@@ -6505,31 +6852,45 @@ packages:
         - gogol-youtube < 0 # tried gogol-youtube-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-analytics < 0 # tried gogol-youtube-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-reporting < 0 # tried gogol-youtube-reporting-0.5.0, but its *library* requires the disabled package: gogol-core
-        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* requires base >=4.4 && < 4.11 and the snapshot contains base-4.17.1.0
+        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* requires base >=4.4 && < 4.11 and the snapshot contains base-4.18.0.0
         - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires base64-bytestring >=1.0.0 && < 1.2.0.1 and the snapshot contains base64-bytestring-1.2.1.0
         - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires bytestring >=0.10.6 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - google-oauth2-jwt < 0 # tried google-oauth2-jwt-0.3.3, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.5
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.5.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires vector >=0.12.0.1 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - graphite < 0 # tried graphite-0.10.0.1, but its *library* requires the disabled package: graphviz
+        - graphula < 0 # tried graphula-2.0.2.2, but its *library* requires the disabled package: persistent
+        - graphviz < 0 # tried graphviz-2999.20.1.0, but its *library* requires the disabled package: wl-pprint-text
+        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
-        - greskell-core < 0 # tried greskell-core-1.0.0.1, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - greskell-core < 0 # tried greskell-core-1.0.0.1, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - greskell-core < 0 # tried greskell-core-1.0.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
-        - greskell-websocket < 0 # tried greskell-websocket-1.0.0.1, but its *library* requires base >=4.9.1.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - greskell-websocket < 0 # tried greskell-websocket-1.0.0.1, but its *library* requires base >=4.9.1.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - greskell-websocket < 0 # tried greskell-websocket-1.0.0.1, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires groundhog-th >=0.8 && < 0.12 and the snapshot contains groundhog-th-0.12
         - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires the disabled package: groundhog
         - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires mysql >=0.1.1.3 && < 0.2 and the snapshot contains mysql-0.2.1
         - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires the disabled package: groundhog
+        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires the disabled package: groundhog
+        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - groundhog-sqlite < 0 # tried groundhog-sqlite-0.12.0, but its *library* requires the disabled package: groundhog
         - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires aeson >=0.7 && < 2 and the snapshot contains aeson-2.1.2.1
         - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires the disabled package: groundhog
-        - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
+        - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
+        - gtk < 0 # tried gtk-0.15.8, but its *library* requires the disabled package: gtk2hs-buildtools
+        - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires the disabled package: gi-cairo-connector
+        - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gdk
+        - gtk-strut < 0 # tried gtk-strut-0.1.3.2, but its *library* requires the disabled package: gi-gtk
+        - gtk2hs-buildtools < 0 # tried gtk2hs-buildtools-0.13.10.0, but its *library* requires the disabled package: happy
+        - gtk3 < 0 # tried gtk3-0.15.8, but its *library* requires the disabled package: gtk2hs-buildtools
+        - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: incremental-parser
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.19.1
@@ -6538,85 +6899,122 @@ packages:
         - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires language-docker >=11.0.0 && < 12 and the snapshot contains language-docker-12.1.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hakyll < 0 # tried hakyll-4.16.0.0, but its *library* requires optparse-applicative >=0.12 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hakyll-convert < 0 # tried hakyll-convert-0.3.0.4, but its *library* requires time >=1.9 && < 1.12 and the snapshot contains time-1.12.2
         - hamilton < 0 # tried hamilton-0.1.0.3, but its *library* requires the disabled package: typelits-witnesses
-        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
+        - hamtsolo < 0 # tried hamtsolo-1.0.4, but its *executable* requires the disabled package: stm-conduit
+        - handwriting < 0 # tried handwriting-0.1.0.3, but its *library* requires the disabled package: wreq
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires ansi-terminal >=0.9 && < 0.12 and the snapshot contains ansi-terminal-1.0
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path >=0.5 && < 0.9 and the snapshot contains path-0.9.2
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path-io >=1.2 && < 1.7 and the snapshot contains path-io-1.8.1
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
-        - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
-        - hashids < 0 # tried hashids-1.0.2.7, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.1.0
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - happstack-hsp < 0 # tried happstack-hsp-7.3.7.7, but its *library* requires the disabled package: harp
+        - happstack-hsp < 0 # tried happstack-hsp-7.3.7.7, but its *library* requires the disabled package: hsx2hs
+        - happstack-jmacro < 0 # tried happstack-jmacro-7.0.12.5, but its *library* requires the disabled package: wl-pprint-text
+        - happy < 0 # tried happy-1.20.0, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - harp < 0 # tried harp-0.4.3.6, but its *library* requires base < 4.18 and the snapshot contains base-4.18.0.0
+        - hasbolt < 0 # tried hasbolt-0.1.6.2, but its *library* requires the disabled package: connection
+        - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
+        - hashids < 0 # tried hashids-1.0.2.7, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
+        - haskell-gi < 0 # tried haskell-gi-0.26.6, but its *library* requires the disabled package: pretty-show
         - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.17.1.0
+        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.0.0
         - haskell-lsp-client < 0 # tried haskell-lsp-client-1.0.0.1, but its *library* requires the disabled package: haskell-lsp
-        - haskell-lsp-types < 0 # tried haskell-lsp-types-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.17.1.0
+        - haskell-lsp-types < 0 # tried haskell-lsp-types-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.0.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.4.5
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.6.2
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
+        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires the disabled package: references
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Diff >=0.3 && < 0.4 and the snapshot contains Diff-0.4.1
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires network >=2.6 && < 2.9 and the snapshot contains network-3.1.4.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.1.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires warp >=3.2 && < 3.3 and the snapshot contains warp-3.3.25
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires warp >=3.2 && < 3.3 and the snapshot contains warp-3.3.27
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.8.1.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.17.1.0
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.4.5
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.18.0.0
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.6.2
+        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
         - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires stm-containers >=0.2 && < 1 || >=1.1 && < 1.2 and the snapshot contains stm-containers-1.2.0.2
         - haskey-btree < 0 # tried haskey-btree-0.3.0.1, but its *library* requires text >=1.2.1 && < 2 and the snapshot contains text-2.0.2
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
         - haskintex < 0 # tried haskintex-0.8.0.1, but its *library* requires text >=0.11.2.3 && < 2 and the snapshot contains text-2.0.2
+        - haskoin-core < 0 # tried haskoin-core-0.21.2, but its *library* requires the disabled package: base16
+        - haskoin-node < 0 # tried haskoin-node-0.18.1, but its *library* requires the disabled package: haskoin-core
+        - haskoin-store < 0 # tried haskoin-store-0.65.10, but its *library* requires the disabled package: base16
+        - haskoin-store < 0 # tried haskoin-store-0.65.10, but its *library* requires the disabled package: ekg-core
         - haskoin-store < 0 # tried haskoin-store-0.65.10, but its *library* requires the disabled package: ekg-statsd
+        - haskoin-store < 0 # tried haskoin-store-0.65.10, but its *library* requires the disabled package: wreq
+        - haskoin-store-data < 0 # tried haskoin-store-data-0.65.5, but its *library* requires the disabled package: wreq
+        - hasktags < 0 # tried hasktags-0.72.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
+        - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
+        - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - hasql-queue < 0 # tried hasql-queue-1.2.0.2, but its *library* requires the disabled package: here
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.1.2.1
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.2.0
@@ -6626,25 +7024,40 @@ packages:
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: amazonka
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: amazonka-core
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: haxl
-        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-0.11.5
+        - hedgehog < 0 # tried hedgehog-1.2, but its *library* requires ansi-terminal >=0.6 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - hedgehog-classes < 0 # tried hedgehog-classes-0.2.5.4, but its *library* requires the disabled package: hedgehog
+        - hedgehog-fakedata < 0 # tried hedgehog-fakedata-0.0.1.5, but its *library* requires the disabled package: hedgehog
+        - hedgehog-fn < 0 # tried hedgehog-fn-1.0, but its *library* requires the disabled package: hedgehog
+        - hedgehog-optics < 0 # tried hedgehog-optics-1.0.0.2, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - hedgehog-quickcheck < 0 # tried hedgehog-quickcheck-0.1.1, but its *library* requires the disabled package: hedgehog
+        - here < 0 # tried here-1.2.13, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-1.0
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-1.9
-        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires semigroups >=0.18.3 && < 0.19 and the snapshot contains semigroups-0.20
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires vty >=5.15 && < =5.23 and the snapshot contains vty-5.38
+        - hetzner < 0 # tried hetzner-0.2.1.0, but its *library* requires base >=4.16 && < 4.18 and the snapshot contains base-4.18.0.0
         - hgeometry < 0 # tried hgeometry-0.14, but its *library* requires the disabled package: vector-circular
         - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.14, but its *library* requires the disabled package: vector-circular
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.1.0
-        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.17.1.0
+        - hid < 0 # tried hid-0.2.2, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.0.0
+        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.18.0.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
         - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires resourcet >=1.2.3 && < =1.3 and the snapshot contains resourcet-1.3.0
+        - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
+        - hindent < 0 # tried hindent-6.1.0, but its *library* requires the disabled package: ghc-lib-parser
+        - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
         - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires aeson >=0.7 && < 1.4 and the snapshot contains aeson-2.1.2.1
@@ -6663,26 +7076,40 @@ packages:
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires protolude >=0.1.10 && < 0.3 and the snapshot contains protolude-0.3.3
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - hledger-stockquotes < 0 # tried hledger-stockquotes-0.1.2.1, but its *library* requires the disabled package: req
+        - hledger-web < 0 # tried hledger-web-1.30, but its *library* requires the disabled package: yesod-form
+        - hlint < 0 # tried hlint-3.5, but its *library* requires ghc-lib-parser ==9.4.* and the snapshot contains ghc-lib-parser-9.6.2.20230523
+        - hlint < 0 # tried hlint-3.5, but its *library* requires ghc-lib-parser-ex >=9.4.0.0 && < 9.4.1 and the snapshot contains ghc-lib-parser-ex-9.6.0.0
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
         - hmatrix-vector-sized < 0 # tried hmatrix-vector-sized-0.1.3.0, but its *library* requires the disabled package: vector-sized
         - hnix-store-core < 0 # tried hnix-store-core-0.6.1.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hoauth2 < 0 # tried hoauth2-2.8.0, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
         - hocilib < 0 # tried hocilib-0.2.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires MissingH < =1.4.3.0 and the snapshot contains MissingH-1.6.0.0
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires parsec < =3.1.14.0 and the snapshot contains parsec-3.1.16.1
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires split < =0.2.3.4 and the snapshot contains split-0.2.3.5
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
+        - hoogle < 0 # tried hoogle-5.0.18.3, but its *library* requires the disabled package: connection
+        - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.7, but its *executable* requires the disabled package: happy
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.7, but its *executable* requires the disabled package: ixset-typed
+        - horizontal-rule < 0 # tried horizontal-rule-0.6.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires the disabled package: dhall
+        - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires the disabled package: dhall-json
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires aeson >=0.7.1 && < 1.3 and the snapshot contains aeson-2.1.2.1
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires retry >=0.5 && < 0.8 and the snapshot contains retry-0.9.3.1
-        - hpio < 0 # tried hpio-0.9.0.7, but its *executable* requires optparse-applicative >=0.11.0 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires transformers >=0.4.1 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *executable* requires optparse-applicative >=0.11.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires QuickCheck >=2.7.6 && < 2.13 and the snapshot contains QuickCheck-2.14.3
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires mtl >=2.1.3 && < 2.3 and the snapshot contains mtl-2.3.1
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires protolude ==0.2.* and the snapshot contains protolude-0.3.3
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires unix >=2.7.0 && < 2.8 and the snapshot contains unix-2.8.1.0
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires unix-bytestring >=0.3.7 && < 0.4 and the snapshot contains unix-bytestring-0.4.0
         - hprotoc < 0 # tried hprotoc-2.4.17, but its *library* requires the disabled package: protocol-buffers
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires statistics >=0.15.0.0 && < 0.16.0.0 and the snapshot contains statistics-0.16.2.0
@@ -6690,9 +7117,10 @@ packages:
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector >=0.11.0.0 && < 0.13.0.0 and the snapshot contains vector-0.13.0.0
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector-algorithms >=0.8.0.0 && < 0.9.0.0 and the snapshot contains vector-algorithms-0.9.0.1
         - hquantlib-time < 0 # tried hquantlib-time-0.0.5.2, but its *library* requires time >=1.4.0.0 && < 1.12.0.0 and the snapshot contains time-1.12.2
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.17.1.0
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.4.5
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.18.0.0
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.6.2
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires strict >=0.3.2 && < 0.5 and the snapshot contains strict-0.5
         - hsb2hs < 0 # tried hsb2hs-0.3.1, but its *executable* requires the disabled package: preprocessor-tools
         - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
@@ -6702,122 +7130,203 @@ packages:
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires fsnotify >=0.2.1 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.4.5
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser ==8.10.* and the snapshot contains ghc-lib-parser-9.4.5.20230430
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.6.2
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser ==8.10.* and the snapshot contains ghc-lib-parser-9.6.2.20230523
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires hlint >=3.0.0 && < 3.3.0 and the snapshot contains hlint-3.5
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.13.1
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2.2
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires template-haskell >=2.11.0 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires template-haskell >=2.11.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires the disabled package: text-region
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires unix >=2.7.2.0 && < 2.8 and the snapshot contains unix-2.8.1.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.0.0
         - hsexif < 0 # tried hsexif-0.6.1.10, but its *library* requires the disabled package: iconv
-        - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires base >=4.6.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
-        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
-        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.10.10
+        - hsini < 0 # tried hsini-0.5.1.2, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hspec-hedgehog < 0 # tried hspec-hedgehog-0.0.1.2, but its *library* requires the disabled package: hedgehog
+        - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires base >=4.6.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires hspec-core >=2.2.4 && < 2.11 and the snapshot contains hspec-core-2.11.1
+        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
+        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core ==2.7.* and the snapshot contains hspec-core-2.11.1
+        - hspec-tmp-proc < 0 # tried hspec-tmp-proc-0.5.1.2, but its *library* requires the disabled package: tmp-proc
+        - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - hsx2hs < 0 # tried hsx2hs-0.14.1.11, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
+        - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
+        - htaglib < 0 # tried htaglib-1.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.0.2
+        - htoml-parse < 0 # tried htoml-parse-0.1.0.1, but its *library* requires the disabled package: prettyprinter-combinators
+        - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - http-client-restricted < 0 # tried http-client-restricted-0.0.5, but its *library* requires the disabled package: connection
+        - hunit-dejafu < 0 # tried hunit-dejafu-2.0.0.6, but its *library* requires the disabled package: dejafu
+        - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-bits < 0 # tried hw-bits-0.7.2.2, but its *library* requires the disabled package: hw-prim
+        - hw-eliasfano < 0 # tried hw-eliasfano-0.1.2.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-eliasfano < 0 # tried hw-eliasfano-0.1.2.1, but its *executable* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - hw-excess < 0 # tried hw-excess-0.2.3.0, but its *library* requires the disabled package: hw-prim
+        - hw-fingertree < 0 # tried hw-fingertree-0.1.2.1, but its *library* requires the disabled package: hw-prim
+        - hw-hedgehog < 0 # tried hw-hedgehog-0.1.1.1, but its *library* requires the disabled package: hedgehog
+        - hw-hspec-hedgehog < 0 # tried hw-hspec-hedgehog-0.1.1.1, but its *library* requires the disabled package: hedgehog
+        - hw-ip < 0 # tried hw-ip-2.4.2.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json < 0 # tried hw-json-1.3.2.4, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hw-json < 0 # tried hw-json-1.3.2.4, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
+        - hw-json < 0 # tried hw-json-1.3.2.4, but its *library* requires ansi-wl-pprint >=0.6.8.2 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-json-simd < 0 # tried hw-json-simd-0.1.1.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json-simple-cursor < 0 # tried hw-json-simple-cursor-0.1.1.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-json-standard-cursor < 0 # tried hw-json-standard-cursor-0.2.3.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-mquery < 0 # tried hw-mquery-0.2.1.1, but its *library* requires ansi-wl-pprint >=0.6.8 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-packed-vector < 0 # tried hw-packed-vector-0.2.1.1, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-parser < 0 # tried hw-parser-0.1.1.0, but its *library* requires the disabled package: hw-prim
+        - hw-prim < 0 # tried hw-prim-0.6.3.2, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - hw-rankselect < 0 # tried hw-rankselect-0.13.4.1, but its *executable* requires optparse-applicative >=0.11 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-rankselect-base < 0 # tried hw-rankselect-base-0.3.4.1, but its *library* requires the disabled package: bits-extra
+        - hw-rankselect-base < 0 # tried hw-rankselect-base-0.3.4.1, but its *library* requires the disabled package: hw-prim
+        - hw-simd < 0 # tried hw-simd-0.1.2.2, but its *library* requires the disabled package: bits-extra
+        - hw-simd < 0 # tried hw-simd-0.1.2.2, but its *library* requires the disabled package: hw-prim
+        - hw-simd < 0 # tried hw-simd-0.1.2.2, but its *library* requires the disabled package: hw-rankselect
+        - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-balancedparens
+        - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-prim
+        - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-rankselect
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *executable* requires optparse-applicative >=0.15.1.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires ansi-wl-pprint >=0.6.9 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
         - hw-xml < 0 # tried hw-xml-0.5.1.1, but its *library* requires text >=1.2.3.2 && < 2 and the snapshot contains text-2.0.2
         - hyraxAbif < 0 # tried hyraxAbif-0.2.4.2, but its *library* requires text >=1.2.4 && < 1.3 and the snapshot contains text-2.0.2
         - iconv < 0 # tried iconv-0.4.1.3, but its *library* requires bytestring ==0.9.* || ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.8.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.10.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
+        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-terminal < 0.12 and the snapshot contains ansi-terminal-1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-wl-pprint < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - idris < 0 # tried idris-1.3.4, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.4.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires fsnotify >=0.2 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires libffi < 0.2 and the snapshot contains libffi-0.2.1
+        - idris < 0 # tried idris-1.3.4, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - idris < 0 # tried idris-1.3.4, but its *library* requires network >=2.7 && < 3.1.2 and the snapshot contains network-3.1.4.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires text >=1.2.1.0 && < 1.4 and the snapshot contains text-2.0.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires vector < 0.13 and the snapshot contains vector-0.13.0.0
-        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.1.0
-        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.4.5
+        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
+        - ihaskell < 0 # tried ihaskell-0.10.3.0, but its *library* requires ghc >=8.0 && < 9.3 and the snapshot contains ghc-9.6.2
         - ihaskell-hvega < 0 # tried ihaskell-hvega-0.5.0.3, but its *library* requires the disabled package: ihaskell
-        - ilist < 0 # tried ilist-0.4.0.1, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
+        - ilist < 0 # tried ilist-0.4.0.1, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: log-warper
+        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: turtle
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: universum
-        - incremental-parser < 0 # tried incremental-parser-0.5.0.5, but its *library* requires the disabled package: rank2classes
-        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.17.1.0
-        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.17.1.0
+        - incremental-parser < 0 # tried incremental-parser-0.5.0.5, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.0.0
+        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.18.0.0
+        - indents < 0 # tried indents-0.5.0.1, but its *library* requires mtl >=1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - inf-backprop < 0 # tried inf-backprop-0.1.0.2, but its *library* requires the disabled package: simple-expr
         - inflections < 0 # tried inflections-0.4.0.6, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires aeson >=0.7 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires lens >=4.9 && < 5.2 and the snapshot contains lens-5.2.2
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
         - influxdb < 0 # tried influxdb-1.9.2.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.4.5
+        - inline-c < 0 # tried inline-c-0.9.1.8, but its *library* requires ansi-wl-pprint >=0.6.8 && < 1.0.0 and the snapshot contains ansi-wl-pprint-1.0.2
+        - inline-c-cpp < 0 # tried inline-c-cpp-0.5.0.0, but its *library* requires the disabled package: inline-c
+        - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.6.2
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
+        - inline-r < 0 # tried inline-r-1.0.1, but its *library* requires the disabled package: inline-c
         - inliterate < 0 # tried inliterate-0.1.0, but its *library* requires the disabled package: cheapskate
-        - int-cast < 0 # tried int-cast-0.2.0.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
+        - input-parsers < 0 # tried input-parsers-0.3, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - instance-control < 0 # tried instance-control-0.1.2.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - instance-control < 0 # tried instance-control-0.1.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - int-cast < 0 # tried int-cast-0.2.0.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires template-haskell >=2.14.0.0 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires template-haskell >=2.14.0.0 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - interpolatedstring-qq2 < 0 # tried interpolatedstring-qq2-0.1.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - intro < 0 # tried intro-0.9.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - intro < 0 # tried intro-0.9.0.0, but its *library* requires text >=0.7 && < 1.3 and the snapshot contains text-2.0.2
-        - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires template-haskell >=2.14 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - intro < 0 # tried intro-0.9.0.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - invert < 0 # tried invert-1.0.0.3, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - ip < 0 # tried ip-1.7.6, but its *library* requires the disabled package: bytebuild
+        - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires template-haskell >=2.14 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
         - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
         - ipa < 0 # tried ipa-0.3.1.1, but its *library* requires unicode-transforms ^>=0.3.7 and the snapshot contains unicode-transforms-0.4.0.1
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
         - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
-        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.6.0
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
         - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.6.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires attoparsec >=0.13.0.1 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires network >=2.6.2.1 && < 2.8 and the snapshot contains network-3.1.4.0
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires path >=0.5.7 && < 0.7 and the snapshot contains path-0.9.2
+        - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - it-has < 0 # tried it-has-0.2.0.0, but its *library* requires generic-lens >=2.0.0.0 && < =2.0.0.0 and the snapshot contains generic-lens-2.2.2.0
+        - iterable < 0 # tried iterable-3.0, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - ixset < 0 # tried ixset-1.1.1.2, but its *library* requires the disabled package: syb-with-class
-        - ixset-typed < 0 # tried ixset-typed-0.5.1.0, but its *library* requires template-haskell >=2.8 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - ixset-typed < 0 # tried ixset-typed-0.5.1.0, but its *library* requires template-haskell >=2.8 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - ixset-typed-binary-instance < 0 # tried ixset-typed-binary-instance-0.1.0.2, but its *library* requires the disabled package: ixset-typed
         - ixset-typed-conversions < 0 # tried ixset-typed-conversions-0.1.2.0, but its *library* requires the disabled package: ixset-typed
         - ixset-typed-hashable-instance < 0 # tried ixset-typed-hashable-instance-0.1.0.2, but its *library* requires the disabled package: ixset-typed
         - javascript-extras < 0 # tried javascript-extras-0.5.0.0, but its *library* requires the disabled package: ghcjs-base-stub
+        - jmacro < 0 # tried jmacro-0.6.18, but its *library* requires the disabled package: wl-pprint-text
         - jmacro-rpc-happstack < 0 # tried jmacro-rpc-happstack-0.3.2, but its *library* requires the disabled package: jmacro-rpc
         - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: jmacro-rpc
+        - journalctl-stream < 0 # tried journalctl-stream-0.6.0.3, but its *library* requires base < 4.18 and the snapshot contains base-4.18.0.0
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires aeson >=0.11.3.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.12.2
+        - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.13.0
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires lens >=3.8.5 && < 5.2 and the snapshot contains lens-5.2.2
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires primitive >=0.6.1.0 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires ref-tf >=0.4.0.1 && < 0.5 and the snapshot contains ref-tf-0.5.0.1
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires text >=1.2.1.3 && < 1.3 and the snapshot contains text-2.0.2
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires time >=1.5.0.1 && < 1.11 and the snapshot contains time-1.12.2
+        - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - jsaddle < 0 # tried jsaddle-0.9.8.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.17.1.0
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.12.2
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.18.0.0
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.13.0
         - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires lens >=4.12.3 && < 4.20 and the snapshot contains lens-5.2.2
         - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.0.2
+        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - json-alt < 0 # tried json-alt-1.0.0, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.2.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires lens >=4.1 && < 4.20 and the snapshot contains lens-5.2.2
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires smallcheck >=1.0 && < 1.2 and the snapshot contains smallcheck-1.2.1.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires text >=1.1 && < 1.4 and the snapshot contains text-2.0.2
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - json-rpc < 0 # tried json-rpc-1.0.4, but its *library* requires the disabled package: stm-conduit
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires aeson >=0.7 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires base >=4.3.1 && < 4.13 and the snapshot contains base-4.17.1.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires base >=4.3.1 && < 4.13 and the snapshot contains base-4.18.0.0
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires text >=0.11.2 && < 1.3 and the snapshot contains text-2.0.2
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector-algorithms >=0.5.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
         - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.17.1.0
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.18.0.0
         - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
         - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires vector >=0.7.1 && < 0.13 and the snapshot contains vector-0.13.0.0
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.13.1
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: distributed-closure
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
@@ -6835,66 +7344,108 @@ packages:
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.1.2.1
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.7.4
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - keter < 0 # tried keter-2.1.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - keter < 0 # tried keter-2.1.1, but its *library* requires optparse-applicative >=0.16.1 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - keter < 0 # tried keter-2.1.1, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - keter < 0 # tried keter-2.1.1, but its *library* requires unix >=2.7.2 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - keter < 0 # tried keter-2.1.1, but its *library* requires warp-tls >=3.0.3 && < 3.4.0 and the snapshot contains warp-tls-3.4.0
+        - kind-generics-th < 0 # tried kind-generics-th-0.2.3.1, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - kleene < 0 # tried kleene-0.1, but its *library* requires the disabled package: regex-applicative
         - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
-        - kraken < 0 # tried kraken-0.1.0, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.17.1.0
+        - kraken < 0 # tried kraken-0.1.0, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.18.0.0
+        - krank < 0 # tried krank-0.3.0, but its *library* requires the disabled package: req
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires aeson >=1.4.6 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
         - l10n < 0 # tried l10n-0.1.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.2
+        - lackey < 0 # tried lackey-2.0.0.6, but its *library* requires the disabled package: servant-foreign
         - lambdabot-core < 0 # tried lambdabot-core-5.3.1, but its *library* requires the disabled package: dependent-sum-template
         - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.1, but its *library* requires the disabled package: lambdabot-core
-        - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* requires template-haskell < 2.16 and the snapshot contains template-haskell-2.19.0.0
+        - lame < 0 # tried lame-0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-avro < 0 # tried language-avro-0.1.4.0, but its *library* requires the disabled package: avro
+        - language-bash < 0 # tried language-bash-0.9.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-c-quote < 0 # tried language-c-quote-0.13.0.1, but its *library* requires the disabled package: happy
+        - language-haskell-extract < 0 # tried language-haskell-extract-0.2.4, but its *library* requires template-haskell < 2.16 and the snapshot contains template-haskell-2.20.0.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires base16-bytestring ==0.1.* and the snapshot contains base16-bytestring-1.0.2.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.4.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires formatting < 7 and the snapshot contains formatting-7.2.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.2.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires hruby >=0.3.5 && < 0.4 and the snapshot contains hruby-0.5.0.0
-        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires http-api-data >=0.2 && < 0.5 and the snapshot contains http-api-data-0.5
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires http-api-data >=0.2 && < 0.5 and the snapshot contains http-api-data-0.5.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires lens >=4.12 && < 5 and the snapshot contains lens-5.2.2
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires megaparsec >=7 && < 9 and the snapshot contains megaparsec-9.3.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires memory >=0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant >=0.9 && < 0.18 and the snapshot contains servant-0.19.1
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires servant-client >=0.9 && < 0.18 and the snapshot contains servant-client-0.19
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.1.0
         - language-puppet < 0 # tried language-puppet-1.4.6.5, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - language-python < 0 # tried language-python-0.5.8, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - language-thrift < 0 # tried language-thrift-0.12.0.1, but its *library* requires ansi-wl-pprint ==0.6.* and the snapshot contains ansi-wl-pprint-1.0.2
+        - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.20.0.0
+        - learn-physics < 0 # tried learn-physics-0.6.5, but its *library* requires the disabled package: gloss
+        - learn-physics < 0 # tried learn-physics-0.6.5, but its *library* requires the disabled package: not-gloss
+        - learn-physics < 0 # tried learn-physics-0.6.5, but its *library* requires the disabled package: spatial-math
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens ==4.* and the snapshot contains lens-5.2.2
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.2.2
-        - lens-family-th < 0 # tried lens-family-th-0.5.2.1, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - lens-family-th < 0 # tried lens-family-th-0.5.2.1, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.2
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family ==1.2.* and the snapshot contains lens-family-2.1.2
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family-core ==1.2.* and the snapshot contains lens-family-core-2.1.2
+        - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires the disabled package: hs-functors
+        - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - lexer-applicative < 0 # tried lexer-applicative-2.1.0.2, but its *library* requires the disabled package: regex-applicative
+        - libgraph < 0 # tried libgraph-1.14, but its *library* requires the disabled package: monads-tf
         - libgraph < 0 # tried libgraph-1.14, but its *library* requires the disabled package: union-find
-        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* requires base >=4.8 && < 4.11 and the snapshot contains base-4.17.1.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* requires base >=4.8 && < 4.11 and the snapshot contains base-4.18.0.0
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires bytestring ^>=0.10.10.0 and the snapshot contains bytestring-0.11.4.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires exceptions ==0.10.4 and the snapshot contains exceptions-0.10.5
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires exceptions ==0.10.4 and the snapshot contains exceptions-0.10.7
         - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires monad-time ==0.3.* and the snapshot contains monad-time-0.4.0.0
         - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires text >=1.2.3.2 && < 1.2.5 and the snapshot contains text-2.0.2
         - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires time >=1.9 && < 1.10 and the snapshot contains time-1.12.2
+        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires transformers ^>=0.5.6.2 and the snapshot contains transformers-0.6.1.0
         - libmpd < 0 # tried libmpd-0.10.0.0, but its *library* requires text >=0.11 && < 2 and the snapshot contains text-2.0.2
+        - liboath-hs < 0 # tried liboath-hs-0.0.1.2, but its *library* requires the disabled package: inline-c
+        - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: concurrency
+        - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: dejafu
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg
+        - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg-core
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: monad-metrics
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.8.1.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.1.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
+        - linear-base < 0 # tried linear-base-0.3.1, but its *library* requires the disabled package: linear-generics
+        - linear-generics < 0 # tried linear-generics-0.2.1, but its *library* requires template-haskell >=2.16 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - linear-generics < 0 # tried linear-generics-0.2.1, but its *library* requires th-abstraction >=0.4 && < 0.5 and the snapshot contains th-abstraction-0.5.0.0
         - linenoise < 0 # tried linenoise-0.3.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.3.1
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.1
+        - list-transformer < 0 # tried list-transformer-1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - list-witnesses < 0 # tried list-witnesses-0.1.3.2, but its *library* requires the disabled package: functor-products
+        - literatex < 0 # tried literatex-0.3.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - little-logger < 0 # tried little-logger-1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - little-rio < 0 # tried little-rio-2.0.0, but its *library* requires the disabled package: little-logger
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires bytestring >=0.10 && < 0.11.3 and the snapshot contains bytestring-0.11.4.0
+        - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - loc < 0 # tried loc-0.1.4.1, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires aeson ^>=1.4 and the snapshot contains aeson-2.1.2.1
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires ansi-terminal >=0.7 && < 1.0 and the snapshot contains ansi-terminal-1.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mmorph ^>=1.1 and the snapshot contains mmorph-1.2.0
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires o-clock ^>=1.1 and the snapshot contains o-clock-1.3.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires text ^>=1.2.2.0 and the snapshot contains text-2.0.2
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires transformers ^>=0.5.2 and the snapshot contains transformers-0.6.1.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires universum ^>=1.6.0 and the snapshot contains universum-1.8.1.1
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires vector ^>=0.12 and the snapshot contains vector-0.13.0.0
-        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.4.5
+        - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires ghc >=8.6 && < 8.9 and the snapshot contains ghc-9.6.2
+        - lrucaching < 0 # tried lrucaching-0.3.3, but its *library* requires base-compat >=0.9 && < 0.13 and the snapshot contains base-compat-0.13.0
         - lrucaching < 0 # tried lrucaching-0.3.3, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.1.2.1
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.1.4.0
@@ -6902,12 +7453,20 @@ packages:
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant-client >=0.11 && < 0.14 and the snapshot contains servant-client-0.19
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires text >=1.2.2.2 && < 2 and the snapshot contains text-2.0.2
         - lxd-client-config < 0 # tried lxd-client-config-0.1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
+        - lz4-frame-conduit < 0 # tried lz4-frame-conduit-0.1.0.1, but its *library* requires the disabled package: inline-c
+        - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires resourcet >=1.1.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
+        - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-core
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: monad-metrics
+        - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: servant-server
+        - mail-pool < 0 # tried mail-pool-2.2.3, but its *library* requires the disabled package: HaskellNet
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.3.1
+        - mandrill < 0 # tried mandrill-0.5.7.0, but its *library* requires the disabled package: email-validate
         - markup < 0 # tried markup-4.2.0, but its *library* requires the disabled package: attoparsec-uri
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires aeson >=0.11 && < 1.3 and the snapshot contains aeson-2.1.2.1
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.13.1
@@ -6920,157 +7479,243 @@ packages:
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires extra >=1.6.14 && < 1.7 and the snapshot contains extra-1.7.13
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires formatting >=6.3.7 && < 6.4 and the snapshot contains formatting-7.2.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires http-client >=0.5.14 && < 0.6 and the snapshot contains http-client-0.7.13.1
-        - mbug < 0 # tried mbug-1.3.2, but its *library* requires optparse-applicative >=0.14.3.0 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires optparse-applicative >=0.14.3.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires scalpel-core >=0.5.1 && < 0.6 and the snapshot contains scalpel-core-0.6.2.1
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires time >=1.8.0.2 && < 1.9 and the snapshot contains time-1.12.2
+        - mcmc < 0 # tried mcmc-0.8.2.0, but its *library* requires the disabled package: statistics
         - medea < 0 # tried medea-1.2.0, but its *library* requires aeson >=1.4.6.0 && < 2.0.0.0 and the snapshot contains aeson-2.1.2.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires algebraic-graphs ^>=0.5 and the snapshot contains algebraic-graphs-0.7
         - medea < 0 # tried medea-1.2.0, but its *library* requires bytestring ^>=0.10.8.2 and the snapshot contains bytestring-0.11.4.0
+        - medea < 0 # tried medea-1.2.0, but its *library* requires free ^>=5.1.3 and the snapshot contains free-5.2
         - medea < 0 # tried medea-1.2.0, but its *library* requires hashable >=1.2.7.0 && < 1.4.0.0 and the snapshot contains hashable-1.4.2.0
+        - medea < 0 # tried medea-1.2.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.0.2
         - medea < 0 # tried medea-1.2.0, but its *library* requires vector ^>=0.12.0.3 and the snapshot contains vector-0.13.0.0
+        - mega-sdist < 0 # tried mega-sdist-0.4.3.0, but its *executable* requires the disabled package: pantry
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires regex-tdfa >=1.2.3.1 && < 1.3 and the snapshot contains regex-tdfa-1.3.2.1
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
-        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *executable* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *executable* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires ansi-terminal >=0.6.2.3 && < 0.12 and the snapshot contains ansi-terminal-1.0
         - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
+        - mfsolve < 0 # tried mfsolve-0.3.2.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - microlens-process < 0 # tried microlens-process-0.2.0.2, but its *library* requires microlens >=0.3 && < 0.4.13 and the snapshot contains microlens-0.4.13.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.5
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.5.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant-client >=0.13 && < 0.16 and the snapshot contains servant-client-0.19
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - midi-music-box < 0 # tried midi-music-box-0.0.1.2, but its *executable* requires the disabled package: diagrams-postscript
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires lens >=4.4 && < 4.20 and the snapshot contains lens-5.2.2
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires network >=2.4 && < 3.0 and the snapshot contains network-3.1.4.0
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires semigroups >=0.16.2.2 && < 0.19 and the snapshot contains semigroups-0.20
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - mini-egison < 0 # tried mini-egison-1.0.0, but its *library* requires the disabled package: egison-pattern-src
         - mini-egison < 0 # tried mini-egison-1.0.0, but its *library* requires the disabled package: egison-pattern-src-th-mode
+        - minio-hs < 0 # tried minio-hs-1.7.0, but its *library* requires the disabled package: connection
+        - minio-hs < 0 # tried minio-hs-1.7.0, but its *library* requires the disabled package: relude
         - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: jsaddle
+        - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: servant
+        - mmark < 0 # tried mmark-0.0.7.6, but its *library* requires the disabled package: email-validate
+        - mmark-cli < 0 # tried mmark-cli-0.0.5.1, but its *executable* requires the disabled package: stache
+        - mmark-ext < 0 # tried mmark-ext-0.2.1.5, but its *library* requires the disabled package: mmark
+        - model < 0 # tried model-0.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
-        - mole < 0 # tried mole-0.0.7, but its *executable* requires base >=4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - mole < 0 # tried mole-0.0.7, but its *executable* requires base >=4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - mole < 0 # tried mole-0.0.7, but its *executable* requires the disabled package: snap-server
-        - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
+        - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires free >=5.0.2 && < 5.2 and the snapshot contains free-5.2
+        - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
         - monad-bayes < 0 # tried monad-bayes-1.1.0, but its *library* requires vector ^>=0.12.0 and the snapshot contains vector-0.13.0.0
+        - monad-control-aligned < 0 # tried monad-control-aligned-0.0.1.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - monad-control-aligned < 0 # tried monad-control-aligned-0.0.1.1, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2
+        - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires transformers >=0.4.0 && < 0.5.7 and the snapshot contains transformers-0.6.1.0
+        - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires mtl >=2 && < 2.3 and the snapshot contains mtl-2.3.1
         - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires text < 1.3 and the snapshot contains text-2.0.2
-        - monad-mock < 0 # tried monad-mock-0.2.0.0, but its *library* requires template-haskell >=2.10.0.0 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
-        - monad-schedule < 0 # tried monad-schedule-0.1.2.0, but its *library* requires base >=4.13.0 && < =4.17 and the snapshot contains base-4.17.1.0
-        - monad-skeleton < 0 # tried monad-skeleton-0.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.1.0
+        - monad-metrics < 0 # tried monad-metrics-0.2.2.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monad-mock < 0 # tried monad-mock-0.2.0.0, but its *library* requires template-haskell >=2.10.0.0 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - monad-par < 0 # tried monad-par-0.3.5, but its *library* requires mtl >=2.0.1.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - monad-peel < 0 # tried monad-peel-0.2.1.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monad-products < 0 # tried monad-products-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - monad-schedule < 0 # tried monad-schedule-0.1.2.0, but its *library* requires base >=4.13.0 && < =4.17 and the snapshot contains base-4.18.0.0
+        - monad-skeleton < 0 # tried monad-skeleton-0.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
-        - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - monadic-arrays < 0 # tried monadic-arrays-0.2.2, but its *library* requires transformers >=0.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - monads-tf < 0 # tried monads-tf-0.1.0.3, but its *library* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - morpheus-graphql < 0 # tried morpheus-graphql-0.27.3, but its *library* requires the disabled package: morpheus-graphql-code-gen
+        - morpheus-graphql < 0 # tried morpheus-graphql-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-app < 0 # tried morpheus-graphql-app-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-client < 0 # tried morpheus-graphql-client-0.27.3, but its *library* requires the disabled package: req
+        - morpheus-graphql-code-gen < 0 # tried morpheus-graphql-code-gen-0.27.3, but its *executable* requires optparse-applicative >=0.12.0 && < 0.18.0 and the snapshot contains optparse-applicative-0.18.1.0
+        - morpheus-graphql-code-gen-utils < 0 # tried morpheus-graphql-code-gen-utils-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-core < 0 # tried morpheus-graphql-core-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-server < 0 # tried morpheus-graphql-server-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-subscriptions < 0 # tried morpheus-graphql-subscriptions-0.27.3, but its *library* requires the disabled package: relude
+        - morpheus-graphql-tests < 0 # tried morpheus-graphql-tests-0.27.3, but its *library* requires the disabled package: relude
+        - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires hashable >=1.1.2.4 && < 1.4 and the snapshot contains hashable-1.4.2.0
+        - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires mtl >=2.1.3.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - msgpack < 0 # tried msgpack-1.0.1.0, but its *library* requires vector >=0.10.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - msgpack-aeson < 0 # tried msgpack-aeson-0.1.0.0, but its *library* requires the disabled package: msgpack
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires blaze-builder ==0.3.* and the snapshot contains blaze-builder-0.4.2.2
-        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires filepath >=1.1 && < 1.4 and the snapshot contains filepath-1.4.2.2
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires filepath >=1.1 && < 1.4 and the snapshot contains filepath-1.4.100.1
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires msgpack ==0.7.* and the snapshot contains msgpack-1.0.1.0
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires shakespeare-text ==1.0.* and the snapshot contains shakespeare-text-1.1.0
-        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.19.0.0
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.17.1.0
+        - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.20.0.0
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.18.0.0
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires binary-conduit >=1.2.3 && < 1.3 and the snapshot contains binary-conduit-1.3.1
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit >=1.2.3.1 && < 1.3 and the snapshot contains conduit-1.3.5
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit-extra >=1.1.3.4 && < 1.3 and the snapshot contains conduit-extra-1.3.6
+        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires network >=2.6 && < 2.9 || >=3.0 && < 3.1 and the snapshot contains network-3.1.4.0
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.1
         - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - multistate < 0 # tried multistate-0.8.0.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - mstate < 0 # tried mstate-0.2.8, but its *library* requires the disabled package: monad-peel
+        - multistate < 0 # tried multistate-0.8.0.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
+        - multistate < 0 # tried multistate-0.8.0.4, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - multistate < 0 # tried multistate-0.8.0.4, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - mwc-random-accelerate < 0 # tried mwc-random-accelerate-0.2.0.0, but its *library* requires the disabled package: accelerate
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires memory >=0.14.4 && < 0.16 and the snapshot contains memory-0.18.0
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires the disabled package: word24
-        - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires tls >=1.3.5 && < 1.6 and the snapshot contains tls-1.6.0
+        - mysql-haskell < 0 # tried mysql-haskell-0.8.4.3, but its *library* requires tls >=1.3.5 && < 1.6 and the snapshot contains tls-1.7.0
         - mysql-haskell-nem < 0 # tried mysql-haskell-nem-0.1.0.0, but its *library* requires the disabled package: mysql-haskell
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: mysql-haskell
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: tcp-streams-openssl
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: wire-streams
-        - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* requires base ==4.10.* and the snapshot contains base-4.17.1.0
+        - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* requires base ==4.10.* and the snapshot contains base-4.18.0.0
         - n-tuple < 0 # tried n-tuple-0.0.2.0, but its *library* requires singletons >=2.3 && < 2.4 and the snapshot contains singletons-3.0.2
         - n2o-web < 0 # tried n2o-web-0.11.2, but its *library* requires the disabled package: n2o-protocols
-        - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires the disabled package: async-timer
-        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.17.1.0
+        - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - named < 0 # tried named-0.3.0.1, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.0.0
         - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - net-mqtt < 0 # tried net-mqtt-0.8.3.0, but its *library* requires the disabled package: connection
+        - net-mqtt-lens < 0 # tried net-mqtt-lens-0.1.1.0, but its *library* requires the disabled package: net-mqtt
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: hexstring
         - network-anonymous-tor < 0 # tried network-anonymous-tor-0.11.0, but its *library* requires the disabled package: network-attoparsec
         - network-msgpack-rpc < 0 # tried network-msgpack-rpc-0.0.6, but its *library* requires network < 3 and the snapshot contains network-3.1.4.0
+        - network-transport < 0 # tried network-transport-0.5.6, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - next-ref < 0 # tried next-ref-0.1.0.2, but its *library* requires stm >=2.2 && < 2.5 and the snapshot contains stm-2.5.1.0
+        - nix-derivation < 0 # tried nix-derivation-1.1.2, but its *executable* requires the disabled package: pretty-show
+        - nonemptymap < 0 # tried nonemptymap-0.0.6.0, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
         - normalization-insensitive < 0 # tried normalization-insensitive-2.0.2, but its *library* requires text >=1.1.1 && < 1.3 and the snapshot contains text-2.0.2
-        - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - not-gloss < 0 # tried not-gloss-0.7.7.0, but its *library* requires the disabled package: GLUT
+        - not-gloss < 0 # tried not-gloss-0.7.7.0, but its *library* requires the disabled package: vector-binary-instances
+        - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-env-parser < 0 # tried nri-env-parser-0.1.0.8, but its *library* requires the disabled package: nri-prelude
         - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-http < 0 # tried nri-http-0.3.0.0, but its *library* requires the disabled package: nri-prelude
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires the disabled package: nri-prelude
+        - nri-kafka < 0 # tried nri-kafka-0.1.0.4, but its *library* requires unix >=2.7.2.2 && < 2.8.0.0 and the snapshot contains unix-2.8.1.0
         - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-observability < 0 # tried nri-observability-0.1.1.4, but its *library* requires the disabled package: nri-prelude
-        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires resource-pool >=0.2.0.0 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
-        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires template-haskell >=2.15.0.0 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires template-haskell >=2.15.0.0 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - nri-postgresql < 0 # tried nri-postgresql-0.1.0.4, but its *library* requires the disabled package: nri-prelude
         - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
         - nri-redis < 0 # tried nri-redis-0.1.0.4, but its *library* requires the disabled package: nri-prelude
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires aeson >=1.4.6.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires base >=4.12.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant >=0.16.2 && < 0.19 and the snapshot contains servant-0.19.1
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires servant-server >=0.16.2 && < 0.19 and the snapshot contains servant-server-0.19.2
         - nri-test-encoding < 0 # tried nri-test-encoding-0.1.1.3, but its *library* requires the disabled package: nri-prelude
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* requires numhask >=0.3 && < 0.6 and the snapshot contains numhask-0.10.1.1
+        - numhask-space < 0 # tried numhask-space-0.10.0.1, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - numhask-space < 0 # tried numhask-space-0.10.0.1, but its *library* requires tdigest ^>=0.2.1 and the snapshot contains tdigest-0.3
+        - nvim-hs < 0 # tried nvim-hs-2.3.2.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - nvim-hs-contrib < 0 # tried nvim-hs-contrib-2.0.0.1, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - nvim-hs-ghcid < 0 # tried nvim-hs-ghcid-2.0.1.0, but its *library* requires the disabled package: nvim-hs
+        - nvim-hs-ghcid < 0 # tried nvim-hs-ghcid-2.0.1.0, but its *library* requires the disabled package: nvim-hs-contrib
         - nvvm < 0 # tried nvvm-0.10.0.0, but its *library* requires the disabled package: cuda
         - ochintin-daicho < 0 # tried ochintin-daicho-0.3.4.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - oeis < 0 # tried oeis-0.3.10, but its *library* requires HTTP >=4000.2 && < 4000.4 and the snapshot contains HTTP-4000.4.1
-        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires Cabal >=3.2.1.0 && < 3.3 and the snapshot contains Cabal-3.8.1.0
-        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires base >=4.14 && < 4.15 and the snapshot contains base-4.17.1.0
+        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires Cabal >=3.2.1.0 && < 3.3 and the snapshot contains Cabal-3.10.1.0
+        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires base >=4.14 && < 4.15 and the snapshot contains base-4.18.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires bytestring >=0.10.10.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires template-haskell >=2.16.0.0 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires template-haskell >=2.16.0.0 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires text >=1.2.4.0 && < 1.3 and the snapshot contains text-2.0.2
-        - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
-        - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
-        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.8.1.0
+        - om-elm < 0 # tried om-elm-2.0.0.2, but its *library* requires unix >=2.7.2.2 && < 2.8 and the snapshot contains unix-2.8.1.0
+        - one-liner < 0 # tried one-liner-2.1, but its *library* requires the disabled package: linear-base
+        - one-liner-instances < 0 # tried one-liner-instances-0.1.3.0, but its *library* requires the disabled package: one-liner
+        - options < 0 # tried options-1.2.1.1, but its *library* requires the disabled package: monads-tf
+        - optparse-generic < 0 # tried optparse-generic-1.4.9, but its *library* requires optparse-applicative >=0.16.0.0 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - ormolu < 0 # tried ormolu-0.7.1.0, but its *library* requires the disabled package: ghc-lib-parser
+        - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.1.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires groups >=0.4.1 && < 0.5 and the snapshot contains groups-0.5.3
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.3
+        - palette < 0 # tried palette-0.3.0.2, but its *library* requires base >=4.2 && < 4.18 and the snapshot contains base-4.18.0.0
+        - pandoc < 0 # tried pandoc-3.1.3, but its *library* requires the disabled package: connection
         - pandoc-csv2table < 0 # tried pandoc-csv2table-1.0.9, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - pandoc-dhall-decoder < 0 # tried pandoc-dhall-decoder-0.1.0.1, but its *library* requires the disabled package: dhall
+        - pandoc-plot < 0 # tried pandoc-plot-1.7.0, but its *library* requires the disabled package: pandoc
+        - pandoc-symreg < 0 # tried pandoc-symreg-0.2.0.0, but its *library* requires base >=4.16 && < 4.18 and the snapshot contains base-4.18.0.0
+        - pandoc-symreg < 0 # tried pandoc-symreg-0.2.0.0, but its *library* requires mtl ==2.2.* and the snapshot contains mtl-2.3.1
+        - pandoc-symreg < 0 # tried pandoc-symreg-0.2.0.0, but its *library* requires optparse-applicative ==0.17.* and the snapshot contains optparse-applicative-0.18.1.0
+        - pandoc-throw < 0 # tried pandoc-throw-0.1.0.0, but its *library* requires the disabled package: pandoc
+        - pango < 0 # tried pango-0.13.10.0, but its *library* requires the disabled package: gtk2hs-buildtools
+        - pantry < 0 # tried pantry-0.8.2.2, but its *library* requires the disabled package: persistent
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell ==2.15.* and the snapshot contains template-haskell-2.19.0.0
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell ==2.15.* and the snapshot contains template-haskell-2.20.0.0
+        - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires transformers ==0.5.* and the snapshot contains transformers-0.6.1.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires parser-combinators >=1.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
-        - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
+        - partial-semigroup < 0 # tried partial-semigroup-0.6.0.1, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - password-instances < 0 # tried password-instances-3.0.0.0, but its *library* requires the disabled package: persistent
+        - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
         - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires bytestring >=0.10 && < 0.11.4 and the snapshot contains bytestring-0.11.4.0
         - pasta-curves < 0 # tried pasta-curves-0.0.1.0, but its *library* requires memory >=0.16 && < 0.18 and the snapshot contains memory-0.18.0
+        - path-dhall-instance < 0 # tried path-dhall-instance-0.2.1.0, but its *library* requires the disabled package: dhall
         - path-formatting < 0 # tried path-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
+        - path-text-utf8 < 0 # tried path-text-utf8-0.0.1.11, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - pattern-arrows < 0 # tried pattern-arrows-0.0.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires ListLike ==3.1.* and the snapshot contains ListLike-4.7.8
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires hashtables ==1.0.* and the snapshot contains hashtables-1.3.1
         - peggy < 0 # tried peggy-0.3.2, but its *library* requires monad-control ==0.3.* and the snapshot contains monad-control-1.0.3.1
-        - peggy < 0 # tried peggy-0.3.2, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.19.0.0
+        - peggy < 0 # tried peggy-0.3.2, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.20.0.0
         - peregrin < 0 # tried peregrin-0.3.3, but its *library* requires text >=1.1.0 && < 2 and the snapshot contains text-2.0.2
-        - perf < 0 # tried perf-0.10.3, but its *library* requires the disabled package: numhask-space
+        - perf < 0 # tried perf-0.10.3, but its *library* requires optparse-applicative ^>=0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires MonadRandom >=0.5.1.1 && < 0.6 and the snapshot contains MonadRandom-0.6
-        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.1.0
+        - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.0.0
         - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires vector >=0.12.0 && < 0.13 and the snapshot contains vector-0.13.0.0
         - persist < 0 # tried persist-0.1.1.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
@@ -7078,25 +7723,47 @@ packages:
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: persistable-record
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query
         - persistable-types-HDBC-pg < 0 # tried persistable-types-HDBC-pg-0.0.3.5, but its *library* requires the disabled package: relational-query-HDBC
-        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-1.6.0
+        - persistent < 0 # tried persistent-2.14.5.0, but its *library* requires template-haskell >=2.13 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - persistent-discover < 0 # tried persistent-discover-0.1.0.6, but its *library* requires the disabled package: persistent
+        - persistent-documentation < 0 # tried persistent-documentation-0.1.0.4, but its *library* requires the disabled package: persistent
+        - persistent-iproute < 0 # tried persistent-iproute-0.2.5, but its *library* requires the disabled package: persistent
+        - persistent-lens < 0 # tried persistent-lens-1.0.0, but its *library* requires the disabled package: persistent
+        - persistent-mongoDB < 0 # tried persistent-mongoDB-2.13.0.1, but its *library* requires the disabled package: persistent
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.1, but its *library* requires resourcet >=1.2.4 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - persistent-mtl < 0 # tried persistent-mtl-0.5.0.1, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - persistent-mysql < 0 # tried persistent-mysql-2.13.1.4, but its *library* requires the disabled package: persistent
+        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-1.7.0
+        - persistent-pagination < 0 # tried persistent-pagination-0.1.1.2, but its *library* requires the disabled package: persistent
+        - persistent-postgresql < 0 # tried persistent-postgresql-2.13.5.2, but its *library* requires the disabled package: persistent
+        - persistent-qq < 0 # tried persistent-qq-2.12.0.5, but its *library* requires the disabled package: persistent
+        - persistent-redis < 0 # tried persistent-redis-2.13.0.1, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - persistent-sqlite < 0 # tried persistent-sqlite-2.13.1.1, but its *library* requires the disabled package: persistent
+        - persistent-test < 0 # tried persistent-test-2.13.1.3, but its *library* requires the disabled package: persistent
+        - persistent-typed-db < 0 # tried persistent-typed-db-0.1.0.7, but its *library* requires the disabled package: persistent
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.12.1
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires text >=1.1.0 && < 2 and the snapshot contains text-2.0.2
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - phantom-state < 0 # tried phantom-state-0.2.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - phatsort < 0 # tried phatsort-0.6.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires JuicyPixels >=3.2.8 && < 3.3 and the snapshot contains JuicyPixels-3.3.8
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal ==2.2.* and the snapshot contains Cabal-3.8.1.0
+        - picosat < 0 # tried picosat-0.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal ==2.2.* and the snapshot contains Cabal-3.10.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires aeson >=1.3 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires base ==4.11.* and the snapshot contains base-4.17.1.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires base ==4.11.* and the snapshot contains base-4.18.0.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires binary-orphans ==0.1.* and the snapshot contains binary-orphans-1.0.4.1
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires containers ==0.5.* and the snapshot contains containers-0.6.7
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires hashable ==1.2.* and the snapshot contains hashable-1.4.2.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires shake ==0.16.* and the snapshot contains shake-0.19.7
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires transformers ==0.5.* and the snapshot contains transformers-0.6.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires yaml >=0.8 && < 0.11 and the snapshot contains yaml-0.11.11.1
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal ==2.2.* and the snapshot contains Cabal-3.8.1.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base ==4.11.* and the snapshot contains base-4.17.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal ==2.2.* and the snapshot contains Cabal-3.10.1.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base ==4.11.* and the snapshot contains base-4.18.0.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base64-bytestring ==1.0.* and the snapshot contains base64-bytestring-1.2.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
@@ -7104,21 +7771,27 @@ packages:
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires http-client ==0.5.* and the snapshot contains http-client-0.7.13.1
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires shake >=0.16.4 && < 0.17 and the snapshot contains shake-0.19.7
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires unix ==2.7.* and the snapshot contains unix-2.8.1.0
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.0.0
         - pipes-category < 0 # tried pipes-category-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
+        - pipes-extras < 0 # tried pipes-extras-1.0.15, but its *library* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - pipes-misc < 0 # tried pipes-misc-0.5.0.0, but its *library* requires the disabled package: pipes-category
         - pipes-network-tls < 0 # tried pipes-network-tls-0.4, but its *library* requires the disabled package: pipes-network
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.17.1.0
+        - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: cairo
+        - plot < 0 # tried plot-0.2.3.11, but its *library* requires the disabled package: pango
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.18.0.0
         - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires haskell-src-exts-simple >=1.18 && < 1.21 || ^>=1.21 and the snapshot contains haskell-src-exts-simple-1.23.0.0
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires mtl >=2 && < 2.2 || ^>=2.2 and the snapshot contains mtl-2.3.1
+        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires transformers >=0.2 && < 0.5 || ^>=0.5 and the snapshot contains transformers-0.6.1.0
         - poly < 0 # tried poly-0.5.1.0, but its *library* requires the disabled package: vector-sized
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires aeson >=1.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
+        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.0
         - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires the disabled package: polysemy-kvstore
-        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.17.1.0
+        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.0.0
         - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.0
         - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires the disabled package: polysemy-extra
         - polysemy-socket < 0 # tried polysemy-socket-0.0.2.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.1.0
@@ -7130,81 +7803,121 @@ packages:
         - polysemy-vinyl < 0 # tried polysemy-vinyl-0.1.5.0, but its *library* requires the disabled package: polysemy-extra
         - polysemy-vinyl < 0 # tried polysemy-vinyl-0.1.5.0, but its *library* requires the disabled package: polysemy-several
         - polysemy-vinyl < 0 # tried polysemy-vinyl-0.1.5.0, but its *library* requires vinyl >=0.10.0 && < 0.14 and the snapshot contains vinyl-0.14.3
-        - polysemy-zoo < 0 # tried polysemy-zoo-0.8.1.0, but its *library* requires ghc-prim >=0.5.2 && < 0.9 and the snapshot contains ghc-prim-0.9.0
+        - polysemy-zoo < 0 # tried polysemy-zoo-0.8.1.0, but its *library* requires ghc-prim >=0.5.2 && < 0.9 and the snapshot contains ghc-prim-0.10.0
         - polysemy-zoo < 0 # tried polysemy-zoo-0.8.1.0, but its *library* requires text >=1.1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires base >=4.6.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - polysemy-zoo < 0 # tried polysemy-zoo-0.8.1.0, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires base >=4.6.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires containers >=0.5.9.2 && < =0.6.4.1 and the snapshot contains containers-0.6.7
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires ghc-prim >=0.4 && < 0.7 and the snapshot contains ghc-prim-0.9.0
+        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires ghc-prim >=0.4 && < 0.7 and the snapshot contains ghc-prim-0.10.0
         - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: inflections
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires HTTP >=4000.3.7 && < 4000.4 and the snapshot contains HTTP-4000.4.1
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires aeson >=1.4.7 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.17.1.0
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.0.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql >=1.4 && < 1.5 and the snapshot contains hasql-1.6.3
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-dynamic-statements ==0.3.1 and the snapshot contains hasql-dynamic-statements-0.3.1.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-pool >=0.5 && < 0.6 and the snapshot contains hasql-pool-0.9.0.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-pool >=0.5 && < 0.6 and the snapshot contains hasql-pool-0.10
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires jose >=0.8.1 && < 0.9 and the snapshot contains jose-0.10
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens >=4.14 && < 5.1 and the snapshot contains lens-5.2.2
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens-aeson >=1.0.1 && < 1.2 and the snapshot contains lens-aeson-1.2.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.17.1.0
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires swagger2 >=2.4 && < 2.7 and the snapshot contains swagger2-2.8.7
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires time >=1.6 && < 1.11 and the snapshot contains time-1.12.2
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - pqueue < 0 # tried pqueue-1.4.3.0, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.18.0.0
+        - prairie < 0 # tried prairie-0.0.2.0, but its *library* requires template-haskell >=2.15 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - pred-set < 0 # tried pred-set-0.0.1, but its *library* requires the disabled package: HSet
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: pred-set
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - pretty-show < 0 # tried pretty-show-1.10, but its *library* requires the disabled package: happy
+        - pretty-sop < 0 # tried pretty-sop-0.2.0.3, but its *library* requires the disabled package: pretty-show
+        - prettyprinter-combinators < 0 # tried prettyprinter-combinators-0.1.1.1, but its *library* requires the disabled package: pretty-show
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.7
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires lens >=4.10 && < 4.16 and the snapshot contains lens-5.2.2
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires transformers >=0.4.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - profiterole < 0 # tried profiterole-0.1, but its *executable* requires the disabled package: ghc-prof
         - profiteur < 0 # tried profiteur-0.4.6.1, but its *executable* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - prometheus < 0 # tried prometheus-2.2.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - prometheus < 0 # tried prometheus-2.2.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
-        - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
-        - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.1.2, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.4.5
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.17.1.0
-        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.8.1.0
-        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.17.1.0
+        - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.11, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
+        - proto-lens-optparse < 0 # tried proto-lens-optparse-0.1.1.10, but its *library* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.1.2, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
+        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *executable* requires ghc >=8.2 && < 9.3 and the snapshot contains ghc-9.6.2
+        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.7.1.1, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
+        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires Cabal >=2.0 && < 3.7 and the snapshot contains Cabal-3.10.1.0
+        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.6, but its *library* requires base >=4.10 && < 4.17 and the snapshot contains base-4.18.0.0
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
-        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.17.1.0
-        - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.17.1.0
-        - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
+        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.18.0.0
+        - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.18.0.0
+        - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *executable* requires optparse-applicative >=0.14.2.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires bytestring >=0.10.0.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - qnap-decrypt < 0 # tried qnap-decrypt-0.3.5, but its *library* requires the disabled package: cipher-aes128
-        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-0.11.5
+        - quadratic-irrational < 0 # tried quadratic-irrational-0.1.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-1.0
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
-        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires the disabled package: ginger
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+        - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - quickbench < 0 # tried quickbench-1.0.1, but its *library* requires the disabled package: docopt
-        - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
+        - quickcheck-assertions < 0 # tried quickcheck-assertions-0.3.0, but its *library* requires the disabled package: pretty-show
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.5, but its *library* requires the disabled package: unfoldable-restricted
+        - quickcheck-groups < 0 # tried quickcheck-groups-0.0.0.0, but its *library* requires base >=4.14.3.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - quickcheck-groups < 0 # tried quickcheck-groups-0.0.0.0, but its *library* requires semigroupoids >=5.3.7 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - quickcheck-monoid-subclasses < 0 # tried quickcheck-monoid-subclasses-0.1.0.0, but its *library* requires base >=4.14.3.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - quickcheck-monoid-subclasses < 0 # tried quickcheck-monoid-subclasses-0.1.0.0, but its *library* requires semigroupoids >=5.3.7 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.3, but its *library* requires the disabled package: graphviz
+        - quickcheck-state-machine < 0 # tried quickcheck-state-machine-0.7.3, but its *library* requires the disabled package: pretty-show
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires constraints >=0.9.1 && < 0.11 and the snapshot contains constraints-0.13.4
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires extensible >=0.4.7.2 && < 0.4.11 and the snapshot contains extensible-0.9
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.5.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.2.2
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.0
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
-        - random-source < 0 # tried random-source-0.3.0.12, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.17.1.0
+        - random-source < 0 # tried random-source-0.3.0.12, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.18.0.0
+        - random-source < 0 # tried random-source-0.3.0.12, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - rank2classes < 0 # tried rank2classes-1.5.1, but its *library* requires template-haskell >=2.11 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - rank2classes < 0 # tried rank2classes-1.5.1, but its *library* requires the disabled package: data-functor-logistic
+        - rasterific-svg < 0 # tried rasterific-svg-0.3.3.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - rasterific-svg < 0 # tried rasterific-svg-0.3.3.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - reactive-balsa < 0 # tried reactive-balsa-0.4.0.1, but its *library* requires the disabled package: reactive-banana-bunch
+        - reactive-banana < 0 # tried reactive-banana-1.3.2.0, but its *library* requires the disabled package: pqueue
+        - reactive-banana-bunch < 0 # tried reactive-banana-bunch-1.0.0.1, but its *library* requires the disabled package: reactive-banana
+        - reactive-jack < 0 # tried reactive-jack-0.4.1.2, but its *library* requires the disabled package: reactive-banana-bunch
+        - reactive-midyim < 0 # tried reactive-midyim-0.4.1.1, but its *library* requires the disabled package: reactive-banana-bunch
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.1.2.1
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires the disabled package: reanimate-svg
-        - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.17.1.0
+        - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.18.0.0
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
-        - records-sop < 0 # tried records-sop-0.1.1.0, but its *library* requires ghc-prim >=0.5 && < 0.8 and the snapshot contains ghc-prim-0.9.0
+        - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.16, but its *library* requires ghc >=8.6 && < 9.5 and the snapshot contains ghc-9.6.2
+        - records-sop < 0 # tried records-sop-0.1.1.0, but its *library* requires ghc-prim >=0.5 && < 0.8 and the snapshot contains ghc-prim-0.10.0
+        - redact < 0 # tried redact-0.5.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - redis-io < 0 # tried redis-io-1.1.0, but its *library* requires the disabled package: tinylog
         - redis-resp < 0 # tried redis-resp-1.0.0, but its *library* requires the disabled package: bytestring-conversion
+        - reform < 0 # tried reform-0.2.7.5, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
+        - reform-blaze < 0 # tried reform-blaze-0.2.4.4, but its *library* requires the disabled package: reform
         - reform-hamlet < 0 # tried reform-hamlet-0.0.5.3, but its *library* requires shakespeare >=2.0 && < 2.1 and the snapshot contains shakespeare-2.1.0
         - reform-hamlet < 0 # tried reform-hamlet-0.0.5.3, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - reform-happstack < 0 # tried reform-happstack-0.2.5.6, but its *library* requires the disabled package: reform
         - reform-hsp < 0 # tried reform-hsp-0.2.7.2, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - regex-applicative < 0 # tried regex-applicative-0.3.4, but its *library* requires the disabled package: filtrable
+        - regex-applicative-text < 0 # tried regex-applicative-text-0.1.0.1, but its *library* requires base >=4.3 && < 4.18 and the snapshot contains base-4.18.0.0
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires regex-base ==0.93.* and the snapshot contains regex-base-0.94.0.2
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires regex-pcre-builtin ==0.94.* and the snapshot contains regex-pcre-builtin-0.95.2.3.8.44
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
         - regex-tdfa-text < 0 # tried regex-tdfa-text-1.0.0.3, but its *library* requires regex-base < 0.94 and the snapshot contains regex-base-0.94.0.2
+        - registry < 0 # tried registry-0.6.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - registry < 0 # tried registry-0.6.0.0, but its *library* requires semigroupoids >=5.0 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - registry < 0 # tried registry-0.6.0.0, but its *library* requires text >=1.1 && < 2 and the snapshot contains text-2.0.2
         - registry-aeson < 0 # tried registry-aeson-0.3.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
         - registry-hedgehog < 0 # tried registry-hedgehog-0.8.0.0, but its *library* requires tasty-discover >=2 && < 5 and the snapshot contains tasty-discover-5.0.0
@@ -7212,30 +7925,39 @@ packages:
         - registry-hedgehog-aeson < 0 # tried registry-hedgehog-aeson-0.3.0.0, but its *library* requires tasty-discover >=2 && < 5 and the snapshot contains tasty-discover-5.0.0
         - registry-hedgehog-aeson < 0 # tried registry-hedgehog-aeson-0.3.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
         - registry-options < 0 # tried registry-options-0.2.0.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - rel8 < 0 # tried rel8-1.4.1.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
         - relational-query < 0 # tried relational-query-0.12.3.0, but its *library* requires the disabled package: product-isomorphic
         - relational-query-HDBC < 0 # tried relational-query-HDBC-0.7.2.0, but its *library* requires the disabled package: product-isomorphic
         - relational-record < 0 # tried relational-record-0.2.2.0, but its *library* requires the disabled package: product-isomorphic
         - relational-schemas < 0 # tried relational-schemas-0.1.8.0, but its *library* requires the disabled package: relational-query
-        - reorder-expression < 0 # tried reorder-expression-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
-        - repa < 0 # tried repa-3.4.1.5, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.17.1.0
+        - relude < 0 # tried relude-1.2.0.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
+        - relude < 0 # tried relude-1.2.0.0, but its *library* requires ghc-prim >=0.5.0.0 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - reorder-expression < 0 # tried reorder-expression-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
+        - repa < 0 # tried repa-3.4.1.5, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.18.0.0
         - repa < 0 # tried repa-3.4.1.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - repa-algorithms < 0 # tried repa-algorithms-3.4.1.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
         - repa-io < 0 # tried repa-io-3.4.1.2, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - req < 0 # tried req-3.13.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - req-conduit < 0 # tried req-conduit-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
+        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires req >=2.0.0 && < 2.1.0 and the snapshot contains req-3.13.0
         - require < 0 # tried require-0.4.11, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - require < 0 # tried require-0.4.11, but its *library* requires text >=1.2.3.0 && < 2 and the snapshot contains text-2.0.2
-        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* requires base < 4.15 and the snapshot contains base-4.17.1.0
+        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* requires base < 4.15 and the snapshot contains base-4.18.0.0
+        - rev-state < 0 # tried rev-state-0.1.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - rhbzquery < 0 # tried rhbzquery-0.4.4, but its *executable* requires the disabled package: email-validate
+        - rhine < 0 # tried rhine-0.8.1.1, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.0.0
         - rhine < 0 # tried rhine-0.8.1.1, but its *library* requires simple-affine-space ==0.1.1 and the snapshot contains simple-affine-space-0.2.1
-        - rhine-gloss < 0 # tried rhine-gloss-0.8.1.1, but its *library* requires the disabled package: rhine
+        - rhine-gloss < 0 # tried rhine-gloss-0.8.1.1, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.18.0.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires aeson >=0.8 && < 1.5.7 and the snapshot contains aeson-2.1.2.1
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires attoparsec >=0.12.1.6 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires network >=3.0 && < 3.1 and the snapshot contains network-3.1.4.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires resource-pool ==0.2.* and the snapshot contains resource-pool-0.4.0.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires text ==1.2.* and the snapshot contains text-2.0.2
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires time >=1.4.2 && < 1.10 and the snapshot contains time-1.12.2
+        - riak < 0 # tried riak-1.2.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.0.0
         - roc-id < 0 # tried roc-id-0.2.0.0, but its *library* requires the disabled package: vector-sized
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
@@ -7244,23 +7966,35 @@ packages:
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires network >=2.6 && < 2.8 and the snapshot contains network-3.1.4.0
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - rpmbuild-order < 0 # tried rpmbuild-order-0.4.10, but its *library* requires the disabled package: graphviz
+        - rss-conduit < 0 # tried rss-conduit-0.6.0.1, but its *library* requires the disabled package: atom-conduit
+        - safe-exceptions-checked < 0 # tried safe-exceptions-checked-0.1.0, but its *library* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - safe-tensor < 0 # tried safe-tensor-0.2.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - safe-tensor < 0 # tried safe-tensor-0.2.1.1, but its *library* requires singletons >=2.5 && < 2.8 and the snapshot contains singletons-3.0.2
         - salak < 0 # tried salak-0.3.6, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - salak < 0 # tried salak-0.3.6, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - salak < 0 # tried salak-0.3.6, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
         - salak < 0 # tried salak-0.3.6, but its *library* requires time >=1.8.0 && < 1.11 and the snapshot contains time-1.12.2
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires the disabled package: tomland
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.12.2
         - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - sandwich < 0 # tried sandwich-0.1.4.0, but its *library* requires the disabled package: pretty-show
+        - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.3.0, but its *library* requires the disabled package: hedgehog
+        - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.7, but its *library* requires the disabled package: sandwich
+        - sandwich-slack < 0 # tried sandwich-slack-0.1.1.0, but its *library* requires the disabled package: wreq
+        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.2.1.0, but its *library* requires the disabled package: sandwich
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - scale < 0 # tried scale-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires containers >=0.5.7.1 && < 0.6 and the snapshot contains containers-0.6.7
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires text >=1.2.0.0 && < 2 and the snapshot contains text-2.0.2
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires aeson >=1 && < 1.4.3.0 and the snapshot contains aeson-2.1.2.1
+        - secp256k1-haskell < 0 # tried secp256k1-haskell-0.6.1, but its *library* requires the disabled package: base16
+        - selda < 0 # tried selda-0.5.2.0, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - selda < 0 # tried selda-0.5.2.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - selda < 0 # tried selda-0.5.2.0, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - selda-json < 0 # tried selda-json-0.1.1.1, but its *library* requires aeson >=1.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
@@ -7270,191 +8004,346 @@ packages:
         - selda-postgresql < 0 # tried selda-postgresql-0.1.8.2, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
+        - semigroupoid-extras < 0 # tried semigroupoid-extras-5, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - sendgrid-v3 < 0 # tried sendgrid-v3-1.0.0.1, but its *library* requires the disabled package: wreq
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires base >=4.11 && < 4.14 and the snapshot contains base-4.17.1.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires base >=4.11 && < 4.14 and the snapshot contains base-4.18.0.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires http-client >=0.5.6 && < 0.7 and the snapshot contains http-client-0.7.13.1
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires lens >=4.15 && < 4.20 and the snapshot contains lens-5.2.2
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires optparse-applicative >=0.12 && < 0.16 and the snapshot contains optparse-applicative-0.17.1.0
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires optparse-applicative >=0.12 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.0.2
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix < 2.8 and the snapshot contains unix-2.8.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix-compat < 0.6 and the snapshot contains unix-compat-0.7
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - seqid < 0 # tried seqid-0.6.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - seqid < 0 # tried seqid-0.6.2, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - seqid-streams < 0 # tried seqid-streams-0.7.2, but its *library* requires the disabled package: seqid
         - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
+        - servant < 0 # tried servant-0.19.1, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant < 0 # tried servant-0.19.1, but its *library* requires bifunctors >=5.5.3 && < 5.6 and the snapshot contains bifunctors-5.6.1
+        - servant < 0 # tried servant-0.19.1, but its *library* requires http-api-data >=0.4.1 && < 0.5.1 and the snapshot contains http-api-data-0.5.1
+        - servant < 0 # tried servant-0.19.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant < 0 # tried servant-0.19.1, but its *library* requires singleton-bool >=0.1.4 && < 0.1.7 and the snapshot contains singleton-bool-0.1.7
+        - servant < 0 # tried servant-0.19.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-auth-client < 0 # tried servant-auth-client-0.4.1.0, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.5
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.7
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5.1
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-types >=0.9 && < 0.12 and the snapshot contains http-types-0.12.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires memory >=0.11 && < 0.15 and the snapshot contains memory-0.18.0
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.19.1
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.19.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
+        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.0, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires jose >=0.7.0.0 && < 0.10 and the snapshot contains jose-0.10
         - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires monad-time >=0.3.1.0 && < 0.4 and the snapshot contains monad-time-0.4.0.0
+        - servant-auth-server < 0 # tried servant-auth-server-0.4.7.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.1, but its *library* requires lens >=4.16.1 && < 5.2 and the snapshot contains lens-5.2.2
+        - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: servant-server
+        - servant-blaze < 0 # tried servant-blaze-0.9.1, but its *library* requires the disabled package: servant
+        - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.13.0
+        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant
+        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-client
+        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-client-core
+        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *library* requires the disabled package: servant-server
+        - servant-checked-exceptions-core < 0 # tried servant-checked-exceptions-core-2.2.0.1, but its *library* requires the disabled package: servant
+        - servant-checked-exceptions-core < 0 # tried servant-checked-exceptions-core-2.2.0.1, but its *library* requires the disabled package: servant-docs
+        - servant-client < 0 # tried servant-client-0.19, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-client < 0 # tried servant-client-0.19, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-client < 0 # tried servant-client-0.19, but its *library* requires semigroupoids >=5.3.1 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - servant-client < 0 # tried servant-client-0.19, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires free >=5.1 && < 5.2 and the snapshot contains free-5.2
+        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires template-haskell >=2.11.1.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - servant-client-core < 0 # tried servant-client-core-0.19, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-conduit < 0 # tried servant-conduit-0.15.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-conduit < 0 # tried servant-conduit-0.15.1, but its *library* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - servant-docs < 0 # tried servant-docs-0.12, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.19.1
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-elm < 0 # tried servant-elm-0.7.3, but its *library* requires the disabled package: servant
+        - servant-elm < 0 # tried servant-elm-0.7.3, but its *library* requires the disabled package: servant-foreign
+        - servant-elm < 0 # tried servant-elm-0.7.3, but its *library* requires the disabled package: wl-pprint-text
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.17.1.0
+        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
+        - servant-exceptions < 0 # tried servant-exceptions-0.2.1, but its *library* requires the disabled package: servant
+        - servant-exceptions-server < 0 # tried servant-exceptions-server-0.2.1, but its *library* requires the disabled package: servant
+        - servant-exceptions-server < 0 # tried servant-exceptions-server-0.2.1, but its *library* requires the disabled package: servant-server
+        - servant-foreign < 0 # tried servant-foreign-0.15.4, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires semigroupoids >=5.3.1 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - servant-http-streams < 0 # tried servant-http-streams-0.18.4, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.1.2.1
+        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.6.7
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires formatting >=6.2 && < 6.4 and the snapshot contains formatting-7.2.0
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires lens >=4.15 && < 4.18 and the snapshot contains lens-5.2.2
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant >=0.9 && < 0.17 and the snapshot contains servant-0.19.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - servant-lucid < 0 # tried servant-lucid-0.9.0.6, but its *library* requires the disabled package: servant
+        - servant-machines < 0 # tried servant-machines-0.15.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires QuickCheck >=2.12.6.1 && < 2.14 and the snapshot contains QuickCheck-2.14.3
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.17.1.0
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.12.2
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.18.0.0
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.0
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19.1
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.2
+        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - servant-multipart-api < 0 # tried servant-multipart-api-0.12.1, but its *library* requires the disabled package: servant
+        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-client
+        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-multipart
+        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *executable* requires the disabled package: servant-server
+        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *library* requires the disabled package: servant
+        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.1, but its *library* requires the disabled package: servant-client-core
+        - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.6, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires lens >=4.9 && < 5 and the snapshot contains lens-5.2.2
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires pandoc-types >=1.12 && < 1.18 and the snapshot contains pandoc-types-1.23
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires servant-docs >=0.11.1 && < 0.12 and the snapshot contains servant-docs-0.12
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - servant-pipes < 0 # tried servant-pipes-0.15.3, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.1.2.1
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.1.0
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base-compat-batteries >=0.10.1 && < 0.12 and the snapshot contains base-compat-batteries-0.12.2
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.0.0
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires base-compat-batteries >=0.10.1 && < 0.12 and the snapshot contains base-compat-batteries-0.13.0
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires hspec >=2.5.6 && < 2.8 and the snapshot contains hspec-2.10.10
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires hspec >=2.5.6 && < 2.8 and the snapshot contains hspec-2.11.1
+        - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.19.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-client >=0.17 && < 0.19 and the snapshot contains servant-client-0.19
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.19.2
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.0.2
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
+        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant
+        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant-client
+        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant-server
+        - servant-rawm < 0 # tried servant-rawm-1.0.0.0, but its *library* requires the disabled package: servant
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.1.0
+        - servant-server < 0 # tried servant-server-0.19.2, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-server < 0 # tried servant-server-0.19.2, but its *library* requires http-api-data >=0.4.1 && < 0.5.1 and the snapshot contains http-api-data-0.5.1
+        - servant-server < 0 # tried servant-server-0.19.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - servant-server < 0 # tried servant-server-0.19.2, but its *library* requires resourcet >=1.2.2 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - servant-server < 0 # tried servant-server-0.19.2, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-static-th < 0 # tried servant-static-th-1.0.0.0, but its *library* requires the disabled package: servant
+        - servant-static-th < 0 # tried servant-static-th-1.0.0.0, but its *library* requires the disabled package: servant-server
+        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.0.0
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.19.1
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.1.0
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.0.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
+        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant >=0.14 && < 0.15 and the snapshot contains servant-0.19.1
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant-client-core >=0.14 && < 0.15 and the snapshot contains servant-client-core-0.19
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.17.1.0
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.18.0.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.0.0
+        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
         - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires servant-server >=0.13 && < 0.15 and the snapshot contains servant-server-0.19.2
+        - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant
+        - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant-foreign
+        - servant-subscriber < 0 # tried servant-subscriber-0.7.0.0, but its *library* requires the disabled package: servant-server
+        - servant-swagger < 0 # tried servant-swagger-1.1.11, but its *library* requires the disabled package: servant
+        - servant-swagger-ui < 0 # tried servant-swagger-ui-0.3.5.5.0.0, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.18.0.0
+        - servant-swagger-ui-core < 0 # tried servant-swagger-ui-core-0.3.5, but its *library* requires the disabled package: servant
+        - servant-swagger-ui-core < 0 # tried servant-swagger-ui-core-0.3.5, but its *library* requires the disabled package: servant-server
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires aeson >=0.8.0.2 && < 2.1.0 and the snapshot contains aeson-2.1.2.1
-        - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.1.0
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.17.1.0
+        - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.0.0
+        - servant-websockets < 0 # tried servant-websockets-2.0.0, but its *library* requires the disabled package: servant-server
+        - servant-xml < 0 # tried servant-xml-1.0.2, but its *library* requires the disabled package: servant
+        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.18.0.0
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.19.1
         - serverless-haskell < 0 # tried serverless-haskell-0.12.6, but its *library* requires the disabled package: amazonka-core
+        - serversession < 0 # tried serversession-1.0.3, but its *library* requires the disabled package: persistent-test
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-2.0.1, but its *library* requires persistent ==2.13.* and the snapshot contains persistent-2.14.5.0
+        - serversession-backend-redis < 0 # tried serversession-backend-redis-1.0.5, but its *library* requires the disabled package: serversession
+        - serversession-frontend-wai < 0 # tried serversession-frontend-wai-1.0.1, but its *library* requires the disabled package: serversession
+        - serversession-frontend-yesod < 0 # tried serversession-frontend-yesod-1.0.1, but its *library* requires the disabled package: serversession
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.5
+        - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.7
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
+        - sets < 0 # tried sets-0.0.6.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - sexpr-parser < 0 # tried sexpr-parser-0.2.2.0, but its *library* requires megaparsec >=6.5 && < 9.3 and the snapshot contains megaparsec-9.3.1
         - shake-language-c < 0 # tried shake-language-c-0.12.0, but its *library* requires the disabled package: fclabels
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed
-        - shellmet < 0 # tried shellmet-0.0.4.1, but its *library* requires base >=4.10.1.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - shell-conduit < 0 # tried shell-conduit-5.0.0, but its *library* requires the disabled package: monads-tf
+        - shellmet < 0 # tried shellmet-0.0.4.1, but its *library* requires base >=4.10.1.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - shelltestrunner < 0 # tried shelltestrunner-1.9, but its *executable* requires the disabled package: test-framework
         - shikensu < 0 # tried shikensu-0.4.1, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.2
+        - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
+        - simple-expr < 0 # tried simple-expr-0.1.0.2, but its *library* requires the disabled package: graphviz
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires text >=0.11.0 && < 2.0.0 and the snapshot contains text-2.0.2
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
+        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - simple-media-timestamp-formatting < 0 # tried simple-media-timestamp-formatting-0.1.1.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.19.0.0
+        - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.20.0.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - siphash < 0 # tried siphash-1.0.3, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.11.4.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.17.1.0
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.18.0.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires constraints >=0.9 && < 0.11 and the snapshot contains constraints-0.13.4
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires lens >=4.15 && < 5 and the snapshot contains lens-5.2.2
+        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires random ==1.1.* and the snapshot contains random-1.2.1.1
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
-        - slack-web < 0 # tried slack-web-1.6.1.0, but its *executable* requires the disabled package: butcher
-        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.17.1.0
-        - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
+        - skylighting < 0 # tried skylighting-0.13.2.1, but its *executable* requires the disabled package: pretty-show
+        - slack-progressbar < 0 # tried slack-progressbar-0.1.0.1, but its *library* requires the disabled package: wreq
+        - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
+        - slick < 0 # tried slick-1.2.1.0, but its *library* requires the disabled package: pandoc
+        - slist < 0 # tried slist-0.2.1.0, but its *library* requires base >=4.10.1.0 && < 4.18 and the snapshot contains base-4.18.0.0
+        - slynx < 0 # tried slynx-0.7.2.1, but its *library* requires the disabled package: statistics
+        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.18.0.0
+        - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
+        - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.1
         - smash < 0 # tried smash-0.1.3, but its *library* requires hashable ^>=1.3 and the snapshot contains hashable-1.4.2.0
         - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires base >=4.1 && < 4.17 and the snapshot contains base-4.17.1.0
-        - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires base >=4.1 && < 4.17 and the snapshot contains base-4.18.0.0
+        - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
         - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires lens >=4.0 && < 5.2 and the snapshot contains lens-5.2.2
-        - smash-microlens < 0 # tried smash-microlens-0.1.0.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - smash-microlens < 0 # tried smash-microlens-0.1.0.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires linear >=1.16 && < 1.22 and the snapshot contains linear-1.22
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - smtp-mail < 0 # tried smtp-mail-0.3.0.0, but its *library* requires the disabled package: connection
+        - snap < 0 # tried snap-1.1.3.1, but its *library* requires base >=4 && < 4.18 and the snapshot contains base-4.18.0.0
+        - snap < 0 # tried snap-1.1.3.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - snap < 0 # tried snap-1.1.3.1, but its *library* requires the disabled package: snap-server
+        - snap < 0 # tried snap-1.1.3.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - soap < 0 # tried soap-0.2.3.6, but its *library* requires the disabled package: iconv
         - soap-openssl < 0 # tried soap-openssl-0.1.0.2, but its *library* requires the disabled package: soap
-        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires the disabled package: soap
+        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires the disabled package: connection
         - socket-activation < 0 # tried socket-activation-0.1.0.2, but its *library* requires network >=2.3 && < 2.9 and the snapshot contains network-3.1.4.0
+        - solana-staking-csvs < 0 # tried solana-staking-csvs-0.1.2.0, but its *library* requires the disabled package: req
+        - spacecookie < 0 # tried spacecookie-1.0.0.2, but its *library* requires the disabled package: filepath-bytestring
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires inline-java >=0.7.0 && < 0.9 and the snapshot contains inline-java-0.10.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires jvm >=0.4.0.1 && < 0.5 and the snapshot contains jvm-0.6.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: distributed-closure
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: jni
-        - sparse-linear-algebra < 0 # tried sparse-linear-algebra-0.3.1, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.1.0
-        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires Cabal >=1.24 && < 3.5 and the snapshot contains Cabal-3.8.1.0
+        - sparse-linear-algebra < 0 # tried sparse-linear-algebra-0.3.1, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.0.0
+        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires Cabal >=1.24 && < 3.5 and the snapshot contains Cabal-3.10.1.0
         - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires ad >=4.2 && < 4.5 and the snapshot contains ad-4.5.4
-        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires Cabal ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0 || ^>=3.4.0.0 || ^>=3.6.0.0 and the snapshot contains Cabal-3.8.1.0
-        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires base >=4.3.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - spatial-math < 0 # tried spatial-math-0.5.0.1, but its *library* requires the disabled package: TypeCompose
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires Cabal ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0 || ^>=3.4.0.0 || ^>=3.6.0.0 and the snapshot contains Cabal-3.10.1.0
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires base >=4.3.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - speculation < 0 # tried speculation-1.5.0.3, but its *library* requires stm >=2.1 && < 2.5 and the snapshot contains stm-2.5.1.0
+        - speculation < 0 # tried speculation-1.5.0.3, but its *library* requires transformers >=0.2.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sqlcli < 0 # tried sqlcli-0.2.2.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - sqlcli-odbc < 0 # tried sqlcli-odbc-0.2.0.1, but its *library* requires the disabled package: sqlcli
         - sqlite-simple-errors < 0 # tried sqlite-simple-errors-0.6.1.0, but its *library* requires text >=1.2 && < 1.2.4 and the snapshot contains text-2.0.2
         - squeal-postgresql < 0 # tried squeal-postgresql-0.9.1.0, but its *library* requires the disabled package: records-sop
+        - srt-attoparsec < 0 # tried srt-attoparsec-0.1.0.0, but its *library* requires mtl >=1.0 && < =2.3 and the snapshot contains mtl-2.3.1
         - srt-attoparsec < 0 # tried srt-attoparsec-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires dhall >=1 && < 1.41 and the snapshot contains dhall-1.41.2
+        - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires dhall >=1 && < 1.41 and the snapshot contains dhall-1.42.0
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - srt-formatting < 0 # tried srt-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
-        - stack < 0 # tried stack-2.11.1, but its *library* requires ansi-terminal >=1.0 and the snapshot contains ansi-terminal-0.11.5
-        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires base >=4.12.0.0 && < 4.16 and the snapshot contains base-4.17.1.0
+        - srtree < 0 # tried srtree-1.0.0.4, but its *library* requires base >=4.16 && < 4.18 and the snapshot contains base-4.18.0.0
+        - srtree < 0 # tried srtree-1.0.0.4, but its *library* requires mtl ==2.2.* and the snapshot contains mtl-2.3.1
+        - stache < 0 # tried stache-2.3.3, but its *library* requires template-haskell >=2.11 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - stack < 0 # tried stack-2.11.1, but its *library* requires Cabal >=3.8.1.0 && < 3.10 and the snapshot contains Cabal-3.10.1.0
+        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires base >=4.12.0.0 && < 4.16 and the snapshot contains base-4.18.0.0
+        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires transformers ==0.5.6.* and the snapshot contains transformers-0.6.1.0
+        - stateWriter < 0 # tried stateWriter-0.3.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - stateWriter < 0 # tried stateWriter-0.3.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - statistics < 0 # tried statistics-0.16.2.0, but its *library* requires the disabled package: vector-binary-instances
+        - statistics-linreg < 0 # tried statistics-linreg-0.3, but its *library* requires the disabled package: statistics
         - stb-image-redux < 0 # tried stb-image-redux-0.2.1.2, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - stm-conduit < 0 # tried stm-conduit-4.0.1, but its *library* requires resourcet >=0.3 && < 1.3 and the snapshot contains resourcet-1.3.0
+        - stm-conduit < 0 # tried stm-conduit-4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - stm-lifted < 0 # tried stm-lifted-2.5.0.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - stm-supply < 0 # tried stm-supply-0.2.0.0, but its *library* requires the disabled package: concurrent-supply
+        - stopwatch < 0 # tried stopwatch-0.1.0.6, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - streaming < 0 # tried streaming-0.2.3.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
+        - streaming < 0 # tried streaming-0.2.3.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - streaming-attoparsec < 0 # tried streaming-attoparsec-1.0.0.1, but its *library* requires the disabled package: streaming
+        - streaming-attoparsec < 0 # tried streaming-attoparsec-1.0.0.1, but its *library* requires the disabled package: streaming-bytestring
+        - streaming-bytestring < 0 # tried streaming-bytestring-0.3.0, but its *library* requires ghc-prim >=0.4 && < 0.10 and the snapshot contains ghc-prim-0.10.0
         - streaming-cassava < 0 # tried streaming-cassava-0.2.0.0, but its *library* requires streaming-bytestring ==0.2.* and the snapshot contains streaming-bytestring-0.3.0
-        - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.17.1.0
+        - streaming-wai < 0 # tried streaming-wai-0.1.1, but its *library* requires the disabled package: streaming
+        - streamly < 0 # tried streamly-0.9.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - streamly-bytestring < 0 # tried streamly-bytestring-0.2.0, but its *library* requires the disabled package: streamly-core
+        - streamly-core < 0 # tried streamly-core-0.1.0, but its *library* requires ghc-prim >=0.5.3 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+        - streamly-core < 0 # tried streamly-core-0.1.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - streamly-examples < 0 # tried streamly-examples-0.1.3, but its *executable* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - streamly-process < 0 # tried streamly-process-0.3.0, but its *library* requires the disabled package: streamly
+        - streamly-process < 0 # tried streamly-process-0.3.0, but its *library* requires the disabled package: streamly-core
+        - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.18.0.0
+        - streamt < 0 # tried streamt-0.5.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - strict-tuple-lens < 0 # tried strict-tuple-lens-0.2, but its *library* requires lens ^>=5 and the snapshot contains lens-5.2.2
         - string-class < 0 # tried string-class-0.1.7.0, but its *library* requires text >=0.11.0.1 && < 1.3 and the snapshot contains text-2.0.2
+        - stripe-concepts < 0 # tried stripe-concepts-1.0.3.2, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
         - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
+        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-core
         - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-http-client
         - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+        - stripe-scotty < 0 # tried stripe-scotty-1.1.0.3, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
+        - stripe-signature < 0 # tried stripe-signature-1.0.0.15, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec >=2.1.0 && < 2.8 and the snapshot contains hspec-2.10.10
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec-core >=2.1.0 && < 2.8 and the snapshot contains hspec-core-2.10.10
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec >=2.1.0 && < 2.8 and the snapshot contains hspec-2.11.1
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec-core >=2.1.0 && < 2.8 and the snapshot contains hspec-core-2.11.1
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.1
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
+        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - stripe-wreq < 0 # tried stripe-wreq-1.0.1.15, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 and the snapshot contains base-4.18.0.0
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable ==1.3.* and the snapshot contains hashable-1.4.2.0
-        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.19.0.0
+        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
         - strongweak < 0 # tried strongweak-0.6.0, but its *library* requires the disabled package: refined1
+        - structured-cli < 0 # tried structured-cli-2.7.0.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
         - sv < 0 # tried sv-1.4.0.1, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.1.0
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.0.0
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.1
         - sv < 0 # tried sv-1.4.0.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - sv < 0 # tried sv-1.4.0.1, but its *library* requires the disabled package: hw-dsv
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires the disabled package: validation
+        - sv < 0 # tried sv-1.4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires the disabled package: validation
         - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.1.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.0.0
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.1
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires lens >=4 && < 4.20 and the snapshot contains lens-5.2.2
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires mtl >=2.0.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires profunctors >=5.2.1 && < 5.6 and the snapshot contains profunctors-5.6.2
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires the disabled package: validation
+        - sv-core < 0 # tried sv-core-0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - sv-core < 0 # tried sv-core-0.5, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires aeson >=1.0 && < 2.0 and the snapshot contains aeson-2.1.2.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires containers >=0.5.0.0 && < 0.6 and the snapshot contains containers-0.6.7
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-api-data >=0.3.4 && < 0.4 and the snapshot contains http-api-data-0.5
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-api-data >=0.3.4 && < 0.4 and the snapshot contains http-api-data-0.5.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-media >=0.4 && < 0.8 and the snapshot contains http-media-0.8.0.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires katip >=0.4 && < 0.6 and the snapshot contains katip-0.8.7.4
@@ -7462,137 +8351,230 @@ packages:
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.0.0
-        - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.1.0
+        - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - sydtest < 0 # tried sydtest-0.15.0.0, but its *library* requires the disabled package: pretty-show
+        - sydtest-aeson < 0 # tried sydtest-aeson-0.1.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-amqp < 0 # tried sydtest-amqp-0.1.0.0, but its *library* requires the disabled package: amqp
+        - sydtest-autodocodec < 0 # tried sydtest-autodocodec-0.0.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-hedgehog < 0 # tried sydtest-hedgehog-0.4.0.0, but its *library* requires the disabled package: hedgehog
+        - sydtest-hedis < 0 # tried sydtest-hedis-0.0.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-mongo < 0 # tried sydtest-mongo-0.0.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-persistent < 0 # tried sydtest-persistent-0.0.0.1, but its *library* requires the disabled package: persistent
+        - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.2, but its *library* requires the disabled package: persistent
+        - sydtest-persistent-sqlite < 0 # tried sydtest-persistent-sqlite-0.2.0.2, but its *library* requires the disabled package: persistent
+        - sydtest-process < 0 # tried sydtest-process-0.0.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-rabbitmq < 0 # tried sydtest-rabbitmq-0.1.0.0, but its *library* requires the disabled package: amqp
+        - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-client
+        - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: servant-server
+        - sydtest-typed-process < 0 # tried sydtest-typed-process-0.0.0.0, but its *library* requires the disabled package: sydtest
+        - sydtest-wai < 0 # tried sydtest-wai-0.2.0.0, but its *library* requires the disabled package: pretty-show
+        - sydtest-webdriver < 0 # tried sydtest-webdriver-0.0.0.1, but its *library* requires the disabled package: sydtest
+        - sydtest-webdriver < 0 # tried sydtest-webdriver-0.0.0.1, but its *library* requires the disabled package: sydtest-wai
+        - sydtest-webdriver-screenshot < 0 # tried sydtest-webdriver-screenshot-0.0.0.1, but its *library* requires the disabled package: sydtest
+        - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: sydtest
+        - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: sydtest-wai
+        - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: yesod
+        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: sydtest
+        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: sydtest-wai
+        - sydtest-yesod < 0 # tried sydtest-yesod-0.3.0.1, but its *library* requires the disabled package: yesod-test
         - taffybar < 0 # tried taffybar-4.0.0, but its *library* requires scotty >=0.11.0 && < 0.12.0 and the snapshot contains scotty-0.12.1
+        - tagged-identity < 0 # tried tagged-identity-0.1.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - tasty-dejafu < 0 # tried tasty-dejafu-2.1.0.0, but its *library* requires the disabled package: dejafu
+        - tasty-hedgehog < 0 # tried tasty-hedgehog-1.4.0.1, but its *library* requires the disabled package: hedgehog
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.4.3
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires time >=1.5 && < 1.9 and the snapshot contains time-1.12.2
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires ansi-terminal >=0.8 && < 0.12 and the snapshot contains ansi-terminal-1.0
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.4.0
+        - telegram-bot-api < 0 # tried telegram-bot-api-6.7, but its *library* requires the disabled package: servant
+        - telegram-bot-api < 0 # tried telegram-bot-api-6.7, but its *library* requires the disabled package: servant-client
+        - telegram-bot-api < 0 # tried telegram-bot-api-6.7, but its *library* requires the disabled package: servant-server
+        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: servant
+        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: servant-client
+        - telegram-bot-simple < 0 # tried telegram-bot-simple-0.12, but its *library* requires the disabled package: servant-server
+        - template < 0 # tried template-0.2.0.10, but its *library* requires mtl >=1.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - template < 0 # tried template-0.2.0.10, but its *library* requires text >=0.7.2 && < 1.3 and the snapshot contains text-2.0.2
+        - termbox-banana < 0 # tried termbox-banana-1.0.0, but its *library* requires the disabled package: reactive-banana
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
-        - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
+        - termonad < 0 # tried termonad-4.5.0.0, but its *library* requires the disabled package: inline-c
+        - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - test-framework < 0 # tried test-framework-0.8.2.0, but its *library* requires ansi-wl-pprint >=0.5.1 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - test-framework-hunit < 0 # tried test-framework-hunit-0.3.0.2, but its *library* requires the disabled package: test-framework
+        - test-framework-leancheck < 0 # tried test-framework-leancheck-0.0.4, but its *library* requires the disabled package: test-framework
+        - test-framework-quickcheck2 < 0 # tried test-framework-quickcheck2-0.3.0.5, but its *library* requires the disabled package: test-framework
+        - test-framework-smallcheck < 0 # tried test-framework-smallcheck-0.2, but its *library* requires the disabled package: test-framework
         - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: language-haskell-extract
+        - test-framework-th < 0 # tried test-framework-th-0.2.4, but its *library* requires the disabled package: test-framework
         - text-all < 0 # tried text-all-0.4.2, but its *library* requires text ==1.2.3.* and the snapshot contains text-2.0.2
         - text-all < 0 # tried text-all-0.4.2, but its *library* requires text-format ==0.3.1.* and the snapshot contains text-format-0.3.2.1
         - text-generic-pretty < 0 # tried text-generic-pretty-1.2.1, but its *library* requires wl-pprint-text < 1.2 and the snapshot contains wl-pprint-text-1.2.0.2
-        - th-extras < 0 # tried th-extras-0.0.0.6, but its *library* requires template-haskell < 2.19 and the snapshot contains template-haskell-2.19.0.0
-        - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.19.0.0
+        - th-extras < 0 # tried th-extras-0.0.0.6, but its *library* requires template-haskell < 2.19 and the snapshot contains template-haskell-2.20.0.0
+        - th-extras < 0 # tried th-extras-0.0.0.6, but its *library* requires th-abstraction >=0.4 && < 0.5 and the snapshot contains th-abstraction-0.5.0.0
+        - th-printf < 0 # tried th-printf-0.7, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
+        - threepenny-gui < 0 # tried threepenny-gui-0.9.4.0, but its *library* requires template-haskell >=2.7.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - threepenny-gui < 0 # tried threepenny-gui-0.9.4.0, but its *library* requires the disabled package: snap-server
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: clay
         - threepenny-gui-flexbox < 0 # tried threepenny-gui-flexbox-0.4.2, but its *library* requires the disabled package: threepenny-gui
-        - through-text < 0 # tried through-text-0.1.0.0, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.17.1.0
+        - through-text < 0 # tried through-text-0.1.0.0, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.18.0.0
         - thumbnail-plus < 0 # tried thumbnail-plus-1.0.5, but its *library* requires either < 5 and the snapshot contains either-5.0.2
+        - thyme < 0 # tried thyme-0.4, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - tldr < 0 # tried tldr-0.9.2, but its *library* requires the disabled package: cmark
-        - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.6.0
-        - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
+        - tlynx < 0 # tried tlynx-0.7.2.1, but its *library* requires the disabled package: statistics
+        - tmp-proc < 0 # tried tmp-proc-0.5.1.3, but its *executable* requires the disabled package: connection
+        - tmp-proc < 0 # tried tmp-proc-0.5.1.3, but its *executable* requires the disabled package: req
+        - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.5.2.2, but its *library* requires the disabled package: tmp-proc
+        - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: amqp
+        - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: tmp-proc
+        - tmp-proc-redis < 0 # tried tmp-proc-redis-0.5.1.2, but its *library* requires the disabled package: tmp-proc
+        - toml-reader-parse < 0 # tried toml-reader-parse-0.1.1.1, but its *library* requires the disabled package: prettyprinter-combinators
+        - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
-        - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
-        - tonatona < 0 # tried tonatona-0.1.2.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
-        - tonatona-logger < 0 # tried tonatona-logger-0.2.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
-        - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
+        - tonatona < 0 # tried tonatona-0.1.2.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
+        - tonatona-logger < 0 # tried tonatona-logger-0.2.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
+        - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* requires persistent >=2.8 && < 2.11 and the snapshot contains persistent-2.14.5.0
         - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* requires persistent-postgresql >=2.8 && < 2.11 and the snapshot contains persistent-postgresql-2.13.5.2
         - tonatona-persistent-postgresql < 0 # tried tonatona-persistent-postgresql-0.1.0.2, but its *library* requires resource-pool >=0.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
-        - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires persistent >=2.8 && < 2.11 and the snapshot contains persistent-2.14.5.0
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires persistent-sqlite >=2.8 && < 2.11 and the snapshot contains persistent-sqlite-2.13.1.1
         - tonatona-persistent-sqlite < 0 # tried tonatona-persistent-sqlite-0.1.0.2, but its *library* requires resource-pool >=0.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
-        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant >=0.13 && < 0.17 and the snapshot contains servant-0.19.1
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires servant-server >=0.13 && < 0.17 and the snapshot contains servant-server-0.19.2
         - tonatona-servant < 0 # tried tonatona-servant-0.1.0.4, but its *library* requires wai-extra >=3.0.27 && < 3.1 and the snapshot contains wai-extra-3.1.13.0
+        - tracing-control < 0 # tried tracing-control-0.0.7.3, but its *library* requires the disabled package: stm-lifted
         - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.17.1.0
+        - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - transformers-fix < 0 # tried transformers-fix-1.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.18.0.0
+        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires writer-cps-transformers ==0.1.1.4 and the snapshot contains writer-cps-transformers-0.5.6.1
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires network >=2.8.0.0 && < 3.0.0.0 and the snapshot contains network-3.1.4.0
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: TCache
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
-        - true-name < 0 # tried true-name-0.1.0.3, but its *library* requires template-haskell >=2.7 && < 2.15 and the snapshot contains template-haskell-2.19.0.0
+        - triplesec < 0 # tried triplesec-0.2.2.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - true-name < 0 # tried true-name-0.1.0.3, but its *library* requires template-haskell >=2.7 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.2.0
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - turtle < 0 # tried turtle-1.6.1, but its *library* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
+        - turtle < 0 # tried turtle-1.6.1, but its *library* requires optparse-applicative >=0.16 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
-        - type-errors-pretty < 0 # tried type-errors-pretty-0.0.1.2, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.17.1.0
-        - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.17.1.0
+        - type-errors-pretty < 0 # tried type-errors-pretty-0.0.1.2, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.18.0.0
+        - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.18.0.0
+        - tz < 0 # tried tz-0.1.3.6, but its *library* requires template-haskell >=2.6 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - tztime < 0 # tried tztime-0.1.0.0, but its *library* requires the disabled package: tz
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires attoparsec >=0.13.2.2 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.17.1.0
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.18.0.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires cryptonite >=0.25 && < 0.27 and the snapshot contains cryptonite-0.30
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires http-api-data >=0.3.8.1 && < 0.5 and the snapshot contains http-api-data-0.5
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires http-api-data >=0.3.8.1 && < 0.5 and the snapshot contains http-api-data-0.5.1
+        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires parser-combinators >=1.0.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.1.2.1
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.17.1.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.18.0.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base64-bytestring >=1.0.0.1 && < 1.1 and the snapshot contains base64-bytestring-1.2.1.0
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires timerep >=2.0.0.2 && < 2.1 and the snapshot contains timerep-2.1.0.0
+        - unbound-generics < 0 # tried unbound-generics-0.4.3, but its *library* requires ansi-wl-pprint >=0.6.7.2 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+        - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
-        - union-find < 0 # tried union-find-0.2, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.17.1.0
+        - unification-fd < 0 # tried unification-fd-0.11.2, but its *library* requires logict >=0.4 && < 0.8.1 and the snapshot contains logict-0.8.1.0
+        - union < 0 # tried union-0.1.2, but its *library* requires base >=4.9 && < 4.18 and the snapshot contains base-4.18.0.0
+        - union-find < 0 # tried union-find-0.2, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.18.0.0
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
+        - units-parser < 0 # tried units-parser-0.1.1.4, but its *library* requires mtl >=1.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - universum < 0 # tried universum-1.8.1.1, but its *library* requires text >=1.0.0.0 && < =2.0.1 and the snapshot contains text-2.0.2
+        - unliftio-pool < 0 # tried unliftio-pool-0.4.2.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - unliftio-streams < 0 # tried unliftio-streams-0.1.1.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - urbit-hob < 0 # tried urbit-hob-0.3.3, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - uri-templater < 0 # tried uri-templater-0.3.1.0, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.2
         - urlpath < 0 # tried urlpath-9.0.1, but its *library* requires the disabled package: attoparsec-uri
         - userid < 0 # tried userid-0.1.3.7, but its *library* requires aeson >=0.9 && < 2.1 and the snapshot contains aeson-2.1.2.1
-        - userid < 0 # tried userid-0.1.3.7, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.1.0
+        - userid < 0 # tried userid-0.1.3.7, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.0.0
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text-short >=0.1.1 && < 0.1.4 and the snapshot contains text-short-0.1.5
-        - vado < 0 # tried vado-0.0.14, but its *library* requires base >=4.0.0.0 && < 4.17 and the snapshot contains base-4.17.1.0
+        - vado < 0 # tried vado-0.0.14, but its *library* requires base >=4.0.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
+        - validation < 0 # tried validation-1.1.2, but its *library* requires assoc >=1 && < 1.1 and the snapshot contains assoc-1.1
+        - validation < 0 # tried validation-1.1.2, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
+        - validity-persistent < 0 # tried validity-persistent-0.0.0.0, but its *library* requires the disabled package: persistent
         - variable-media-field < 0 # tried variable-media-field-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
+        - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: dhall
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: variable-media-field
         - variable-media-field-optics < 0 # tried variable-media-field-optics-0.1.0.0, but its *library* requires the disabled package: variable-media-field
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires base >=4.0.0.0 && < 4.11 and the snapshot contains base-4.17.1.0
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires base >=4.0.0.0 && < 4.11 and the snapshot contains base-4.18.0.0
         - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires containers >=0.5.5.1 && < 0.6 and the snapshot contains containers-0.6.7
+        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires mtl >=2.0.1.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires text >=0.11.1.5 && < 1.3 and the snapshot contains text-2.0.2
-        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.17.1.0
+        - vector-binary-instances < 0 # tried vector-binary-instances-0.2.5.2, but its *library* requires base >3 && < 4.18 and the snapshot contains base-4.18.0.0
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.18.0.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
-        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires template-haskell >=2.12 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires semigroupoids >=5.3 && < 5.4 and the snapshot contains semigroupoids-6.0.0.1
+        - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires template-haskell >=2.12 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.17.1.0
+        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.18.0.0
         - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires primitive >=0.6 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.0.0
         - vector-sized < 0 # tried vector-sized-1.5.0, but its *library* requires primitive >=0.5 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.0.2
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires the disabled package: protocol-buffers
+        - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - verbosity < 0 # tried verbosity-0.4.0.0, but its *library* requires the disabled package: dhall
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires aeson >=1.2 && < 2.0 and the snapshot contains aeson-2.1.2.1
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires base >=4.9 && < 4.15 and the snapshot contains base-4.17.1.0
+        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires base >=4.9 && < 4.15 and the snapshot contains base-4.18.0.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires brick >0.26.1 && < 0.54 and the snapshot contains brick-1.9
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2.2
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.0.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector-algorithms >=0.6.0.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vty >=5.13 && < 5.29 and the snapshot contains vty-5.38
-        - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.17.1.0
+        - wai-cli < 0 # tried wai-cli-0.2.3, but its *library* requires the disabled package: monads-tf
+        - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
+        - wai-middleware-metrics < 0 # tried wai-middleware-metrics-0.2.4, but its *library* requires the disabled package: ekg-core
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.1.2.1
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.13.1
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
+        - wai-middleware-throttle < 0 # tried wai-middleware-throttle-0.3.0.1, but its *library* requires the disabled package: cache
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
         - wai-transformers < 0 # tried wai-transformers-0.1.0, but its *library* requires the disabled package: monad-control-aligned
+        - wave < 0 # tried wave-0.2.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires attoparsec >=0.13 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires base >=4.8 && < 4.14 and the snapshot contains base-4.17.1.0
+        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires base >=4.8 && < 4.14 and the snapshot contains base-4.18.0.0
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires dlist >=0.7 && < 0.9 and the snapshot contains dlist-1.0
+        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - wavefront < 0 # tried wavefront-0.7.1.4, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.0.0
+        - web-plugins < 0 # tried web-plugins-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - web-plugins < 0 # tried web-plugins-0.4.1, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
-        - web3 < 0 # tried web3-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
-        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web-routes-th < 0 # tried web-routes-th-0.22.8.1, but its *library* requires template-haskell >=2.11 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
+        - web3 < 0 # tried web3-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
+        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
         - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
         - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
@@ -7600,195 +8582,150 @@ packages:
         - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.0.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.1.1
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires microlens-aeson >2.2 && < 2.4 and the snapshot contains microlens-aeson-2.5.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires vinyl >0.5 && < 0.14 and the snapshot contains vinyl-0.14.3
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
+        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.13.1
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.1.1
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.17.1.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.19.0.0
+        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.20.0.0
         - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.0.2
         - webby < 0 # tried webby-1.1.1, but its *library* requires formatting >=6.3.7 && < 7.2 and the snapshot contains formatting-7.2.0
+        - webby < 0 # tried webby-1.1.1, but its *library* requires resourcet ==1.2.* and the snapshot contains resourcet-1.3.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.11.0.0
         - webgear-server < 0 # tried webgear-server-1.0.5, but its *library* requires the disabled package: bytestring-conversion
         - websockets-simple < 0 # tried websockets-simple-0.2.0, but its *library* requires the disabled package: monad-control-aligned
         - websockets-snap < 0 # tried websockets-snap-0.10.3.1, but its *library* requires the disabled package: snap-server
+        - weigh < 0 # tried weigh-0.0.16, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires text >=0.11.3.1 && < 1.3 and the snapshot contains text-2.0.2
         - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires time >=1.4.0 && < 1.12 and the snapshot contains time-1.12.2
-        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.1.0
+        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.0.0
         - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
-        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.17.1.0
+        - wild-bind < 0 # tried wild-bind-0.1.2.9, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires base >=4.6 && < 4.17 and the snapshot contains base-4.18.0.0
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires text >=1.2.0 && < 1.3 and the snapshot contains text-2.0.2
+        - wild-bind-x11 < 0 # tried wild-bind-x11-0.2.0.15, but its *library* requires transformers >=0.3.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - wire-streams < 0 # tried wire-streams-0.1.1.0, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
         - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires bytestring >=0.10.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - wl-pprint-console < 0 # tried wl-pprint-console-0.1.0.2, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
         - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
+        - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires semigroupoids >=3 && < 6 and the snapshot contains semigroupoids-6.0.0.1
         - wl-pprint-extras < 0 # tried wl-pprint-extras-3.5.0.5, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
         - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.7
         - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.0.2
+        - wl-pprint-terminfo < 0 # tried wl-pprint-terminfo-3.7.1.4, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - wl-pprint-text < 0 # tried wl-pprint-text-1.2.0.2, but its *library* requires base-compat >=0.10 && < 0.13 and the snapshot contains base-compat-0.13.0
         - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: ansigraph
         - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: clock-extras
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: connection
         - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: next-ref
+        - wrecker < 0 # tried wrecker-1.3.2.0, but its *library* requires the disabled package: wreq
+        - wreq < 0 # tried wreq-0.5.4.0, but its *library* requires Cabal < 3.9 and the snapshot contains Cabal-3.10.1.0
+        - wreq-stringless < 0 # tried wreq-stringless-0.5.9.1, but its *library* requires the disabled package: wreq
+        - writer-cps-exceptions < 0 # tried writer-cps-exceptions-0.1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - writer-cps-full < 0 # tried writer-cps-full-0.1.0.0, but its *library* requires the disabled package: writer-cps-morph
         - writer-cps-lens < 0 # tried writer-cps-lens-0.1.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
+        - writer-cps-lens < 0 # tried writer-cps-lens-0.1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
+        - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ws < 0 # tried ws-0.0.5, but its *library* requires the disabled package: attoparsec-uri
+        - xdg-desktop-entry < 0 # tried xdg-desktop-entry-0.1.1.1, but its *library* requires the disabled package: ConfigFile
+        - xlsx < 0 # tried xlsx-1.1.0.1, but its *library* requires the disabled package: zip
+        - xlsx-tabular < 0 # tried xlsx-tabular-0.2.2.1, but its *library* requires the disabled package: xlsx
+        - xml-parser < 0 # tried xml-parser-0.1.1.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.1.0
+        - xmonad-contrib < 0 # tried xmonad-contrib-0.17.1, but its *library* requires mtl >=1 && < 2.3 and the snapshot contains mtl-2.3.1
         - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: libmpd
+        - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: xmonad-contrib
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires yeshql-core ==4.1.1.2 and the snapshot contains yeshql-core-4.2.0.0
+        - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: yesod-form
+        - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: yesod-persistent
         - yesod-alerts < 0 # tried yesod-alerts-0.1.3.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
+        - yesod-auth < 0 # tried yesod-auth-1.6.11.1, but its *library* requires the disabled package: email-validate
+        - yesod-auth < 0 # tried yesod-auth-1.6.11.1, but its *library* requires the disabled package: persistent
+        - yesod-auth-basic < 0 # tried yesod-auth-basic-0.1.0.3, but its *library* requires the disabled package: yesod
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires persistent >=2.1 && < 2.8 and the snapshot contains persistent-2.14.5.0
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-auth >=1.4.18 && < 1.5 and the snapshot contains yesod-auth-1.6.11.1
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-form >=1.4 && < 1.5 and the snapshot contains yesod-form-1.7.4
+        - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: persistent
+        - yesod-auth-oauth2 < 0 # tried yesod-auth-oauth2-0.7.1.0, but its *library* requires the disabled package: hoauth2
+        - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: classy-prelude-yesod
+        - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: yesod-auth
+        - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: yesod-form
+        - yesod-form < 0 # tried yesod-form-1.7.4, but its *library* requires the disabled package: email-validate
+        - yesod-form < 0 # tried yesod-form-1.7.4, but its *library* requires the disabled package: persistent
+        - yesod-form-bootstrap4 < 0 # tried yesod-form-bootstrap4-3.0.1, but its *library* requires the disabled package: yesod-form
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-form >=1.4.4.1 && < 1.5 and the snapshot contains yesod-form-1.7.4
+        - yesod-markdown < 0 # tried yesod-markdown-0.12.6.13, but its *library* requires the disabled package: persistent
+        - yesod-middleware-csp < 0 # tried yesod-middleware-csp-1.2.0, but its *library* requires the disabled package: yesod
+        - yesod-paginator < 0 # tried yesod-paginator-1.1.2.2, but its *library* requires the disabled package: persistent
+        - yesod-persistent < 0 # tried yesod-persistent-1.6.0.8, but its *library* requires the disabled package: persistent
+        - yesod-recaptcha2 < 0 # tried yesod-recaptcha2-1.0.2, but its *library* requires the disabled package: yesod-form
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* requires yesod >=1.2 && < 1.5 and the snapshot contains yesod-1.6.2.1
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-core >=1.2 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-static >=1.2.1 && < 1.6 and the snapshot contains yesod-static-1.6.1.0
+        - yesod-test < 0 # tried yesod-test-1.6.15, but its *library* requires the disabled package: pretty-show
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires aeson >=0.7 && < 2.0 and the snapshot contains aeson-2.1.2.1
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
         - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
+        - zenacy-html < 0 # tried zenacy-html-2.1.0, but its *library* requires the disabled package: pretty-show
         - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.12.2
+        - zigzag < 0 # tried zigzag-0.0.1.0, but its *library* requires base >=4.11.1 && < 4.18 and the snapshot contains base-4.18.0.0
+        - zio < 0 # tried zio-0.1.0.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
+        - zio < 0 # tried zio-0.1.0.2, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - zip < 0 # tried zip-2.0.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - zipper-extra < 0 # tried zipper-extra-0.1.3.2, but its *library* requires the disabled package: comonad-extras
+        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.13.0
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19.1
         - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant-client >=0.9 && < 0.12 and the snapshot contains servant-client-0.19
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires aeson >=0.7 && < 1.3 and the snapshot contains aeson-2.1.2.1
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.12.2
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires base-compat ==0.9.* and the snapshot contains base-compat-0.13.0
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires bytestring ==0.10.* and the snapshot contains bytestring-0.11.4.0
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5
+        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data ==0.3.* and the snapshot contains http-api-data-0.5.1
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.19.1
         - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - zm < 0 # tried zm-0.3.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - zm < 0 # tried zm-0.3.2, but its *library* requires containers ==0.5.* and the snapshot contains containers-0.6.7
         - zm < 0 # tried zm-0.3.2, but its *library* requires flat ==0.3.* and the snapshot contains flat-0.6
         - zm < 0 # tried zm-0.3.2, but its *library* requires model >=0.4.4 && < 0.5 and the snapshot contains model-0.5
+        - zm < 0 # tried zm-0.3.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - zot < 0 # tried zot-0.0.3, but its *executable* requires the disabled package: monads-tf
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
-        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.17.1.0
+        - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires unix ==2.7.* and the snapshot contains unix-2.8.1.0
+        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires storable-record >=0.0.5 && < 0.0.6 and the snapshot contains storable-record-0.0.7
     # End of Library and exe bounds failures
 
     "Stackage upper bounds":
-        # https://github.com/commercialhaskell/stackage/issues/6744
-        - resourcet < 1.3.0
-
-        # https://github.com/commercialhaskell/stackage/issues/6857
-        - deriving-trans < 0.6
-
-        # https://github.com/commercialhaskell/stackage/issues/6883
-        - pandoc < 3.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6897
-        - th-abstraction < 0.5.0.0
-
-        # https://github.com/commercialhaskell/stackage/issues/6906
-        - base-compat < 0.13.0
-        - base-compat-batteries < 0.13.0
-        - lattices < 2.2
-
-        # https://github.com/commercialhaskell/stackage/issues/6908
-        - eliminators < 0.9.3
-        - singletons-base < 3.2
-        - singletons-th < 3.2
-        - th-desugar < 1.15
-
-        # https://github.com/commercialhaskell/stackage/issues/6909
-        - semigroupoids < 6
-        - rebase < 1.20
-        - rerebase < 1.20
-
-        # https://github.com/commercialhaskell/stackage/issues/6910
-        - bifunctors < 5.6
-        - rebase < 1.20
-        - rerebase < 1.20
-
-        # https://github.com/commercialhaskell/stackage/issues/6911
-        - ghc-lib < 9.6
-        - ghc-lib-parser < 9.6
-        - ghc-lib-parser-ex < 9.6
-
-        # https://github.com/commercialhaskell/stackage/issues/6912
-        - free < 5.2
-
-        # https://github.com/commercialhaskell/stackage/issues/6913
-        - cabal-install < 3.10.1.0
-        - cabal-install-solver < 3.10.1.0
-
-        # https://github.com/commercialhaskell/stackage/issues/6917
-        - some < 1.0.5
-
-        # https://github.com/commercialhaskell/stackage/issues/6922
-        - ghc-exactprint < 1.7
-
-        # https://github.com/commercialhaskell/stackage/issues/6923
-        - http-api-data < 0.5.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6926
-        - singleton-bool < 0.1.7
-
-        # https://github.com/commercialhaskell/stackage/issues/6932
-        - ormolu < 0.6
-
-        # https://github.com/dhall-lang/dhall-haskell/issues/2516
-        - dhall < 1.42
-        - dhall-bash < 1.0.41
-        - dhall-json < 1.7.12
-
-        # https://github.com/commercialhaskell/stackage/issues/6952
-        - hspec < 2.11
-        - hspec-core < 2.11
-        - hspec-discover < 2.11
-        - tasty-hspec < 1.2.0.4
-
-        # https://github.com/commercialhaskell/stackage/issues/6955
-        - logict < 0.8.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6976
-        - ansi-terminal < 1.0
-
-        # https://github.com/commercialhaskell/stackage/issues/6977
-        - hasql-pool < 0.10
-        - hasql-optparse-applicative < 0.7.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6981
-        - ansi-wl-pprint < 1.0.2
-
         # https://github.com/commercialhaskell/stackage/issues/6983
         - pandoc-symreg < 0.2.1
-
-        # https://github.com/commercialhaskell/stackage/issues/6997
-        - tls < 1.7
-        - crypton-connection < 0
-        - warp-tls < 3.3.7
-        - http-client-tls < 0.3.6.2
-        - network-conduit-tls < 1.4.0
-        - http-conduit < 2.3.8.2
-        - wuss < 2.0.1.4
-
-        # https://github.com/commercialhaskell/stackage/issues/6998
-        - crypton-x509 < 0
-        - crypton-x509-store < 0
-        - crypton-x509-system < 0
-        - crypton-x509-validation < 0
-        - warp < 3.3.26
 
         # https://github.com/commercialhaskell/stackage/issues/7003
         - megaparsec < 9.4
@@ -8104,93 +9041,461 @@ skipped-tests:
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
     # Test bounds issues
+    - Decimal # tried Decimal-0.5.2, but its *test-suite* requires the disabled package: test-framework
+    - Decimal # tried Decimal-0.5.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - Decimal # tried Decimal-0.5.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - Diff # tried Diff-0.4.1, but its *test-suite* requires the disabled package: test-framework
+    - Diff # tried Diff-0.4.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework
+    - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-th
-    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.2
-    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires hspec >=2.4 && < 2.8 and the snapshot contains hspec-2.10.10
+    - GLFW-b # tried GLFW-b-3.3.0.0, but its *test-suite* requires the disabled package: test-framework
+    - GLFW-b # tried GLFW-b-3.3.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - Glob # tried Glob-0.10.2, but its *test-suite* requires the disabled package: test-framework
+    - Glob # tried Glob-0.10.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - Glob # tried Glob-0.10.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - HTTP # tried HTTP-4000.4.1, but its *test-suite* requires the disabled package: test-framework
+    - HTTP # tried HTTP-4000.4.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - IPv6Addr # tried IPv6Addr-2.0.5, but its *test-suite* requires the disabled package: test-framework
+    - IPv6Addr # tried IPv6Addr-2.0.5, but its *test-suite* requires the disabled package: test-framework-hunit
+    - RSA # tried RSA-2.4.1, but its *test-suite* requires the disabled package: test-framework
+    - RSA # tried RSA-2.4.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - SHA # tried SHA-1.6.4.4, but its *test-suite* requires the disabled package: test-framework
+    - SHA # tried SHA-1.6.4.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - acid-state # tried acid-state-0.16.1.2, but its *test-suite* requires the disabled package: hedgehog
+    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires hspec >=2.4 && < 2.8 and the snapshot contains hspec-2.11.1
+    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires the disabled package: hedgehog
+    - arbor-lru-cache # tried arbor-lru-cache-0.1.1.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
+    - astro # tried astro-0.4.3.0, but its *test-suite* requires the disabled package: test-framework
+    - astro # tried astro-0.4.3.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - astro # tried astro-0.4.3.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - async # tried async-2.2.4, but its *test-suite* requires the disabled package: test-framework
+    - async # tried async-2.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
+    - async-refresh # tried async-refresh-0.3.0.0, but its *test-suite* requires the disabled package: criterion
+    - async-refresh # tried async-refresh-0.3.0.0, but its *test-suite* requires the disabled package: test-framework
+    - async-refresh # tried async-refresh-0.3.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - async-refresh-tokens # tried async-refresh-tokens-0.4.0.0, but its *test-suite* requires the disabled package: criterion
+    - async-refresh-tokens # tried async-refresh-tokens-0.4.0.0, but its *test-suite* requires the disabled package: test-framework
+    - async-refresh-tokens # tried async-refresh-tokens-0.4.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - aws-cloudfront-signed-cookies # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *test-suite* requires the disabled package: hedgehog
+    - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework
+    - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - base58-bytestring # tried base58-bytestring-0.1.0, but its *test-suite* requires the disabled package: quickcheck-assertions
+    - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework
+    - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - binary-conduit # tried binary-conduit-1.3.1, but its *test-suite* requires the disabled package: quickcheck-assertions
+    - binary-tagged # tried binary-tagged-0.3.1, but its *test-suite* requires the disabled package: binary-instances
+    - bindings-GLFW # tried bindings-GLFW-3.3.2.0, but its *test-suite* requires the disabled package: test-framework
+    - bindings-GLFW # tried bindings-GLFW-3.3.2.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - bitwise-enum # tried bitwise-enum-1.0.1.0, but its *test-suite* requires the disabled package: test-framework
+    - bitwise-enum # tried bitwise-enum-1.0.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - blake2 # tried blake2-0.3.0, but its *test-suite* requires the disabled package: hlint
+    - blaze-builder # tried blaze-builder-0.4.2.2, but its *test-suite* requires the disabled package: test-framework
+    - blaze-builder # tried blaze-builder-0.4.2.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - blaze-builder # tried blaze-builder-0.4.2.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - blaze-html # tried blaze-html-0.9.1.2, but its *test-suite* requires the disabled package: test-framework
+    - blaze-html # tried blaze-html-0.9.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - blaze-html # tried blaze-html-0.9.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - blaze-textual # tried blaze-textual-0.2.3.1, but its *test-suite* requires the disabled package: test-framework
+    - blaze-textual # tried blaze-textual-0.2.3.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - bloodhound # tried bloodhound-0.21.0.0, but its *test-suite* requires the disabled package: quickcheck-properties
+    - brotli-streams # tried brotli-streams-0.0.0.0, but its *test-suite* requires the disabled package: test-framework
+    - brotli-streams # tried brotli-streams-0.0.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - brotli-streams # tried brotli-streams-0.0.0.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - bsb-http-chunked # tried bsb-http-chunked-0.0.0.4, but its *test-suite* requires the disabled package: hedgehog
+    - bsb-http-chunked # tried bsb-http-chunked-0.0.0.4, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - bson # tried bson-0.4.0.1, but its *test-suite* requires the disabled package: test-framework
+    - bson # tried bson-0.4.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - buffer-builder # tried buffer-builder-0.2.4.8, but its *test-suite* requires the disabled package: criterion
+    - bugsnag-hs # tried bugsnag-hs-0.2.0.9, but its *test-suite* requires the disabled package: hedgehog
+    - bytehash # tried bytehash-0.1.0.0, but its *test-suite* requires the disabled package: hedgehog
     - bytehash # tried bytehash-0.1.0.0, but its *test-suite* requires the disabled package: primitive-checked
-    - cabal-install # tried cabal-install-3.8.1.0, but its *test-suite* requires the disabled package: Cabal-QuickCheck
-    - cabal-install # tried cabal-install-3.8.1.0, but its *test-suite* requires the disabled package: Cabal-described
-    - cabal-install # tried cabal-install-3.8.1.0, but its *test-suite* requires the disabled package: Cabal-tree-diff
-    - cassava-conduit # tried cassava-conduit-0.6.2, but its *test-suite* requires QuickCheck ==2.12.* and the snapshot contains QuickCheck-2.14.3
-    - cleff # tried cleff-0.3.3.0, but its *test-suite* requires base >=4.12 && < 4.17 and the snapshot contains base-4.17.1.0
-    - cleff # tried cleff-0.3.3.0, but its *test-suite* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.19.0.0
+    - bytehash # tried bytehash-0.1.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - c2hs # tried c2hs-0.28.8, but its *test-suite* requires the disabled package: test-framework
+    - c2hs # tried c2hs-0.28.8, but its *test-suite* requires the disabled package: test-framework-hunit
+    - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-QuickCheck
+    - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-described
+    - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: Cabal-tree-diff
+    - cabal-install # tried cabal-install-3.10.1.0, but its *test-suite* requires the disabled package: pretty-show
+    - cacophony # tried cacophony-0.10.1, but its *test-suite* requires the disabled package: hlint
+    - cereal # tried cereal-0.5.8.3, but its *test-suite* requires the disabled package: test-framework
+    - cereal # tried cereal-0.5.8.3, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - cipher-aes # tried cipher-aes-0.2.11, but its *test-suite* requires the disabled package: crypto-cipher-tests
+    - cipher-aes # tried cipher-aes-0.2.11, but its *test-suite* requires the disabled package: test-framework
+    - cipher-aes # tried cipher-aes-0.2.11, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - cipher-camellia # tried cipher-camellia-0.0.2, but its *test-suite* requires the disabled package: crypto-cipher-tests
+    - cipher-camellia # tried cipher-camellia-0.0.2, but its *test-suite* requires the disabled package: test-framework
+    - cipher-camellia # tried cipher-camellia-0.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - cipher-rc4 # tried cipher-rc4-0.1.4, but its *test-suite* requires the disabled package: crypto-cipher-tests
+    - cipher-rc4 # tried cipher-rc4-0.1.4, but its *test-suite* requires the disabled package: test-framework
+    - cipher-rc4 # tried cipher-rc4-0.1.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - co-log-core # tried co-log-core-0.3.2.0, but its *test-suite* requires doctest >=0.16.0 && < 0.21 and the snapshot contains doctest-0.21.1
     - colour # tried colour-2.3.6, but its *test-suite* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.1
+    - colour # tried colour-2.3.6, but its *test-suite* requires the disabled package: test-framework
+    - colour # tried colour-2.3.6, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - comfort-array # tried comfort-array-0.5.2.3, but its *test-suite* requires the disabled package: ChasingBottoms
+    - comfort-array-shape # tried comfort-array-shape-0.0, but its *test-suite* requires the disabled package: ChasingBottoms
+    - compdata # tried compdata-0.13.0, but its *test-suite* requires the disabled package: test-framework
+    - compdata # tried compdata-0.13.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - compdata # tried compdata-0.13.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - concurrent-extra # tried concurrent-extra-0.7.0.12, but its *test-suite* requires the disabled package: test-framework
+    - concurrent-extra # tried concurrent-extra-0.7.0.12, but its *test-suite* requires the disabled package: test-framework-hunit
+    - conduit-parse # tried conduit-parse-0.2.1.1, but its *test-suite* requires the disabled package: hlint
     - conferer # tried conferer-1.1.0.0, but its *test-suite* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
     - conferer-aeson # tried conferer-aeson-1.1.0.2, but its *test-suite* requires aeson >=0.10 && < 2.1 and the snapshot contains aeson-2.1.2.1
     - conferer-aeson # tried conferer-aeson-1.1.0.2, but its *test-suite* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
+    - config-ini # tried config-ini-0.2.5.0, but its *test-suite* requires the disabled package: hedgehog
+    - configurator # tried configurator-0.3.0.0, but its *test-suite* requires the disabled package: test-framework
+    - configurator # tried configurator-0.3.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - crc32c # tried crc32c-0.1.0, but its *test-suite* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.11.4.0
+    - cron # tried cron-0.7.0, but its *test-suite* requires the disabled package: hedgehog
+    - cron # tried cron-0.7.0, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - ctrie # tried ctrie-0.2, but its *test-suite* requires the disabled package: test-framework
+    - ctrie # tried ctrie-0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-optics
+    - cursor-gen # tried cursor-gen-0.4.0.0, but its *test-suite* requires the disabled package: pretty-show
+    - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework
+    - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - cyclotomic # tried cyclotomic-1.1.2, but its *test-suite* requires the disabled package: test-framework-smallcheck
+    - data-hash # tried data-hash-0.2.0.1, but its *test-suite* requires the disabled package: test-framework
+    - data-hash # tried data-hash-0.2.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - data-interval # tried data-interval-2.1.1, but its *test-suite* requires the disabled package: ChasingBottoms
+    - data-sketches # tried data-sketches-0.3.1.0, but its *test-suite* requires the disabled package: pretty-show
+    - data-sketches # tried data-sketches-0.3.1.0, but its *test-suite* requires the disabled package: statistics
+    - data-textual # tried data-textual-0.3.0.3, but its *test-suite* requires the disabled package: test-framework
+    - data-textual # tried data-textual-0.3.0.3, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - deepseq-generics # tried deepseq-generics-0.2.0.0, but its *test-suite* requires the disabled package: test-framework
+    - deepseq-generics # tried deepseq-generics-0.2.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - detour-via-sci # tried detour-via-sci-1.0.0, but its *test-suite* requires the disabled package: hlint
+    - discrimination # tried discrimination-0.5, but its *test-suite* requires the disabled package: criterion
+    - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework
+    - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-th
+    - double-conversion # tried double-conversion-2.0.4.2, but its *test-suite* requires the disabled package: test-framework
+    - double-conversion # tried double-conversion-2.0.4.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - double-conversion # tried double-conversion-2.0.4.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - dublincore-xml-conduit # tried dublincore-xml-conduit-0.1.0.2, but its *test-suite* requires the disabled package: hlint
+    - easy-logger # tried easy-logger-0.1.0.7, but its *test-suite* requires the disabled package: quickcheck-assertions
     - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires QuickCheck >=2.4 && < 2.9 and the snapshot contains QuickCheck-2.14.3
-    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires directory >=1.0 && < 1.3 and the snapshot contains directory-1.3.7.1
-    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires doctest >=0.10 && < 0.12 and the snapshot contains doctest-0.20.1
-    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires hlint >=1.7 && < 1.10 and the snapshot contains hlint-3.5
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires directory >=1.0 && < 1.3 and the snapshot contains directory-1.3.8.1
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires doctest >=0.10 && < 0.12 and the snapshot contains doctest-0.21.1
+    - ed25519 # tried ed25519-0.0.5.0, but its *test-suite* requires the disabled package: hlint
+    - either # tried either-5.0.2, but its *test-suite* requires the disabled package: test-framework
+    - either # tried either-5.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - enummapset # tried enummapset-0.7.1.0, but its *test-suite* requires the disabled package: test-framework
+    - enummapset # tried enummapset-0.7.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - enummapset # tried enummapset-0.7.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - errors-ext # tried errors-ext-0.4.2, but its *test-suite* requires the disabled package: binary-ext
+    - evm-opcodes # tried evm-opcodes-0.1.2, but its *test-suite* requires the disabled package: hedgehog
+    - evm-opcodes # tried evm-opcodes-0.1.2, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - exception-transformers # tried exception-transformers-0.4.0.11, but its *test-suite* requires the disabled package: test-framework
+    - exception-transformers # tried exception-transformers-0.4.0.11, but its *test-suite* requires the disabled package: test-framework-hunit
+    - exception-transformers # tried exception-transformers-0.4.0.11, but its *test-suite* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *test-suite* requires the disabled package: test-framework-th
-    - filepath-bytestring # tried filepath-bytestring-1.4.2.1.12, but its *test-suite* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.4.2.2
-    - filtrable # tried filtrable-0.1.6.0, but its *test-suite* requires tasty >=1.3.1 && < 1.4 and the snapshot contains tasty-1.4.3
-    - fixed-vector-hetero # tried fixed-vector-hetero-0.6.1.1, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.20.1
+    - fingertree # tried fingertree-0.1.5.0, but its *test-suite* requires the disabled package: test-framework
+    - fingertree # tried fingertree-0.1.5.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - fingertree # tried fingertree-0.1.5.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - fixed-vector-hetero # tried fixed-vector-hetero-0.6.1.1, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.21.1
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires genvalidity < 1.0.0.0 and the snapshot contains genvalidity-1.1.0.0
+    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: hedgehog
+    - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hedgehog
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires validity < 0.12.0.0 and the snapshot contains validity-0.12.0.1
-    - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires tasty >=1.2.3 && < 1.3 and the snapshot contains tasty-1.4.3
-    - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires tasty-hspec >=1.1.5.1 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.3
-    - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - hal # tried hal-1.0.0.1, but its *test-suite* requires hedgehog >=1.0.3 && < 1.2 and the snapshot contains hedgehog-1.2
+    - friday # tried friday-0.2.3.2, but its *test-suite* requires the disabled package: test-framework
+    - friday # tried friday-0.2.3.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - fsnotify # tried fsnotify-0.4.1.0, but its *test-suite* requires the disabled package: sandwich
+    - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: hedgehog
+    - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog
+    - fused-effects # tried fused-effects-1.1.2.2, but its *test-suite* requires the disabled package: hedgehog-fn
+    - generic-data # tried generic-data-1.1.0.0, but its *test-suite* requires the disabled package: one-liner
+    - genvalidity-aeson # tried genvalidity-aeson-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest-aeson
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: pretty-show
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *test-suite* requires the disabled package: sydtest
+    - genvalidity-bytestring # tried genvalidity-bytestring-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-case-insensitive # tried genvalidity-case-insensitive-0.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-property
+    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
+    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *test-suite* requires the disabled package: pretty-show
+    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
+    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *test-suite* requires the disabled package: pretty-show
+    - genvalidity-path # tried genvalidity-path-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-scientific # tried genvalidity-scientific-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-text # tried genvalidity-text-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-time # tried genvalidity-time-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec-aeson
+    - genvalidity-unordered-containers # tried genvalidity-unordered-containers-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-uuid # tried genvalidity-uuid-1.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - genvalidity-vector # tried genvalidity-vector-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework
+    - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - geodetics # tried geodetics-0.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec >=2.4.4 && < 2.11 and the snapshot contains hspec-2.11.1
+    - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.10 and the snapshot contains hspec-discover-2.11.1
+    - haddock-library # tried haddock-library-1.11.0, but its *test-suite* requires optparse-applicative >=0.15 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+    - hal # tried hal-1.0.0.1, but its *test-suite* requires the disabled package: hedgehog
+    - hal # tried hal-1.0.0.1, but its *test-suite* requires the disabled package: hspec-hedgehog
     - hal # tried hal-1.0.0.1, but its *test-suite* requires vector >=0.12.0.0 && < 0.13 and the snapshot contains vector-0.13.0.0
-    - horizontal-rule # tried horizontal-rule-0.6.0.0, but its *test-suite* requires the disabled package: HMock
+    - half # tried half-0.3.1, but its *test-suite* requires the disabled package: test-framework
+    - half # tried half-0.3.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - hashable # tried hashable-1.4.2.0, but its *test-suite* requires the disabled package: test-framework
+    - hashable # tried hashable-1.4.2.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - hashable # tried hashable-1.4.2.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework
+    - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - hashtables # tried hashtables-1.3.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - haskell-src-exts # tried haskell-src-exts-1.23.1, but its *test-suite* requires the disabled package: pretty-show
+    - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework
+    - hedis # tried hedis-0.15.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - hedn # tried hedn-0.3.0.4, but its *test-suite* requires the disabled package: hedgehog
+    - heist # tried heist-1.1.1.1, but its *test-suite* requires the disabled package: test-framework
+    - heist # tried heist-1.1.1.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - heist # tried heist-1.1.1.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - hex-text # tried hex-text-0.1.0.8, but its *test-suite* requires hspec ^>=2.8.5 || ^>=2.9 || ^>=2.10 and the snapshot contains hspec-2.11.1
+    - hexml-lens # tried hexml-lens-0.2.2, but its *test-suite* requires the disabled package: wreq
+    - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *test-suite* requires the disabled package: test-framework
+    - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - hsc2hs # tried hsc2hs-0.68.9, but its *test-suite* requires the disabled package: test-framework
+    - hsc2hs # tried hsc2hs-0.68.9, but its *test-suite* requires the disabled package: test-framework-hunit
     - http-io-streams # tried http-io-streams-0.1.6.2, but its *test-suite* requires the disabled package: snap
     - http-io-streams # tried http-io-streams-0.1.6.2, but its *test-suite* requires the disabled package: snap-server
     - http-media # tried http-media-0.8.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.14 and the snapshot contains QuickCheck-2.14.3
+    - http-media # tried http-media-0.8.0.0, but its *test-suite* requires the disabled package: test-framework
+    - http-media # tried http-media-0.8.0.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     - http-streams # tried http-streams-0.8.9.6, but its *test-suite* requires the disabled package: snap-server
-    - indexed-containers # tried indexed-containers-0.1.0.2, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.10.10
-    - monad-par # tried monad-par-0.3.5, but its *test-suite* requires the disabled package: test-framework-th
-    - mwc-random # tried mwc-random-0.15.0.2, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.20.1
+    - hw-conduit # tried hw-conduit-0.2.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.21.1
+    - hw-diagnostics # tried hw-diagnostics-0.0.1.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.21.1
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.21.1
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires the disabled package: hedgehog
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires the disabled package: test-framework
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - hw-fingertree-strict # tried hw-fingertree-strict-0.1.2.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.21.1
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires the disabled package: hedgehog
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires the disabled package: hw-hedgehog
+    - hw-int # tried hw-int-0.0.2.0, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
+    - hw-string-parse # tried hw-string-parse-0.0.0.5, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.21.1
+    - indexed-containers # tried indexed-containers-0.1.0.2, but its *test-suite* requires hspec >=2.4.8 && < 2.8 and the snapshot contains hspec-2.11.1
+    - integer-types # tried integer-types-0.1.1.0, but its *test-suite* requires hspec ^>=2.8.5 || ^>=2.9 || ^>=2.10 and the snapshot contains hspec-2.11.1
+    - integer-types # tried integer-types-0.1.1.0, but its *test-suite* requires the disabled package: hedgehog
+    - integer-types # tried integer-types-0.1.1.0, but its *test-suite* requires the disabled package: hspec-hedgehog
+    - io-streams # tried io-streams-1.5.2.2, but its *test-suite* requires the disabled package: test-framework
+    - io-streams # tried io-streams-1.5.2.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - io-streams # tried io-streams-1.5.2.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - io-streams-haproxy # tried io-streams-haproxy-1.0.1.0, but its *test-suite* requires the disabled package: test-framework
+    - io-streams-haproxy # tried io-streams-haproxy-1.0.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - irc # tried irc-0.6.1.0, but its *test-suite* requires the disabled package: test-framework
+    - irc # tried irc-0.6.1.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - irc # tried irc-0.6.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - jose # tried jose-0.10, but its *test-suite* requires the disabled package: hedgehog
+    - jose # tried jose-0.10, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - jsonifier # tried jsonifier-0.2.1.2, but its *test-suite* requires the disabled package: hedgehog
+    - keyed-vals-redis # tried keyed-vals-redis-0.2.0.0, but its *test-suite* requires the disabled package: hspec-tmp-proc
+    - keyed-vals-redis # tried keyed-vals-redis-0.2.0.0, but its *test-suite* requires the disabled package: tmp-proc-redis
+    - language-glsl # tried language-glsl-0.3.0, but its *test-suite* requires the disabled package: test-framework
+    - language-glsl # tried language-glsl-0.3.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - lapack # tried lapack-0.5.1, but its *test-suite* requires the disabled package: ChasingBottoms
+    - largeword # tried largeword-1.2.5, but its *test-suite* requires the disabled package: test-framework
+    - largeword # tried largeword-1.2.5, but its *test-suite* requires the disabled package: test-framework-hunit
+    - largeword # tried largeword-1.2.5, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - lens # tried lens-5.2.2, but its *test-suite* requires the disabled package: test-framework
+    - lens # tried lens-5.2.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - lens # tried lens-5.2.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - lifted-base # tried lifted-base-0.2.3.12, but its *test-suite* requires the disabled package: test-framework
+    - lifted-base # tried lifted-base-0.2.3.12, but its *test-suite* requires the disabled package: test-framework-hunit
+    - linear # tried linear-1.22, but its *test-suite* requires the disabled package: test-framework
+    - linear # tried linear-1.22, but its *test-suite* requires the disabled package: test-framework-hunit
+    - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: abstract-deque-tests
+    - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework
+    - lockfree-queue # tried lockfree-queue-0.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
+    - map-syntax # tried map-syntax-0.3, but its *test-suite* requires hspec >=2.2.3 && < 2.11 and the snapshot contains hspec-2.11.1
+    - massiv-test # tried massiv-test-1.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - math-extras # tried math-extras-0.1.1.0, but its *test-suite* requires the disabled package: hedgehog
+    - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *test-suite* requires the disabled package: hedgehog
+    - minimorph # tried minimorph-0.3.0.1, but its *test-suite* requires the disabled package: test-framework
+    - minimorph # tried minimorph-0.3.0.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - miniutter # tried miniutter-0.5.1.2, but its *test-suite* requires the disabled package: test-framework
+    - miniutter # tried miniutter-0.5.1.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - monad-memo # tried monad-memo-0.5.4, but its *test-suite* requires the disabled package: test-framework
+    - monad-memo # tried monad-memo-0.5.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - murmur3 # tried murmur3-1.0.5, but its *test-suite* requires the disabled package: base16
+    - murmur3 # tried murmur3-1.0.5, but its *test-suite* requires the disabled package: test-framework
+    - murmur3 # tried murmur3-1.0.5, but its *test-suite* requires the disabled package: test-framework-hunit
+    - murmur3 # tried murmur3-1.0.5, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - mustache # tried mustache-2.4.2, but its *test-suite* requires the disabled package: wreq
+    - mwc-random # tried mwc-random-0.15.0.2, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.21.1
+    - nanovg # tried nanovg-0.8.1.0, but its *test-suite* requires the disabled package: inline-c
+    - nettle # tried nettle-0.3.0, but its *test-suite* requires the disabled package: crypto-cipher-tests
+    - nettle # tried nettle-0.3.0, but its *test-suite* requires the disabled package: test-framework
+    - nettle # tried nettle-0.3.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - nettle # tried nettle-0.3.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - nonempty-containers # tried nonempty-containers-0.3.4.4, but its *test-suite* requires the disabled package: hedgehog
+    - nonempty-containers # tried nonempty-containers-0.3.4.4, but its *test-suite* requires the disabled package: hedgehog-fn
+    - nonempty-containers # tried nonempty-containers-0.3.4.4, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - nothunks # tried nothunks-0.1.4, but its *test-suite* requires the disabled package: hedgehog
+    - nothunks # tried nothunks-0.1.4, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - nqe # tried nqe-0.6.4, but its *test-suite* requires the disabled package: stm-conduit
+    - numbers # tried numbers-3000.2.0.2, but its *test-suite* requires the disabled package: test-framework
+    - numbers # tried numbers-3000.2.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - o-clock # tried o-clock-1.3.0, but its *test-suite* requires doctest >=0.16 && < 0.21 and the snapshot contains doctest-0.21.1
+    - o-clock # tried o-clock-1.3.0, but its *test-suite* requires the disabled package: hedgehog
+    - o-clock # tried o-clock-1.3.0, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - oops # tried oops-0.2.0.1, but its *test-suite* requires the disabled package: hedgehog
+    - oops # tried oops-0.2.0.1, but its *test-suite* requires the disabled package: hedgehog-quickcheck
+    - oops # tried oops-0.2.0.1, but its *test-suite* requires the disabled package: hw-hspec-hedgehog
+    - opaleye # tried opaleye-0.9.6.2, but its *test-suite* requires the disabled package: dotenv
+    - openssl-streams # tried openssl-streams-1.2.3.0, but its *test-suite* requires the disabled package: test-framework
+    - openssl-streams # tried openssl-streams-1.2.3.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - opml-conduit # tried opml-conduit-0.9.0.0, but its *test-suite* requires the disabled package: hlint
     - optics # tried optics-0.4.2, but its *test-suite* requires inspection-testing >=0.4.1.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.1
-    - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell
-    - options # tried options-1.2.1.1, but its *test-suite* requires the disabled package: chell-quickcheck
-    - phatsort # tried phatsort-0.6.0.0, but its *test-suite* requires the disabled package: HMock
+    - pandoc-types # tried pandoc-types-1.23, but its *test-suite* requires the disabled package: test-framework
+    - pandoc-types # tried pandoc-types-1.23, but its *test-suite* requires the disabled package: test-framework-hunit
+    - pandoc-types # tried pandoc-types-1.23, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework
+    - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - partial-order # tried partial-order-0.2.0.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - path # tried path-0.9.2, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - path # tried path-0.9.2, but its *test-suite* requires the disabled package: genvalidity-property
+    - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework
+    - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework-hunit
+    - pem # tried pem-0.2.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - perfect-hash-generator # tried perfect-hash-generator-1.0.0, but its *test-suite* requires the disabled package: test-framework
+    - perfect-hash-generator # tried perfect-hash-generator-1.0.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - pipes # tried pipes-4.3.16, but its *test-suite* requires the disabled package: test-framework
+    - pipes # tried pipes-4.3.16, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - pipes-csv # tried pipes-csv-1.4.3, but its *test-suite* requires the disabled package: test-framework
+    - pipes-csv # tried pipes-csv-1.4.3, but its *test-suite* requires the disabled package: test-framework-hunit
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
-    - quickcheck-state-machine # tried quickcheck-state-machine-0.7.3, but its *test-suite* requires persistent >=2.10.4 && < 2.11 and the snapshot contains persistent-2.14.5.0
-    - quickcheck-state-machine # tried quickcheck-state-machine-0.7.3, but its *test-suite* requires persistent-sqlite < 2.11 and the snapshot contains persistent-sqlite-2.13.1.1
-    - quickcheck-state-machine # tried quickcheck-state-machine-0.7.3, but its *test-suite* requires persistent-template < 2.11 and the snapshot contains persistent-template-2.12.0.0
-    - quickcheck-state-machine # tried quickcheck-state-machine-0.7.3, but its *test-suite* requires the disabled package: hs-rqlite
-    - redact # tried redact-0.5.0.0, but its *test-suite* requires the disabled package: HMock
-    - rel8 # tried rel8-1.4.1.0, but its *test-suite* requires hedgehog ^>=1.0 || ^>=1.1 and the snapshot contains hedgehog-1.2
+    - postgresql-syntax # tried postgresql-syntax-0.4.1, but its *test-suite* requires the disabled package: hedgehog
+    - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework
+    - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - prefix-units # tried prefix-units-0.3.0.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - pretty-relative-time # tried pretty-relative-time-0.3.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - ptr-poker # tried ptr-poker-0.1.2.13, but its *test-suite* requires the disabled package: hedgehog
+    - pureMD5 # tried pureMD5-2.1.4, but its *test-suite* requires the disabled package: crypto-api-tests
+    - pureMD5 # tried pureMD5-2.1.4, but its *test-suite* requires the disabled package: test-framework
+    - pureMD5 # tried pureMD5-2.1.4, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - quicklz # tried quicklz-1.5.0.11, but its *test-suite* requires the disabled package: test-framework
+    - quicklz # tried quicklz-1.5.0.11, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - range # tried range-0.3.0.2, but its *test-suite* requires the disabled package: test-framework
+    - range # tried range-0.3.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - rank1dynamic # tried rank1dynamic-0.4.1, but its *test-suite* requires the disabled package: test-framework
+    - rank1dynamic # tried rank1dynamic-0.4.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - rec-def # tried rec-def-0.2.1, but its *test-suite* requires the disabled package: concurrency
+    - rec-def # tried rec-def-0.2.1, but its *test-suite* requires the disabled package: dejafu
+    - rec-def # tried rec-def-0.2.1, but its *test-suite* requires the disabled package: tasty-dejafu
+    - redis-glob # tried redis-glob-0.1.0.4, but its *test-suite* requires the disabled package: ascii-superset
+    - retry # tried retry-0.9.3.1, but its *test-suite* requires the disabled package: hedgehog
+    - retry # tried retry-0.9.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - rng-utils # tried rng-utils-0.3.1, but its *test-suite* requires the disabled package: hedgehog
+    - rng-utils # tried rng-utils-0.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - safe-coloured-text-gen # tried safe-coloured-text-gen-0.0.0.1, but its *test-suite* requires the disabled package: genvalidity-sydtest
+    - safe-coloured-text-gen # tried safe-coloured-text-gen-0.0.0.1, but its *test-suite* requires the disabled package: sydtest
+    - safe-coloured-text-layout # tried safe-coloured-text-layout-0.0.0.0, but its *test-suite* requires the disabled package: sydtest
+    - safe-coloured-text-layout-gen # tried safe-coloured-text-layout-gen-0.0.0.0, but its *test-suite* requires the disabled package: genvalidity-sydtest
+    - safe-coloured-text-layout-gen # tried safe-coloured-text-layout-gen-0.0.0.0, but its *test-suite* requires the disabled package: sydtest
+    - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework
+    - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - safeio # tried safeio-0.0.5.0, but its *test-suite* requires the disabled package: test-framework-th
-    - servant # tried servant-0.19.1, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant # tried servant-0.19.1, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires hspec >=2.5.5 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires jose >=0.7.0.0 && < 0.10 and the snapshot contains jose-0.10
-    - servant-auth-client # tried servant-auth-client-0.4.1.0, but its *test-suite* requires the disabled package: servant-auth-server
-    - servant-client # tried servant-client-0.19, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-client # tried servant-client-0.19, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-client # tried servant-client-0.19, but its *test-suite* requires tdigest >=0.2 && < 0.3 and the snapshot contains tdigest-0.3
-    - servant-client-core # tried servant-client-core-0.19, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-client-core # tried servant-client-core-0.19, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-foreign # tried servant-foreign-0.15.4, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-foreign # tried servant-foreign-0.15.4, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-http-streams # tried servant-http-streams-0.18.4, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-http-streams # tried servant-http-streams-0.18.4, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-http-streams # tried servant-http-streams-0.18.4, but its *test-suite* requires tdigest >=0.2 && < 0.3 and the snapshot contains tdigest-0.3
-    - servant-server # tried servant-server-0.19.2, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-server # tried servant-server-0.19.2, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
-    - servant-swagger # tried servant-swagger-1.1.11, but its *test-suite* requires hspec >=2.6.0 && < 2.10 and the snapshot contains hspec-2.10.10
-    - servant-swagger # tried servant-swagger-1.1.11, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.10 and the snapshot contains hspec-discover-2.10.10
+    - saltine # tried saltine-0.2.1.0, but its *test-suite* requires the disabled package: test-framework
+    - saltine # tried saltine-0.2.1.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - scheduler # tried scheduler-2.0.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework
+    - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - scrypt # tried scrypt-0.5.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - sdl2 # tried sdl2-2.5.5.0, but its *test-suite* requires the disabled package: weigh
+    - serialise # tried serialise-0.2.6.0, but its *test-suite* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
+    - siggy-chardust # tried siggy-chardust-1.0.0, but its *test-suite* requires the disabled package: hlint
+    - simple-affine-space # tried simple-affine-space-0.2.1, but its *test-suite* requires the disabled package: hlint
+    - singletons-base # tried singletons-base-3.2, but its *test-suite* requires the disabled package: turtle
+    - skylighting-core # tried skylighting-core-0.13.2.1, but its *test-suite* requires the disabled package: pretty-show
+    - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework
+    - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - snap-core # tried snap-core-1.0.5.1, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - squeather # tried squeather-0.8.0.0, but its *test-suite* requires the disabled package: hedgehog
     - string-qq # tried string-qq-0.0.4, but its *test-suite* requires text >=1.2 && < 1.3 and the snapshot contains text-2.0.2
-    - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.10.10
+    - string-variants # tried string-variants-0.2.2.0, but its *test-suite* requires the disabled package: hedgehog
+    - string-variants # tried string-variants-0.2.2.0, but its *test-suite* requires the disabled package: hspec-hedgehog
+    - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec >=2.5.5 && < 2.11 and the snapshot contains hspec-2.11.1
+    - swagger2 # tried swagger2-2.8.7, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.11.1
+    - swish # tried swish-0.10.4.0, but its *test-suite* requires the disabled package: test-framework
+    - swish # tried swish-0.10.4.0, but its *test-suite* requires the disabled package: test-framework-hunit
     - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell-quickcheck
     - tar # tried tar-0.5.1.1, but its *test-suite* requires the disabled package: bytestring-handle
+    - tar-conduit # tried tar-conduit-0.3.2, but its *test-suite* requires the disabled package: weigh
+    - tasty-autocollect # tried tasty-autocollect-0.4.1, but its *test-suite* requires the disabled package: explainable-predicates
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.1
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec-core >=2.7.10 && < 2.11 and the snapshot contains hspec-core-2.11.1
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires the disabled package: hedgehog
+    - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - tcp-streams # tried tcp-streams-1.0.1.1, but its *test-suite* requires the disabled package: test-framework
+    - tcp-streams # tried tcp-streams-1.0.1.1, but its *test-suite* requires the disabled package: test-framework-hunit
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.3
-    - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
+    - terminal-progress-bar # tried terminal-progress-bar-0.4.2, but its *test-suite* requires the disabled package: test-framework
+    - terminal-progress-bar # tried terminal-progress-bar-0.4.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - texmath # tried texmath-0.12.8, but its *test-suite* requires the disabled package: pretty-show
+    - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework
+    - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - text-icu # tried text-icu-0.8.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - text-printer # tried text-printer-0.5.0.2, but its *test-suite* requires the disabled package: test-framework
+    - text-printer # tried text-printer-0.5.0.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - threads # tried threads-0.5.1.7, but its *test-suite* requires the disabled package: test-framework
+    - threads # tried threads-0.5.1.7, but its *test-suite* requires the disabled package: test-framework-hunit
     - transient # tried transient-0.7.0.0, but its *test-suite* requires random ==1.1 and the snapshot contains random-1.2.1.1
-    - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.10.10
+    - ttrie # tried ttrie-0.1.2.2, but its *test-suite* requires the disabled package: test-framework
+    - ttrie # tried ttrie-0.1.2.2, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - type-map # tried type-map-0.1.7.0, but its *test-suite* requires the disabled package: test-framework
+    - type-map # tried type-map-0.1.7.0, but its *test-suite* requires the disabled package: test-framework-hunit
+    - typst # tried typst-0.1.0.0, but its *test-suite* requires the disabled package: pretty-show
+    - unexceptionalio # tried unexceptionalio-0.5.1, but its *test-suite* requires the disabled package: test-framework
+    - unexceptionalio # tried unexceptionalio-0.5.1, but its *test-suite* requires the disabled package: test-framework-hunit
+    - unicode-data # tried unicode-data-0.4.0.1, but its *test-suite* requires hspec >=2.0 && < 2.11 and the snapshot contains hspec-2.11.1
+    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *test-suite* requires the disabled package: hedgehog
+    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - utf8-light # tried utf8-light-0.4.4.0, but its *test-suite* requires hspec >=2.3 && < 2.11 and the snapshot contains hspec-2.11.1
+    - validity-case-insensitive # tried validity-case-insensitive-0.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - validity-path # tried validity-path-0.4.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
+    - wai-middleware-delegate # tried wai-middleware-delegate-0.1.3.1, but its *test-suite* requires the disabled package: connection
+    - wai-rate-limit-redis # tried wai-rate-limit-redis-0.2.0.1, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - wai-saml2 # tried wai-saml2-0.4, but its *test-suite* requires the disabled package: pretty-show
+    - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.11.1
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.0.2
-    - wreq # tried wreq-0.5.4.0, but its *test-suite* requires the disabled package: snap-server
-    - xlsx # tried xlsx-1.1.0.1, but its *test-suite* requires lens >=3.8 && < 5.2 and the snapshot contains lens-5.2.2
+    - websockets # tried websockets-0.12.7.3, but its *test-suite* requires the disabled package: test-framework
+    - websockets # tried websockets-0.12.7.3, but its *test-suite* requires the disabled package: test-framework-hunit
+    - websockets # tried websockets-0.12.7.3, but its *test-suite* requires the disabled package: test-framework-quickcheck2
+    - wide-word # tried wide-word-0.1.5.0, but its *test-suite* requires the disabled package: hedgehog
+    - with-utf8 # tried with-utf8-1.0.2.4, but its *test-suite* requires the disabled package: hedgehog
+    - with-utf8 # tried with-utf8-1.0.2.4, but its *test-suite* requires the disabled package: tasty-hedgehog
+    - xmlhtml # tried xmlhtml-0.2.5.4, but its *test-suite* requires hspec >=2.4 && < 2.11 and the snapshot contains hspec-2.11.1
+    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: persistent
+    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: persistent-sqlite
+    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod
+    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod-test
+    - yesod-static # tried yesod-static-1.6.1.0, but its *test-suite* requires the disabled package: yesod-test
+    - zenacy-unicode # tried zenacy-unicode-1.0.2, but its *test-suite* requires the disabled package: test-framework
+    - zenacy-unicode # tried zenacy-unicode-1.0.2, but its *test-suite* requires the disabled package: test-framework-hunit
+    - zstd # tried zstd-0.1.3.0, but its *test-suite* requires the disabled package: test-framework
+    - zstd # tried zstd-0.1.3.0, but its *test-suite* requires the disabled package: test-framework-quickcheck2
     # End of Test bounds issues
 
     # general failures
@@ -8763,32 +10068,240 @@ skipped-benchmarks:
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
     # Benchmark bounds issues
+    - Color # tried Color-0.3.3, but its *benchmarks* requires the disabled package: criterion
+    - Earley # tried Earley-0.13.0.1, but its *benchmarks* requires the disabled package: criterion
+    - ForestStructures # tried ForestStructures-0.0.1.1, but its *benchmarks* requires the disabled package: criterion
     - IntervalMap # tried IntervalMap-0.6.2.1, but its *benchmarks* requires the disabled package: SegmentTree
+    - IntervalMap # tried IntervalMap-0.6.2.1, but its *benchmarks* requires the disabled package: criterion
+    - IntervalMap # tried IntervalMap-0.6.2.1, but its *benchmarks* requires the disabled package: weigh
+    - JuicyPixels-extra # tried JuicyPixels-extra-0.6.0, but its *benchmarks* requires the disabled package: criterion
+    - OrderedBits # tried OrderedBits-0.0.2.0, but its *benchmarks* requires the disabled package: criterion
+    - acc # tried acc-0.2.0.2, but its *benchmarks* requires the disabled package: criterion
+    - acid-state # tried acid-state-0.16.1.2, but its *benchmarks* requires the disabled package: criterion
+    - ad # tried ad-4.5.4, but its *benchmarks* requires the disabled package: criterion
+    - aeson-combinators # tried aeson-combinators-0.1.0.1, but its *benchmarks* requires the disabled package: criterion
+    - aeson-schemas # tried aeson-schemas-1.4.1.0, but its *benchmarks* requires the disabled package: criterion
+    - aws-xray-client # tried aws-xray-client-0.1.0.2, but its *benchmarks* requires the disabled package: criterion
+    - base16-bytestring # tried base16-bytestring-1.0.2.0, but its *benchmarks* requires the disabled package: criterion
+    - base32 # tried base32-0.3.1.0, but its *benchmarks* requires the disabled package: criterion
+    - base58-bytestring # tried base58-bytestring-0.1.0, but its *benchmarks* requires the disabled package: criterion
+    - base64 # tried base64-0.4.2.4, but its *benchmarks* requires the disabled package: criterion
+    - base64-bytestring # tried base64-bytestring-1.2.1.0, but its *benchmarks* requires the disabled package: criterion
+    - bencoding # tried bencoding-0.4.5.4, but its *benchmarks* requires the disabled package: criterion
+    - binary-tagged # tried binary-tagged-0.3.1, but its *benchmarks* requires the disabled package: binary-instances
+    - binary-tagged # tried binary-tagged-0.3.1, but its *benchmarks* requires the disabled package: criterion
+    - bitset-word8 # tried bitset-word8-0.1.1.2, but its *benchmarks* requires the disabled package: criterion
+    - blake2 # tried blake2-0.3.0, but its *benchmarks* requires the disabled package: criterion
+    - broadcast-chan # tried broadcast-chan-0.2.1.2, but its *benchmarks* requires the disabled package: criterion
+    - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: criterion
     - buffer-builder # tried buffer-builder-0.2.4.8, but its *benchmarks* requires the disabled package: json-builder
-    - cborg-json # tried cborg-json-0.2.5.0, but its *benchmarks* requires criterion >=1.0 && < 1.6 and the snapshot contains criterion-1.6.1.0
+    - bytestring-trie # tried bytestring-trie-0.2.7.2, but its *benchmarks* requires the disabled package: criterion
+    - bz2 # tried bz2-1.0.1.0, but its *benchmarks* requires the disabled package: criterion
+    - cacophony # tried cacophony-0.10.1, but its *benchmarks* requires the disabled package: criterion
+    - cdar-mBound # tried cdar-mBound-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - cipher-aes # tried cipher-aes-0.2.11, but its *benchmarks* requires the disabled package: criterion
     - cipher-aes # tried cipher-aes-0.2.11, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - cipher-camellia # tried cipher-camellia-0.0.2, but its *benchmarks* requires the disabled package: criterion
     - cipher-camellia # tried cipher-camellia-0.0.2, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - cipher-rc4 # tried cipher-rc4-0.1.4, but its *benchmarks* requires the disabled package: criterion
     - cipher-rc4 # tried cipher-rc4-0.1.4, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
+    - circular # tried circular-0.4.0.3, but its *benchmarks* requires the disabled package: criterion
     - cmark-gfm # tried cmark-gfm-0.2.5, but its *benchmarks* requires the disabled package: cheapskate
-    - country # tried country-0.2.3.1, but its *benchmarks* requires the disabled package: compact
-    - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires criterion >=0.8 && < 1.2 and the snapshot contains criterion-1.6.1.0
+    - cmark-gfm # tried cmark-gfm-0.2.5, but its *benchmarks* requires the disabled package: criterion
+    - compdata # tried compdata-0.13.0, but its *benchmarks* requires the disabled package: criterion
+    - compensated # tried compensated-0.8.3, but its *benchmarks* requires the disabled package: criterion
+    - contiguous # tried contiguous-0.6.3.0, but its *benchmarks* requires the disabled package: weigh
+    - cprng-aes # tried cprng-aes-0.6.1, but its *benchmarks* requires the disabled package: criterion
+    - cron # tried cron-0.7.0, but its *benchmarks* requires the disabled package: criterion
+    - cryptohash # tried cryptohash-0.11.9, but its *benchmarks* requires the disabled package: criterion
+    - css-syntax # tried css-syntax-0.1.0.1, but its *benchmarks* requires the disabled package: criterion
+    - ctrie # tried ctrie-0.2, but its *benchmarks* requires the disabled package: criterion
+    - cursor-gen # tried cursor-gen-0.4.0.0, but its *benchmarks* requires the disabled package: criterion
+    - cursor-gen # tried cursor-gen-0.4.0.0, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - data-diverse # tried data-diverse-4.7.1.0, but its *benchmarks* requires the disabled package: criterion
+    - data-has # tried data-has-0.4.0.0, but its *benchmarks* requires the disabled package: criterion
+    - data-msgpack # tried data-msgpack-0.0.13, but its *benchmarks* requires the disabled package: criterion
+    - data-sketches # tried data-sketches-0.3.1.0, but its *benchmarks* requires the disabled package: criterion
+    - dbus # tried dbus-1.2.29, but its *benchmarks* requires the disabled package: criterion
+    - derive-storable # tried derive-storable-0.3.1.0, but its *benchmarks* requires the disabled package: criterion
+    - diagrams-lib # tried diagrams-lib-1.4.6, but its *benchmarks* requires the disabled package: criterion
+    - dimensional # tried dimensional-1.5, but its *benchmarks* requires the disabled package: criterion
+    - discrimination # tried discrimination-0.5, but its *benchmarks* requires the disabled package: criterion
+    - do-list # tried do-list-1.0.1, but its *benchmarks* requires the disabled package: criterion
+    - doclayout # tried doclayout-0.4.0.1, but its *benchmarks* requires the disabled package: criterion
+    - doctemplates # tried doctemplates-0.11, but its *benchmarks* requires the disabled package: criterion
+    - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires the disabled package: criterion
+    - edit-distance # tried edit-distance-0.2.2.1, but its *benchmarks* requires the disabled package: criterion
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-hunit
+    - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-quickcheck2
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th
-    - filepath-bytestring # tried filepath-bytestring-1.4.2.1.12, but its *benchmarks* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.4.2.2
+    - fmt # tried fmt-0.6.3.0, but its *benchmarks* requires the disabled package: criterion
+    - foldl # tried foldl-1.4.14, but its *benchmarks* requires the disabled package: criterion
+    - formatting # tried formatting-7.2.0, but its *benchmarks* requires the disabled package: criterion
+    - generics-sop # tried generics-sop-0.5.1.3, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-aeson # tried genvalidity-aeson-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-aeson # tried genvalidity-aeson-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-appendful # tried genvalidity-appendful-0.1.0.0, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-bytestring # tried genvalidity-bytestring-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-bytestring # tried genvalidity-bytestring-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-case-insensitive # tried genvalidity-case-insensitive-0.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-case-insensitive # tried genvalidity-case-insensitive-0.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-containers # tried genvalidity-containers-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-mergeful # tried genvalidity-mergeful-0.3.0.0, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-mergeless # tried genvalidity-mergeless-0.3.0.0, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-path # tried genvalidity-path-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-path # tried genvalidity-path-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-text # tried genvalidity-text-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-text # tried genvalidity-text-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-time # tried genvalidity-time-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-time # tried genvalidity-time-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-typed-uuid # tried genvalidity-typed-uuid-0.1.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - genvalidity-uuid # tried genvalidity-uuid-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - genvalidity-uuid # tried genvalidity-uuid-1.0.0.1, but its *benchmarks* requires the disabled package: genvalidity-criterion
+    - glob-posix # tried glob-posix-0.2.0.1, but its *benchmarks* requires the disabled package: criterion
+    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: criterion
+    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: statistics
+    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework
+    - heist # tried heist-1.1.1.1, but its *benchmarks* requires the disabled package: test-framework-hunit
+    - histogram-fill # tried histogram-fill-0.9.1.0, but its *benchmarks* requires the disabled package: criterion
+    - hledger # tried hledger-1.30.1, but its *benchmarks* requires the disabled package: criterion
+    - hmatrix-morpheus # tried hmatrix-morpheus-0.1.1.2, but its *benchmarks* requires the disabled package: criterion
+    - html-email-validate # tried html-email-validate-0.2.0.0, but its *benchmarks* requires the disabled package: criterion
+    - html-entity-map # tried html-entity-map-0.1.0.0, but its *benchmarks* requires the disabled package: criterion
+    - htoml-megaparsec # tried htoml-megaparsec-2.1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - http-link-header # tried http-link-header-1.2.1, but its *benchmarks* requires the disabled package: criterion
+    - human-readable-duration # tried human-readable-duration-0.2.1.4, but its *benchmarks* requires the disabled package: criterion
+    - hw-conduit # tried hw-conduit-0.2.1.1, but its *benchmarks* requires the disabled package: criterion
+    - hweblib # tried hweblib-0.6.3, but its *benchmarks* requires the disabled package: criterion
+    - hxt-regex-xmlschema # tried hxt-regex-xmlschema-9.2.0.7, but its *benchmarks* requires the disabled package: criterion
+    - identicon # tried identicon-0.2.2, but its *benchmarks* requires the disabled package: criterion
+    - include-file # tried include-file-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - intset-imperative # tried intset-imperative-0.1.0.0, but its *benchmarks* requires the disabled package: criterion
+    - jose-jwt # tried jose-jwt-0.9.5, but its *benchmarks* requires the disabled package: criterion
+    - katip # tried katip-0.8.7.4, but its *benchmarks* requires the disabled package: criterion
+    - kazura-queue # tried kazura-queue-0.1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - kdt # tried kdt-0.2.5, but its *benchmarks* requires the disabled package: criterion
+    - lens # tried lens-5.2.2, but its *benchmarks* requires the disabled package: criterion
+    - lifted-base # tried lifted-base-0.2.3.12, but its *benchmarks* requires the disabled package: criterion
+    - lifted-base # tried lifted-base-0.2.3.12, but its *benchmarks* requires the disabled package: monad-peel
+    - logging-effect # tried logging-effect-1.4.0, but its *benchmarks* requires the disabled package: criterion
+    - loop # tried loop-0.3.0, but its *benchmarks* requires the disabled package: criterion
+    - lucid # tried lucid-2.11.20230408, but its *benchmarks* requires the disabled package: criterion
+    - lz4 # tried lz4-0.2.3.1, but its *benchmarks* requires the disabled package: criterion
     - lz4 # tried lz4-0.2.3.1, but its *benchmarks* requires the disabled package: snappy
-    - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *benchmarks* requires criterion >=1.4.1 && < 1.6 and the snapshot contains criterion-1.6.1.0
+    - machines # tried machines-0.7.3, but its *benchmarks* requires the disabled package: criterion
+    - machines # tried machines-0.7.3, but its *benchmarks* requires the disabled package: streaming
+    - massiv-io # tried massiv-io-1.0.0.1, but its *benchmarks* requires the disabled package: criterion
+    - matrices # tried matrices-0.5.0, but its *benchmarks* requires the disabled package: criterion
+    - matrix # tried matrix-0.3.6.1, but its *benchmarks* requires the disabled package: criterion
+    - megaparsec # tried megaparsec-9.3.1, but its *benchmarks* requires the disabled package: criterion
+    - megaparsec # tried megaparsec-9.3.1, but its *benchmarks* requires the disabled package: weigh
+    - memcache # tried memcache-0.3.0.1, but its *benchmarks* requires the disabled package: criterion
+    - min-max-pqueue # tried min-max-pqueue-0.1.0.2, but its *benchmarks* requires the disabled package: criterion
     - minisat-solver # tried minisat-solver-0.1, but its *benchmarks* requires the disabled package: easyrender
+    - modern-uri # tried modern-uri-0.3.6.0, but its *benchmarks* requires the disabled package: criterion
+    - modern-uri # tried modern-uri-0.3.6.0, but its *benchmarks* requires the disabled package: weigh
+    - monad-memo # tried monad-memo-0.5.4, but its *benchmarks* requires the disabled package: criterion
+    - mongoDB # tried mongoDB-2.7.1.2, but its *benchmarks* requires the disabled package: criterion
+    - monoid-extras # tried monoid-extras-0.6.2, but its *benchmarks* requires the disabled package: criterion
+    - netpbm # tried netpbm-1.0.4, but its *benchmarks* requires the disabled package: criterion
+    - network-uri # tried network-uri-2.6.4.2, but its *benchmarks* requires the disabled package: criterion
     - o-clock # tried o-clock-1.3.0, but its *benchmarks* requires the disabled package: tiempo
+    - openpgp-asciiarmor # tried openpgp-asciiarmor-0.1.2, but its *benchmarks* requires the disabled package: criterion
+    - pandoc-types # tried pandoc-types-1.23, but its *benchmarks* requires the disabled package: criterion
+    - pava # tried pava-0.1.1.4, but its *benchmarks* requires the disabled package: criterion
+    - pcre2 # tried pcre2-2.2.1, but its *benchmarks* requires the disabled package: criterion
+    - pg-transact # tried pg-transact-0.3.2.0, but its *benchmarks* requires the disabled package: criterion
+    - pipes # tried pipes-4.3.16, but its *benchmarks* requires optparse-applicative >=0.12 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
+    - pipes # tried pipes-4.3.16, but its *benchmarks* requires the disabled package: criterion
+    - pontarius-xmpp # tried pontarius-xmpp-0.5.6.6, but its *benchmarks* requires the disabled package: criterion
+    - posix-paths # tried posix-paths-0.3.0.0, but its *benchmarks* requires the disabled package: criterion
+    - postgresql-typed # tried postgresql-typed-0.6.2.2, but its *benchmarks* requires the disabled package: criterion
+    - pretty-simple # tried pretty-simple-4.1.2.0, but its *benchmarks* requires the disabled package: criterion
+    - product-profunctors # tried product-profunctors-0.11.1.1, but its *benchmarks* requires the disabled package: criterion
+    - prometheus-client # tried prometheus-client-1.1.0, but its *benchmarks* requires the disabled package: criterion
+    - psqueues # tried psqueues-0.2.7.3, but its *benchmarks* requires the disabled package: criterion
     - psqueues # tried psqueues-0.2.7.3, but its *benchmarks* requires the disabled package: fingertree-psqueue
-    - regex-applicative # tried regex-applicative-0.3.4, but its *benchmarks* requires the disabled package: parsers-megaparsec
-    - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires criterion >=1.0 && < 1.6 and the snapshot contains criterion-1.6.1.0
-    - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires criterion < 1.3 and the snapshot contains criterion-1.6.1.0
+    - ptr-poker # tried ptr-poker-0.1.2.13, but its *benchmarks* requires the disabled package: criterion
+    - ral # tried ral-0.2.1, but its *benchmarks* requires the disabled package: criterion
+    - ramus # tried ramus-0.1.2, but its *benchmarks* requires the disabled package: criterion
+    - random-bytestring # tried random-bytestring-0.1.4, but its *benchmarks* requires the disabled package: criterion
+    - rcu # tried rcu-0.2.6, but its *benchmarks* requires the disabled package: criterion
+    - rdf # tried rdf-0.1.0.7, but its *benchmarks* requires the disabled package: criterion
+    - reinterpret-cast # tried reinterpret-cast-0.1.0, but its *benchmarks* requires the disabled package: criterion
+    - reroute # tried reroute-0.7.0.0, but its *benchmarks* requires the disabled package: criterion
+    - rng-utils # tried rng-utils-0.3.1, but its *benchmarks* requires the disabled package: criterion
+    - saltine # tried saltine-0.2.1.0, but its *benchmarks* requires the disabled package: criterion
+    - sampling # tried sampling-0.3.5, but its *benchmarks* requires the disabled package: criterion
+    - sandi # tried sandi-0.5, but its *benchmarks* requires the disabled package: criterion
+    - scalpel-core # tried scalpel-core-0.6.2.1, but its *benchmarks* requires the disabled package: criterion
+    - scanner # tried scanner-0.3.1, but its *benchmarks* requires the disabled package: criterion
+    - scotty # tried scotty-0.12.1, but its *benchmarks* requires the disabled package: weigh
+    - search-algorithms # tried search-algorithms-0.3.2, but its *benchmarks* requires the disabled package: criterion
+    - semver # tried semver-0.4.0.1, but its *benchmarks* requires the disabled package: criterion
+    - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
+    - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires ghc-prim >=0.3.1.0 && < 0.10 and the snapshot contains ghc-prim-0.10.0
+    - serialise # tried serialise-0.2.6.0, but its *benchmarks* requires the disabled package: criterion
+    - sexp-grammar # tried sexp-grammar-2.3.4.1, but its *benchmarks* requires the disabled package: criterion
+    - simple-vec3 # tried simple-vec3-0.6.0.1, but its *benchmarks* requires the disabled package: criterion
+    - skylighting-core # tried skylighting-core-0.13.2.1, but its *benchmarks* requires the disabled package: criterion
+    - sorted-list # tried sorted-list-0.2.1.0, but its *benchmarks* requires the disabled package: criterion
+    - sourcemap # tried sourcemap-0.1.7, but its *benchmarks* requires the disabled package: criterion
+    - stitch # tried stitch-0.6.0.0, but its *benchmarks* requires the disabled package: criterion
+    - stm-hamt # tried stm-hamt-1.2.0.11, but its *benchmarks* requires the disabled package: criterion
+    - store # tried store-0.7.16, but its *benchmarks* requires the disabled package: criterion
+    - store # tried store-0.7.16, but its *benchmarks* requires the disabled package: vector-binary-instances
+    - store # tried store-0.7.16, but its *benchmarks* requires the disabled package: weigh
+    - string-interpolate # tried string-interpolate-0.3.2.1, but its *benchmarks* requires the disabled package: criterion
+    - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires the disabled package: criterion
+    - tar # tried tar-0.5.1.1, but its *benchmarks* requires the disabled package: criterion
+    - tar-conduit # tried tar-conduit-0.3.2, but its *benchmarks* requires the disabled package: criterion
+    - tensors # tried tensors-0.1.5, but its *benchmarks* requires the disabled package: criterion
+    - terminal-progress-bar # tried terminal-progress-bar-0.4.2, but its *benchmarks* requires the disabled package: criterion
+    - text-builder # tried text-builder-0.6.7, but its *benchmarks* requires the disabled package: criterion
+    - text-builder-dev # tried text-builder-dev-0.3.3.2, but its *benchmarks* requires the disabled package: criterion
+    - text-manipulate # tried text-manipulate-0.3.1.0, but its *benchmarks* requires the disabled package: criterion
+    - text-metrics # tried text-metrics-0.3.2, but its *benchmarks* requires the disabled package: criterion
+    - text-metrics # tried text-metrics-0.3.2, but its *benchmarks* requires the disabled package: weigh
+    - text-show # tried text-show-3.10.3, but its *benchmarks* requires the disabled package: criterion
+    - thread-local-storage # tried thread-local-storage-0.2, but its *benchmarks* requires the disabled package: criterion
+    - tidal # tried tidal-1.9.4, but its *benchmarks* requires the disabled package: criterion
+    - tidal # tried tidal-1.9.4, but its *benchmarks* requires the disabled package: weigh
+    - tmp-postgres # tried tmp-postgres-1.34.1.0, but its *benchmarks* requires the disabled package: criterion
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: criterion-plus
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: stm-stats
-    - turtle # tried turtle-1.6.1, but its *benchmarks* requires text < 1.3 and the snapshot contains text-2.0.2
+    - type-of-html # tried type-of-html-1.6.2.0, but its *benchmarks* requires the disabled package: criterion
+    - type-of-html # tried type-of-html-1.6.2.0, but its *benchmarks* requires the disabled package: weigh
+    - ua-parser # tried ua-parser-0.7.7.0, but its *benchmarks* requires the disabled package: criterion
+    - unagi-chan # tried unagi-chan-0.4.1.4, but its *benchmarks* requires the disabled package: criterion
     - unicode-transforms # tried unicode-transforms-0.4.0.1, but its *benchmarks* requires path >=0.0.0 && < 0.9 and the snapshot contains path-0.9.2
     - unicode-transforms # tried unicode-transforms-0.4.0.1, but its *benchmarks* requires path-io >=0.1.0 && < 1.7 and the snapshot contains path-io-1.8.1
+    - uri-bytestring # tried uri-bytestring-0.3.3.1, but its *benchmarks* requires the disabled package: criterion
+    - varying # tried varying-0.8.1.0, but its *benchmarks* requires the disabled package: criterion
+    - vec # tried vec-0.5, but its *benchmarks* requires the disabled package: criterion
+    - vector-hashtables # tried vector-hashtables-0.1.1.3, but its *benchmarks* requires the disabled package: criterion
+    - vinyl # tried vinyl-0.14.3, but its *benchmarks* requires the disabled package: criterion
+    - websockets # tried websockets-0.12.7.3, but its *benchmarks* requires the disabled package: criterion
+    - word-wrap # tried word-wrap-0.5, but its *benchmarks* requires the disabled package: criterion
+    - word8 # tried word8-0.1.3, but its *benchmarks* requires the disabled package: criterion
     - xeno # tried xeno-0.6, but its *benchmarks* requires the disabled package: bzlib
+    - xeno # tried xeno-0.6, but its *benchmarks* requires the disabled package: criterion
+    - xeno # tried xeno-0.6, but its *benchmarks* requires the disabled package: weigh
+    - xmlbf-xeno # tried xmlbf-xeno-0.2.2, but its *benchmarks* requires the disabled package: criterion
+    - xmlgen # tried xmlgen-0.6.2.2, but its *benchmarks* requires the disabled package: criterion
+    - xor # tried xor-0.0.1.1, but its *benchmarks* requires the disabled package: criterion
+    - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: criterion
     - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: xxhash
+    - yi-rope # tried yi-rope-0.11, but its *benchmarks* requires the disabled package: criterion
+    - zippers # tried zippers-0.3.2, but its *benchmarks* requires the disabled package: criterion
+    - zstd # tried zstd-0.1.3.0, but its *benchmarks* requires the disabled package: criterion
     # End of Benchmark bounds issues
 
 # end of skipped-benchmarks


### PR DESCRIPTION
Initial preparation for bumping Nightly to ghc-9.6

closes #6993

Note we cannot merge this until we have branched lts-21 from current nightly