### PR TITLE
Re-enable polysemy-webserver

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4868,7 +4868,7 @@ packages:
         - valida-base
 
     "Andrew Miller <andrew@amxl.com> @A1kmm":
-        - polysemy-webserver < 0 # 0.2.1.1 # fails to compile (#7017)
+        - polysemy-webserver
 
     "Simon Shine <shreddedglory@gmail.com> @sshine":
         - evm-opcodes


### PR DESCRIPTION
It had an unnecessary dependency on polysemy-plugin in a way that didn't compile with ghc-9.6.x, which is removed in 0.2.1.2.

This was amongst the compiler errors referenced in: #7017.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
