### PR TITLE
re-enable validation

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8168,8 +8168,6 @@ packages:
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - utf8-conversions < 0 # tried utf8-conversions-0.1.0.4, but its *library* requires text-short >=0.1.1 && < 0.1.4 and the snapshot contains text-short-0.1.5
         - vado < 0 # tried vado-0.0.14, but its *library* requires base >=4.0.0.0 && < 4.17 and the snapshot contains base-4.18.0.0
-        - validation < 0 # tried validation-1.1.2, but its *library* requires assoc >=1 && < 1.1 and the snapshot contains assoc-1.1
-        - validation < 0 # tried validation-1.1.2, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.0.1
         - variable-media-field < 0 # tried variable-media-field-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.0.2
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: dhall
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: variable-media-field
@@ -9061,8 +9059,6 @@ skipped-tests:
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires QuickCheck >=2.9 && < 2.14 and the snapshot contains QuickCheck-2.14.3
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.2
     - utf8-light # tried utf8-light-0.4.4.0, but its *test-suite* requires hspec >=2.3 && < 2.11 and the snapshot contains hspec-2.11.2
-    - validation # tried validation-1.1.2, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.3
-    - validation # tried validation-1.1.2, but its *test-suite* requires lens >=4 && < 5 and the snapshot contains lens-5.2.2
     - validity-case-insensitive # tried validity-case-insensitive-0.0.0.0, but its *test-suite* requires the disabled package: genvalidity-hspec
     - validity-path # tried validity-path-0.4.0.1, but its *test-suite* requires the disabled package: genvalidity-hspec
     - wai-middleware-delegate # tried wai-middleware-delegate-0.1.3.1, but its *test-suite* requires the disabled package: connection


### PR DESCRIPTION
validation-1.1.3 resolves the bounds issues that resulted in removal in #6958

Verified using `./verify-package validation-1.1.3`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
