### PR TITLE
remove expected test suite failure of elynx-tree

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8417,7 +8417,6 @@ expected-test-failures:
     - download # 0.3.2.7 https://github.com/fpco/stackage/issues/2811
     - duration # 0.2.0.0
     - ede # 0.3.3.0 hashable order dependent
-    - elynx-tree # https://github.com/commercialhaskell/stackage/issues/6996
     - fixed-vector-hetero # 0.6.1.1
     - generic-optics # 2.2.1.0 optimization output https://github.com/kcsongor/generic-lens/issues/133
     - github-types # https://github.com/commercialhaskell/stackage/issues/6549


### PR DESCRIPTION
- was fixed in elynx-tree version 0.7.2.1
- fixes https://github.com/commercialhaskell/stackage/issues/6996