### PR TITLE
Reenable shelltestrunner and test-framework-hunit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7984,7 +7984,6 @@ packages:
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed
         - shell-conduit < 0 # tried shell-conduit-5.0.0, but its *library* requires the disabled package: monads-tf
         - shellmet < 0 # tried shellmet-0.0.4.1, but its *library* requires base >=4.10.1.0 && < 4.17 and the snapshot contains base-4.18.0.0
-        - shelltestrunner < 0 # tried shelltestrunner-1.9, but its *executable* requires the disabled package: test-framework
         - shikensu < 0 # tried shikensu-0.4.1, but its *library* requires text ==1.* and the snapshot contains text-2.0.2
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.2
         - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.18.0.0
@@ -8188,7 +8187,6 @@ packages:
         - termcolor < 0 # tried termcolor-0.2.0.0, but its *executable* requires the disabled package: cli
         - termonad < 0 # tried termonad-4.5.0.0, but its *library* requires the disabled package: inline-c
         - test-fixture < 0 # tried test-fixture-0.5.1.0, but its *library* requires template-haskell >=2.10 && < 2.13 and the snapshot contains template-haskell-2.20.0.0
-        - test-framework-hunit < 0 # tried test-framework-hunit-0.3.0.2, but its *library* requires the disabled package: test-framework
         - test-framework-leancheck < 0 # tried test-framework-leancheck-0.0.4, but its *library* requires the disabled package: test-framework
         - test-framework-quickcheck2 < 0 # tried test-framework-quickcheck2-0.3.0.5, but its *library* requires the disabled package: test-framework
         - test-framework-smallcheck < 0 # tried test-framework-smallcheck-0.2, but its *library* requires the disabled package: test-framework


### PR DESCRIPTION
I suppose there are many more packages that could be reenabled now that `test-framework` is back.