### PR TITLE
Reenable test-framework, take over some grandfathered packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -112,6 +112,15 @@ packages:
         - microaeson
         - cassava
         - ini
+        - cryptohash-sha256
+        - cryptohash-sha512
+        - newtype
+        - resolv
+
+        - blaze-builder
+        - regex-pcre-builtin
+        - test-framework
+
 
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
@@ -5053,7 +5062,6 @@ packages:
         - bindings-uname
         - bitarray
         - blank-canvas
-        - blaze-builder
         - blaze-svg
         - blaze-textual
         - bloomfilter
@@ -5115,8 +5123,6 @@ packages:
         - crypto-pubkey-openssh < 0 # 0.2.7 compile fail
         - crypto-random < 0 # https://github.com/vincenthz/hs-crypto-random/issues/15
         - cryptohash-cryptoapi
-        - cryptohash-sha256
-        - cryptohash-sha512
         - cryptostore
         - css-text
         - csv
@@ -5331,7 +5337,6 @@ packages:
         - network-run
         - network-transport
         - network-uri < 2.7.0.0 || > 2.7.0.0 # 2.7.0.0 was deprecated, don't remove bound until >2.7.0.0 is released.
-        - newtype
         - next-ref
         - nicify-lib
         - normaldistribution
@@ -5387,11 +5392,9 @@ packages:
         - recv
         - refinery < 0 # 0.4.0.0 # fails to compile (#7017)
         - regex-applicative-text
-        - regex-pcre-builtin
         - regex-tdfa-text
         - relapse
         - relational-schemas
-        - resolv
         - resource-pool
         - resourcet
         - rest-rewrite
@@ -5465,7 +5468,6 @@ packages:
         - temporary
         - temporary-rc
         - temporary-resourcet
-        - test-framework
         - test-framework-hunit
         - test-framework-quickcheck2
         - test-framework-smallcheck
@@ -8186,7 +8188,6 @@ packages:
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - termonad < 0 # tried termonad-4.5.0.0, but its *library* requires the disabled package: inline-c
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
-        - test-framework < 0 # tried test-framework-0.8.2.0, but its *library* requires ansi-wl-pprint >=0.5.1 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - test-framework-hunit < 0 # tried test-framework-hunit-0.3.0.2, but its *library* requires the disabled package: test-framework
         - test-framework-leancheck < 0 # tried test-framework-leancheck-0.0.4, but its *library* requires the disabled package: test-framework
         - test-framework-quickcheck2 < 0 # tried test-framework-quickcheck2-0.3.0.5, but its *library* requires the disabled package: test-framework
@@ -8632,7 +8633,7 @@ package-flags:
 
     aws-sns-verify:
       development: true
-    
+
     optics-operators:
       build-readme: false
 # end of package-flags


### PR DESCRIPTION
Please run the commenter to reenable all packages that are disabled
because of test-framework.
