### PR TITLE
re-enable calligraphy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2725,7 +2725,7 @@ packages:
         - apecs-gloss
         - apecs-physics < 0 # 0.4.5 compile fail https://github.com/jonascarpay/apecs/issues/95
         - aeson-commit
-        - calligraphy < 0 # not ready for ghc 9.6 https://github.com/jonascarpay/calligraphy/issues/28
+        - calligraphy
         - js-chart
         - safe-gen
         - tasty-focus


### PR DESCRIPTION
Released 0.1.5 with GHC 9.6 support

Tracking issue: https://github.com/jonascarpay/calligraphy/issues/28