### PR TITLE
Reenable monad-schedule

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7371,7 +7371,6 @@ packages:
         - monad-par < 0 # tried monad-par-0.3.5, but its *library* requires mtl >=2.0.1.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - monad-peel < 0 # tried monad-peel-0.2.1.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - monad-products < 0 # tried monad-products-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
-        - monad-schedule < 0 # tried monad-schedule-0.1.2.0, but its *library* requires base >=4.13.0 && < =4.17 and the snapshot contains base-4.18.0.0
         - monad-skeleton < 0 # tried monad-skeleton-0.2, but its *library* requires base >=4.9 && < 4.17 and the snapshot contains base-4.18.0.0
         - monad-unlift-ref < 0 # tried monad-unlift-ref-0.2.1, but its *library* requires the disabled package: monad-unlift
         - monadic-arrays < 0 # tried monadic-arrays-0.2.2, but its *library* requires transformers >=0.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

I have recently released a new version which is compatible again.