### PR TITLE
Add directory-ospath-streaming, remove htoml-parse

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4354,11 +4354,11 @@ packages:
         - emacs-module
         - tasty-ant-xml
         - prettyprinter-combinators
-        - htoml-parse < 0 # https://github.com/sergv/htoml-parse/issues/1
         - htoml-megaparsec
         - composition-prelude
         - toml-reader-parse
         - atomic-counter
+        - directory-ospath-streaming
 
     "Eugene Smolanka <esmolanka@gmail.com> @esmolanka":
         - sexp-grammar


### PR DESCRIPTION
`htoml-parse` is more or less deprecated so removing.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
