### PR TITLE
Reenable feed

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6528,8 +6528,6 @@ packages:
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires tls >=1.3.7 && < 1.7.0 and the snapshot contains tls-1.7.1
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-12.1.0
         - docopt < 0 # tried docopt-0.7.0.7, but its *library* requires template-haskell >=2.15.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
-        - download < 0 # tried download-0.3.2.7, but its *library* requires the disabled package: feed
-        - download-curl < 0 # tried download-curl-0.1.4, but its *library* requires the disabled package: feed
         - drawille < 0 # tried drawille-0.1.2.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.7
         - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.18.0.0
         - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.3
@@ -6597,8 +6595,6 @@ packages:
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires mtl >=1.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires template-haskell >=2.2 && < 2.19 and the snapshot contains template-haskell-2.20.0.0
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - feed < 0 # tried feed-1.3.2.1, but its *library* requires base >=4 && < 4.18 and the snapshot contains base-4.18.0.0
-        - feed < 0 # tried feed-1.3.2.1, but its *library* requires base-compat >=0.9 && < 0.13 and the snapshot contains base-compat-0.13.0
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires fsnotify ==0.3.* and the snapshot contains fsnotify-0.4.1.0
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -6663,7 +6659,6 @@ packages:
         - ginger < 0 # tried ginger-0.10.5.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ginger < 0 # tried ginger-0.10.5.1, but its *library* requires vector >=0.12.0.2 && < 0.13 and the snapshot contains vector-0.13.0.0
         - git-annex < 0 # tried git-annex-10.20230802, but its *executable* requires the disabled package: bloomfilter
-        - git-annex < 0 # tried git-annex-10.20230802, but its *executable* requires the disabled package: feed
         - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.0.0
         - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.18.0.0
         - gitlab-haskell < 0 # tried gitlab-haskell-1.0.0.1, but its *library* requires the disabled package: connection


### PR DESCRIPTION
A hackage revision has been created that relaxes the offending bound: https://github.com/haskell-party/feed/issues/66#issuecomment-1666090849

Also all entries that disable packages citing feed have been removed. It is unfortunately not possible to test them using verify-package, but feed itself has been tested.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
