### PR TITLE
Remove @borsboom maintainership

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1620,27 +1620,6 @@ packages:
         - netcode-io
         - reliable-io
 
-    "Emanuel Borsboom <manny@fpcomplete.com> @borsboom":
-        - BoundedChan
-        - broadcast-chan
-        - fuzzcheck
-        - here
-        - hlibgit2
-        - gitlib-libgit2 < 0 # 3.1.2.1 compile fail
-        - interpolatedstring-perl6
-        - iproute
-        - missing-foreign
-        - multimap
-        - parallel-io
-        - text-binary
-        - Chart-cairo
-        - ghc-events
-        - monad-extras
-        - optparse-simple
-        - hpack
-        - bindings-uname
-        - stack < 9.9.9 || > 9.9.9
-
     "Michael Sloan <mgsloan@gmail.com> @mgsloan":
         - store
         - store-core
@@ -4996,6 +4975,7 @@ packages:
     "Mike Pilgrem <public@pilgrem.com> @mpilgrem":
         - ansi-terminal
         - ansi-terminal-types
+        - stack < 9.9.9 || > 9.9.9
 
     "Torsten Schmits <stackage@schmits.me> @tek":
         - incipit-base
@@ -5015,6 +4995,8 @@ packages:
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean
+        - BoundedChan
+        - Chart-cairo
         - Decimal
         - Diff
         - FloatingHex
@@ -5066,6 +5048,7 @@ packages:
         - binary-parser
         - binary-tagged
         - bindings-DSL
+        - bindings-uname
         - bitarray
         - blank-canvas
         - blaze-builder
@@ -5076,6 +5059,7 @@ packages:
         - box
         - box-csv
         - brick
+        - broadcast-chan
         - buffer-builder
         - byte-order
         - byteable
@@ -5194,16 +5178,19 @@ packages:
         - friendly-time
         - functor-classes-compat
         - functor-combinators
+        - fuzzcheck
         - generic-arbitrary
         - generically
         - generics-sop-lens
         - ghc-byteorder
         - ghc-compact
+        - ghc-events
         - ghc-paths
         - ghc-prof
         - ghcjs-dom-jsaddle
         - git-lfs
         - gitlib
+        - gitlib-libgit2 < 0 # 3.1.2.1 compile fail
         - groom
         - groups
         - gtk
@@ -5223,15 +5210,18 @@ packages:
         - hasql-implicits
         - haxl
         - heap
+        - here
         - hex
         - hierarchical-clustering < 0 # 0.4.7 compile fail https://github.com/commercialhaskell/stackage/issues/6764
         - hjsonpointer
         - hjsonschema
+        - hlibgit2
         - hmatrix
         - hmatrix-gsl
         - hmatrix-special
         - hostname
         - hourglass
+        - hpack
         - hsc2hs
         - hscolour
         - hse-cpp
@@ -5267,7 +5257,9 @@ packages:
         - insert-ordered-containers
         - inspection-testing
         - integer-logarithms
+        - interpolatedstring-perl6
         - io-streams-haproxy
+        - iproute
         - ixset-typed
         - jsaddle-dom
         - json
@@ -5308,10 +5300,12 @@ packages:
         - mfsolve
         - microstache
         - minisat-solver
+        - missing-foreign
         - mmap
         - mmorph
         - mockery
         - monad-control
+        - monad-extras
         - monad-logger
         - monad-loops
         - monad-time
@@ -5320,6 +5314,7 @@ packages:
         - mono-traversable-instances
         - mono-traversable-keys
         - mstate
+        - multimap
         - multiset
         - mwc-random
         - names-th
@@ -5345,7 +5340,9 @@ packages:
         - optional-args
         - options
         - optparse-applicative
+        - optparse-simple
         - parallel
+        - parallel-io
         - path-pieces
         - pcg-random
         - peggy
@@ -5473,6 +5470,7 @@ packages:
         - test-framework-th
         - testing-feat
         - testing-type-modifiers
+        - text-binary
         - text-icu
         - text-latin1
         - text-postgresql


### PR DESCRIPTION
I haven't actively used Haskell in some time and am not really able to usefully respond to maintenance requirements for these packages.  Is there a way to find someone to take them over?

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
