### PR TITLE
Reenable clientsession + deps 

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6187,8 +6187,6 @@ packages:
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires text ^>=1.2.5 and the snapshot contains text-2.0.2
         - brittany < 0 # tried brittany-0.14.0.2, but its *library* requires transformers ^>=0.5.6 and the snapshot contains transformers-0.6.1.0
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
-        - bugsnag-haskell < 0 # tried bugsnag-haskell-0.0.4.4, but its *executable* requires the disabled package: yesod-core
-        - bugsnag-yesod < 0 # tried bugsnag-yesod-1.0.0.1, but its *library* requires the disabled package: yesod-core
         - bugzilla-redhat < 0 # tried bugzilla-redhat-1.0.1, but its *library* requires the disabled package: connection
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
@@ -6275,8 +6273,6 @@ packages:
         - clash-prelude < 0 # tried clash-prelude-1.6.5, but its *library* requires template-haskell >=2.12.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
         - clash-prelude < 0 # tried clash-prelude-1.6.5, but its *library* requires th-abstraction >=0.2.10 && < 0.5.0 and the snapshot contains th-abstraction-0.5.0.0
         - classy-prelude-yesod < 0 # tried classy-prelude-yesod-1.5.0, but its *library* requires the disabled package: yesod
-        - classy-prelude-yesod < 0 # tried classy-prelude-yesod-1.5.0, but its *library* requires the disabled package: yesod-newsfeed
-        - classy-prelude-yesod < 0 # tried classy-prelude-yesod-1.5.0, but its *library* requires the disabled package: yesod-static
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.0.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - clay < 0 # tried clay-0.14.0, but its *library* requires base >=4.11 && < 4.16 and the snapshot contains base-4.18.0.0
@@ -6284,7 +6280,6 @@ packages:
         - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires template-haskell >=2.14 && < 2.20 and the snapshot contains template-haskell-2.20.0.0
         - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.0.0
         - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires ghc >=8.6 && < 9.3 and the snapshot contains ghc-9.6.2
-        - clientsession < 0 # tried clientsession-0.9.1.2, but its *library* requires the disabled package: crypto-random
         - climb < 0 # tried climb-0.4.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.0.2
         - clock-extras < 0 # tried clock-extras-0.1.0.2, but its *library* requires clock >=0.4.6 && < 0.8.0 and the snapshot contains clock-0.8.3
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark >=0.5 && < 0.6 and the snapshot contains cmark-0.6.1
@@ -6934,7 +6929,7 @@ packages:
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires protolude >=0.1.10 && < 0.3 and the snapshot contains protolude-0.3.3
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.0.2
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.0.0
-        - hledger-web < 0 # tried hledger-web-1.30, but its *library* requires the disabled package: clientsession
+        - hledger-web < 0 # tried hledger-web-1.30, but its *library* requires the disabled package: yesod-form
         - hmatrix-backprop < 0 # tried hmatrix-backprop-0.1.3.0, but its *library* requires the disabled package: backprop
         - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
         - hnix-store-core < 0 # tried hnix-store-core-0.6.1.0, but its *library* requires algebraic-graphs >=0.5 && < 0.7 and the snapshot contains algebraic-graphs-0.7
@@ -7868,7 +7863,6 @@ packages:
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.20
         - serverless-haskell < 0 # tried serverless-haskell-0.12.6, but its *library* requires the disabled package: amazonka-core
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-2.0.1, but its *library* requires persistent >=2.13 && < 2.14 and the snapshot contains persistent-2.14.5.1
-        - serversession-frontend-yesod < 0 # tried serversession-frontend-yesod-1.0.1, but its *library* requires the disabled package: yesod-core
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.7
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
@@ -8319,7 +8313,6 @@ packages:
         - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires the disabled package: xmonad-contrib
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires yeshql-core ==4.1.1.2 and the snapshot contains yeshql-core-4.2.0.0
-        - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: yesod-core
         - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: yesod-form
         - yesod-alerts < 0 # tried yesod-alerts-0.1.3.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
         - yesod-auth < 0 # tried yesod-auth-1.6.11.1, but its *library* requires the disabled package: email-validate
@@ -8329,42 +8322,24 @@ packages:
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-form >=1.4 && < 1.5 and the snapshot contains yesod-form-1.7.4
         - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: yesod-auth
-        - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: yesod-core
         - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: yesod-form
         - yesod-auth-oauth2 < 0 # tried yesod-auth-oauth2-0.7.1.0, but its *library* requires the disabled package: hoauth2
         - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: yesod-auth
-        - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: yesod-core
         - yesod-auth-oidc < 0 # tried yesod-auth-oidc-0.1.4, but its *library* requires the disabled package: yesod-form
-        - yesod-core < 0 # tried yesod-core-1.6.24.2, but its *library* requires the disabled package: clientsession
-        - yesod-eventsource < 0 # tried yesod-eventsource-1.6.0.1, but its *library* requires the disabled package: yesod-core
-        - yesod-fb < 0 # tried yesod-fb-0.6.1, but its *library* requires the disabled package: yesod-core
         - yesod-form < 0 # tried yesod-form-1.7.4, but its *library* requires the disabled package: email-validate
-        - yesod-form-bootstrap4 < 0 # tried yesod-form-bootstrap4-3.0.1, but its *library* requires the disabled package: yesod-core
         - yesod-form-bootstrap4 < 0 # tried yesod-form-bootstrap4-3.0.1, but its *library* requires the disabled package: yesod-form
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-form >=1.4.4.1 && < 1.5 and the snapshot contains yesod-form-1.7.4
-        - yesod-gitrepo < 0 # tried yesod-gitrepo-0.3.0, but its *library* requires the disabled package: yesod-core
-        - yesod-gitrev < 0 # tried yesod-gitrev-0.2.2, but its *library* requires the disabled package: yesod-core
-        - yesod-markdown < 0 # tried yesod-markdown-0.12.6.13, but its *library* requires the disabled package: yesod-core
         - yesod-markdown < 0 # tried yesod-markdown-0.12.6.13, but its *library* requires the disabled package: yesod-form
-        - yesod-middleware-csp < 0 # tried yesod-middleware-csp-1.2.0, but its *library* requires the disabled package: yesod-core
-        - yesod-newsfeed < 0 # tried yesod-newsfeed-1.7.0.0, but its *library* requires the disabled package: yesod-core
-        - yesod-page-cursor < 0 # tried yesod-page-cursor-2.0.1.0, but its *library* requires the disabled package: yesod-core
-        - yesod-paginator < 0 # tried yesod-paginator-1.1.2.2, but its *library* requires the disabled package: yesod-core
-        - yesod-persistent < 0 # tried yesod-persistent-1.6.0.8, but its *library* requires the disabled package: yesod-core
-        - yesod-recaptcha2 < 0 # tried yesod-recaptcha2-1.0.2, but its *library* requires the disabled package: yesod-core
+        - yesod-middleware-csp < 0 # tried yesod-middleware-csp-1.2.0, but its *library* requires the disabled package: yesod
+        - yesod-paginator < 0 # tried yesod-paginator-1.1.2.2, but its *executable* requires the disabled package: yesod
         - yesod-recaptcha2 < 0 # tried yesod-recaptcha2-1.0.2, but its *library* requires the disabled package: yesod-form
-        - yesod-routes-flow < 0 # tried yesod-routes-flow-3.0.0.2, but its *library* requires the disabled package: yesod-core
-        - yesod-sitemap < 0 # tried yesod-sitemap-1.6.0, but its *library* requires the disabled package: yesod-core
-        - yesod-static < 0 # tried yesod-static-1.6.1.0, but its *library* requires the disabled package: yesod-core
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* requires yesod >=1.2 && < 1.5 and the snapshot contains yesod-1.6.2.1
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-core >=1.2 && < 1.5 and the snapshot contains yesod-core-1.6.24.2
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-static >=1.2.1 && < 1.6 and the snapshot contains yesod-static-1.6.1.0
-        - yesod-test < 0 # tried yesod-test-1.6.15, but its *library* requires the disabled package: yesod-core
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires aeson >=0.7 && < 2.0 and the snapshot contains aeson-2.1.2.1
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.0.2
-        - yesod-websockets < 0 # tried yesod-websockets-0.3.0.3, but its *library* requires the disabled package: yesod-core
         - zasni-gerna < 0 # tried zasni-gerna-0.0.7.1, but its *library* requires the disabled package: papillon
         - zero < 0 # tried zero-0.1.5, but its *library* requires semigroups >=0.16 && < 0.20 and the snapshot contains semigroups-0.20
         - zigzag < 0 # tried zigzag-0.0.1.0, but its *library* requires base >=4.11.1 && < 4.18 and the snapshot contains base-4.18.0.0
@@ -9084,7 +9059,8 @@ skipped-tests:
     - wild-bind-x11 # tried wild-bind-x11-0.2.0.15, but its *test-suite* requires time >=1.5.0 && < 1.12 and the snapshot contains time-1.12.2
     - wreq # tried wreq-0.5.4.0, but its *test-suite* requires the disabled package: snap-server
     - xmlhtml # tried xmlhtml-0.2.5.4, but its *test-suite* requires hspec >=2.4 && < 2.11 and the snapshot contains hspec-2.11.2
-    - yesod-auth-basic # tried yesod-auth-basic-0.1.0.3, but its *test-suite* requires the disabled package: yesod-test
+    - yesod-middleware-csp # tried yesod-middleware-csp-1.2.0, but its *test-suite* requires the disabled package: classy-prelude-yesod
+    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod
     - yesod-static-angular # tried yesod-static-angular-0.1.8, but its *test-suite* requires yesod-test >=1.2 && < 1.6 and the snapshot contains yesod-test-1.6.15
     - yesod-test # tried yesod-test-1.6.15, but its *test-suite* requires the disabled package: yesod-form
     - zm # tried zm-0.3.2, but its *test-suite* requires doctest >=0.11.1 && < 0.14 and the snapshot contains doctest-0.21.1


### PR DESCRIPTION
- ~~Re #7062: bound hspec-expectations < 0.8.4~~
- Reenable clientsession and its dependencies

I verified `clientsession` and ran `check`, but the reenabled dependencies may fail to build.
