### PR TITLE
Add optparse-applicative 0.18 compatibility flags

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6261,7 +6261,6 @@ packages:
         - bits-extra < 0 # tried bits-extra-0.0.2.3, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.10.0
         - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
         - bloomfilter < 0 # tried bloomfilter-2.0.1.0, but its *library* requires base >=4.4 && < 4.16 and the snapshot contains base-4.18.0.0
-        - bm < 0 # tried bm-0.2.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - bookkeeping < 0 # tried bookkeeping-0.4.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.0.2
         - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.18.0.0
         - boots < 0 # tried boots-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -6989,7 +6988,6 @@ packages:
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hoogle < 0 # tried hoogle-5.0.18.3, but its *library* requires the disabled package: connection
         - hopenpgp-tools < 0 # tried hopenpgp-tools-0.23.7, but its *executable* requires the disabled package: prettyprinter-convert-ansi-wl-pprint
-        - horizontal-rule < 0 # tried horizontal-rule-0.6.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires the disabled package: dhall
         - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires the disabled package: dhall-json
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires aeson >=0.7.1 && < 1.3 and the snapshot contains aeson-2.1.2.1
@@ -7283,7 +7281,6 @@ packages:
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.2
         - list-witnesses < 0 # tried list-witnesses-0.1.4.0, but its *library* requires the disabled package: decidable
         - list-witnesses < 0 # tried list-witnesses-0.1.4.0, but its *library* requires the disabled package: functor-products
-        - literatex < 0 # tried literatex-0.3.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires bytestring >=0.10 && < 0.11.3 and the snapshot contains bytestring-0.11.4.0
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
@@ -7548,7 +7545,6 @@ packages:
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires text >=1.1.0 && < 2 and the snapshot contains text-2.0.2
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - phantom-state < 0 # tried phantom-state-0.2.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - phatsort < 0 # tried phatsort-0.6.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires JuicyPixels >=3.2.8 && < 3.3 and the snapshot contains JuicyPixels-3.3.8
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
@@ -7686,7 +7682,6 @@ packages:
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.18.0.0
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.8.0.0
         - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.16, but its *library* requires ghc >=8.6 && < 9.5 and the snapshot contains ghc-9.6.2
-        - redact < 0 # tried redact-0.5.0.0, but its *executable* requires optparse-applicative >=0.13 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - reddit-scrape < 0 # tried reddit-scrape-0.0.1, but its *library* requires the disabled package: scalpel
         - redis-io < 0 # tried redis-io-1.1.0, but its *library* requires the disabled package: tinylog
         - redis-resp < 0 # tried redis-resp-1.0.0, but its *library* requires the disabled package: bytestring-conversion
@@ -8475,6 +8470,18 @@ package-flags:
 
     optics-operators:
       build-readme: false
+
+    # optparse-applicative dependencies depend on the version
+    bm:
+      optparse-applicative_ge_0_18: true
+    horizontal-rule:
+      optparse-applicative_ge_0_18: true
+    literatex:
+      optparse-applicative_ge_0_18: true
+    phatsort:
+      optparse-applicative_ge_0_18: true
+    redact:
+      optparse-applicative_ge_0_18: true
 # end of package-flags
 
 # Special configure options for individual packages


### PR DESCRIPTION
This commit sets `optparse-applicative` compatibility flags for the following packages:

* [`bm`](https://hackage.haskell.org/package/bm)
* [`horizontal-rule`](https://hackage.haskell.org/package/horizontal-rule)
* [`literatex`](https://hackage.haskell.org/package/literatex)
* [`phatsort`](https://hackage.haskell.org/package/phatsort)
* [`redact`](https://hackage.haskell.org/package/redact)

Details: [`optparse-applicative` Compatibility](https://www.extrema.is/blog/2023/05/28/optparse-applicative-compatibility)

I am hope that this PR for `master` is correct.  Please let me know if I need to change anything.

Thank you @alaendle for the report in #7078 !