### PR TITLE
Re-enable universum

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8200,7 +8200,6 @@ packages:
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.0.2
         - units-parser < 0 # tried units-parser-0.1.1.4, but its *library* requires mtl >=1.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - universum < 0 # tried universum-1.8.1.1, but its *library* requires text >=1.0.0.0 && < =2.0.1 and the snapshot contains text-2.0.2
         - unliftio-pool < 0 # tried unliftio-pool-0.4.2.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - unliftio-streams < 0 # tried unliftio-streams-0.1.1.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - urbit-hob < 0 # tried urbit-hob-0.3.3, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

I tried running `verify-package.sh` and it failed when it tried to build `gauge` dependency, because its latest version on Hackage doesn't work on ARM-based Macs (https://github.com/vincenthz/hs-gauge/pull/106). I am pretty sure it should succeed on a machine with different architecture (but I don't have one currently).