### PR TITLE
Re-enable tmp-proc, hspec-tmp-prc, tmp-proc-redis, tmp-proc-postgres

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7004,7 +7004,6 @@ packages:
         - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires hspec-core >=2.2.4 && < 2.11 and the snapshot contains hspec-core-2.11.2
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.18.0.0
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core >=2.7 && < 2.8 and the snapshot contains hspec-core-2.11.2
-        - hspec-tmp-proc < 0 # tried hspec-tmp-proc-0.5.1.2, but its *library* requires the disabled package: tmp-proc
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires the disabled package: hsp
         - hsx2hs < 0 # tried hsx2hs-0.14.1.11, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
@@ -8086,11 +8085,8 @@ packages:
         - thyme < 0 # tried thyme-0.4, but its *library* requires template-haskell >=2.7 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires the disabled package: postgres-options
-        - tmp-proc < 0 # tried tmp-proc-0.5.1.3, but its *executable* requires the disabled package: connection
-        - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.5.2.2, but its *library* requires the disabled package: tmp-proc
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: amqp
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: tmp-proc
-        - tmp-proc-redis < 0 # tried tmp-proc-redis-0.5.1.2, but its *library* requires the disabled package: tmp-proc
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8086,7 +8086,6 @@ packages:
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.7.0
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires the disabled package: postgres-options
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: amqp
-        - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.1.2, but its *library* requires the disabled package: tmp-proc
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0
         - tonalude < 0 # tried tonalude-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - tonaparser < 0 # tried tonaparser-0.1.0.1, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.18.0.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks


I have recently released new package versions which are compatible again.