### PR TITLE
elynx-tools: 0.7.2.2 fix optparse compiler errors

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4711,7 +4711,7 @@ packages:
         - elynx-markov
         - elynx-nexus
         - elynx-seq
-        - elynx-tools < 0 # https://github.com/dschrempf/elynx/issues/3
+        - elynx-tools
         - elynx-tree
         - glasso
         - mcmc
@@ -6548,7 +6548,6 @@ packages:
         - elm-export < 0 # tried elm-export-0.6.0.1, but its *library* requires the disabled package: wl-pprint-text
         - elm2nix < 0 # tried elm2nix-0.3.0, but its *library* requires the disabled package: here
         - elm2nix < 0 # tried elm2nix-0.3.0, but its *library* requires the disabled package: req
-        - elynx < 0 # tried elynx-0.7.2.1, but its *executable* requires the disabled package: elynx-tools
         - emacs-module < 0 # tried emacs-module-0.2, but its *library* requires the disabled package: monad-interleave
         - email-validate < 0 # tried email-validate-2.3.2.18, but its *library* requires template-haskell >=2.10.0.0 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: typelits-witnesses
@@ -8097,7 +8096,6 @@ packages:
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.18.0.0
         - slick < 0 # tried slick-1.2.1.0, but its *library* requires the disabled package: pandoc
         - slist < 0 # tried slist-0.2.1.0, but its *library* requires base >=4.10.1.0 && < 4.18 and the snapshot contains base-4.18.0.0
-        - slynx < 0 # tried slynx-0.7.2.1, but its *library* requires the disabled package: elynx-tools
         - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.18.0.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.1
@@ -8301,7 +8299,6 @@ packages:
         - thyme < 0 # tried thyme-0.4, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - tldr < 0 # tried tldr-0.9.2, but its *library* requires the disabled package: cmark
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
-        - tlynx < 0 # tried tlynx-0.7.2.1, but its *library* requires the disabled package: elynx-tools
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires the disabled package: postgres-options
         - tmp-proc < 0 # tried tmp-proc-0.5.1.3, but its *executable* requires the disabled package: connection
         - tmp-proc < 0 # tried tmp-proc-0.5.1.3, but its *executable* requires the disabled package: req
@@ -9035,9 +9032,6 @@ skipped-tests:
     - edit # tried edit-1.0.1.0, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.4.3
     - edit # tried edit-1.0.1.0, but its *test-suite* requires tasty-discover >=4.2 && < 4.3 and the snapshot contains tasty-discover-5.0.0
     - either # tried either-5.0.2, but its *test-suite* requires the disabled package: test-framework
-    - elynx-markov # tried elynx-markov-0.7.2.1, but its *test-suite* requires the disabled package: elynx-tools
-    - elynx-seq # tried elynx-seq-0.7.2.1, but its *test-suite* requires the disabled package: elynx-tools
-    - elynx-tree # tried elynx-tree-0.7.2.1, but its *test-suite* requires the disabled package: elynx-tools
     - email-validate # tried email-validate-2.3.2.18, but its *test-suite* requires doctest >=0.8 && < 0.21 and the snapshot contains doctest-0.21.1
     - email-validate # tried email-validate-2.3.2.18, but its *test-suite* requires hspec >=2.2.3 && < 2.11 and the snapshot contains hspec-2.11.1
     - enummapset # tried enummapset-0.7.1.0, but its *test-suite* requires the disabled package: test-framework
@@ -10052,7 +10046,6 @@ skipped-benchmarks:
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.0.0
     - distributed-process # tried distributed-process-0.7.4, but its *benchmarks* requires the disabled package: network-transport-tcp
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires criterion >=0.8 && < 1.2 and the snapshot contains criterion-1.6.2.0
-    - elynx-tree # tried elynx-tree-0.7.2.1, but its *benchmarks* requires the disabled package: elynx-tools
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-hunit
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-quickcheck2


### PR DESCRIPTION
See https://github.com/dschrempf/elynx/issues/3, Compilation problems have been fixed in v0.7.2.2

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
