### PR TITLE
Re-enable Hakyll

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6796,7 +6796,6 @@ packages:
         - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires language-docker >=11.0.0 && < 12 and the snapshot contains language-docker-12.1.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.11.4.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.0.2
-        - hakyll < 0 # tried hakyll-4.16.0.0, but its *library* requires optparse-applicative >=0.12 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hakyll-convert < 0 # tried hakyll-convert-0.3.0.4, but its *library* requires time >=1.9 && < 1.12 and the snapshot contains time-1.12.2
         - hamilton < 0 # tried hamilton-0.1.0.3, but its *library* requires the disabled package: typelits-witnesses
         - hamtsolo < 0 # tried hamtsolo-1.0.4, but its *executable* requires the disabled package: stm-conduit


### PR DESCRIPTION
hakyll-4.16.0.0@rev:1 allows optparse-applicative < 0.19

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`) — `cabal outdated` only lists versions which are either deprecated or not available (no GHC that bundles them yet)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

`./verify-package hakyll-4.16.0.0@rev:1` passed.