### PR TITLE
sandwich: re-enable

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -389,7 +389,7 @@ packages:
     "Tom McLaughlin <tom@codedown.io> @thomasjm":
         - aeson-typescript
         - fsnotify
-        - sandwich < 0 # 0.1.4.0 # fails to compile (#7017)
+        - sandwich
         - sandwich-hedgehog
         - sandwich-quickcheck
         - sandwich-slack
@@ -7899,10 +7899,6 @@ packages:
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires the disabled package: tomland
         - salak-toml < 0 # tried salak-toml-0.3.5.3, but its *library* requires time >=1.8.0 && < 1.10 and the snapshot contains time-1.12.2
         - salak-yaml < 0 # tried salak-yaml-0.3.5.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.0.2
-        - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.3.0, but its *library* requires the disabled package: sandwich
-        - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.7, but its *library* requires the disabled package: sandwich
-        - sandwich-slack < 0 # tried sandwich-slack-0.1.1.0, but its *library* requires the disabled package: sandwich
-        - sandwich-webdriver < 0 # tried sandwich-webdriver-0.2.1.0, but its *library* requires the disabled package: sandwich
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.18.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
@@ -9444,7 +9440,6 @@ skipped-tests:
     - freer-simple # tried freer-simple-1.2.1.2, but its *test-suite* requires the disabled package: tasty
     - freer-simple # tried freer-simple-1.2.1.2, but its *test-suite* requires the disabled package: tasty-quickcheck
     - friday # tried friday-0.2.3.2, but its *test-suite* requires the disabled package: test-framework
-    - fsnotify # tried fsnotify-0.4.1.0, but its *test-suite* requires the disabled package: sandwich
     - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires tasty-hspec >=1.1.5.1 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.4
     - ftp-client # tried ftp-client-0.5.1.4, but its *test-suite* requires the disabled package: tasty
     - functor-combinators # tried functor-combinators-0.4.1.2, but its *test-suite* requires the disabled package: tasty
@@ -10648,7 +10643,6 @@ expected-test-failures:
     - parameterized # 0.5.0.0 https://github.com/commercialhaskell/stackage/issues/5746
     - protobuf # 0.2.1.4
     - record-wrangler # 0.1.1.0
-    - sandwich # https://github.com/commercialhaskell/stackage/issues/6680
     - secp256k1-haskell # #5948/closed
     - servant-static-th # 1.0.0.0 Tasty issue: https://github.com/commercialhaskell/stackage/issues/6090
     - snappy # Could not find module ‘Functions’


### PR DESCRIPTION
I just pushed a new Hackage commit and everything should be working on GHC 9.6. Per #7017 

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
