### PR TITLE
Fix happy constraints, allowing 1.20.1.1 (re #6857)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -90,7 +90,7 @@ packages:
         - Sit
 
         - alex > 3.2.7
-        - happy < 1.20.1 || > 1.21.0
+        - happy < 1.20.1 || >= 1.20.1.1 && < 1.21 || > 1.21.0
         - haskell-src
         - ListLike
         - MissingH


### PR DESCRIPTION
Only 1.20.1 and 1.21.0 should be excluded (these are deprecated).
