### PR TITLE
Re-enable hakyll-convert

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6797,7 +6797,6 @@ packages:
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
         - hakyll < 0 # tried hakyll-4.16.0.0, but its *library* requires optparse-applicative >=0.12 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
-        - hakyll-convert < 0 # tried hakyll-convert-0.3.0.4, but its *library* requires time >=1.9 && < 1.12 and the snapshot contains time-1.12.2
         - hamilton < 0 # tried hamilton-0.1.0.3, but its *library* requires the disabled package: typelits-witnesses
         - hamtsolo < 0 # tried hamtsolo-1.0.4, but its *executable* requires the disabled package: stm-conduit
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0


### PR DESCRIPTION
0.3.0.4@rev:3 allows time < 1.13.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh) — Not applicable
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`) — time 1.13 is not supported because there are no compilers that bundle that version
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

`./verify-package hakyll-convert-0.3.0.4@rev:3` passed.