### PR TITLE
Take over some grandfathered dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -116,10 +116,24 @@ packages:
         - cryptohash-sha512
         - newtype
         - resolv
-
         - blaze-builder
+
+        # Some "grandfathered dependencies" I took over because I contributed to them at some time.
+        # Feel free to snatch them from me!
         - regex-pcre-builtin
         - test-framework
+        - c2hs
+        - cabal-doctest
+        - hackage-security
+        - haskell-lexer
+        - lifted-async
+        - polyparse
+        - silently
+        - text-icu
+        - vector-binary-instances
+        - map-syntax
+        - heist
+        - snap
 
 
     "Diogo Biazus <diogo@biazus.ca>":
@@ -5078,9 +5092,7 @@ packages:
         - bytesmith
         - bytestring-builder
         - bzlib
-        - c2hs
         - ca-province-codes
-        - cabal-doctest
         - cabal-install-solver
         - call-stack
         - casing
@@ -5203,13 +5215,11 @@ packages:
         - groom
         - groups
         - gtk
-        - hackage-security
         - haha
         - hamlet
         - harp
         - hashable
         - haskell-gi-overloading
-        - haskell-lexer
         - haskell-lsp-types
         - haskell-src-exts
         - haskell-src-exts-simple
@@ -5285,7 +5295,6 @@ packages:
         - leb128-cereal
         - libBF
         - libyaml
-        - lifted-async
         - lifted-base
         - loch-th
         - lockfree-queue
@@ -5358,7 +5367,6 @@ packages:
         - pipes-group
         - placeholders
         - poll
-        - polyparse
         - portable-lines
         - posix-pty
         - postgresql-libpq
@@ -5423,7 +5431,6 @@ packages:
         - shakespeare
         - shakespeare-text
         - shell-escape
-        - silently
         - simple-reflect
         - simple-sendfile
         - singleton-bool
@@ -5476,7 +5483,6 @@ packages:
         - testing-feat
         - testing-type-modifiers
         - text-binary
-        - text-icu
         - text-latin1
         - text-postgresql
         - text-printer
@@ -5528,7 +5534,6 @@ packages:
         - vec
         - vector
         - vector-algorithms
-        - vector-binary-instances
         - vector-space
         - vector-th-unbox
         - vty
@@ -5568,9 +5573,6 @@ packages:
         - yesod-persistent
         - zlib
         - zlib-bindings
-        - map-syntax
-        - heist
-        - snap
 
     # If you stop maintaining a package (either just on stackage, or
     # completely), you can move it here. It will be disabled if it


### PR DESCRIPTION
Taking over some grandfathered dependencies so that pings for updates have a target.

(I am not attached to these, if you want them, have them...)
