### PR TITLE
Re-enable xlsx

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2617,7 +2617,7 @@ packages:
         - type-equality
 
     "Kirill Zaborsky <qrilka@gmail.com> @qrilka":
-        - xlsx < 0 # 1.1.0.1 # fails to compile (#7017)
+        - xlsx
 
     "Matt Parsons <parsonsmatt@gmail.com> @parsonsmatt":
         - annotated-exception


### PR DESCRIPTION
Version 1.1.1 adds support for GHC 9.6 so it is buildable again: https://hackage.haskell.org/package/xlsx-1.1.1

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
