### PR TITLE
Adopted chart-svg, removed some projects from bad test lists.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3794,10 +3794,10 @@ packages:
         - validation
 
     "Tony Day <tonyday567@gmail.com> @tonyday567":
+        - chart-svg
         - markup-parse
         - numhask
         - numhask-array
-        - numhask-prelude
         - numhask-space
         - perf
 
@@ -5575,6 +5575,7 @@ packages:
         - nicify-lib
         - normaldistribution
         - nothunks
+        - numhask-prelude
         - old-locale
         - old-time
         - operational
@@ -9184,7 +9185,6 @@ expected-test-failures:
     - ghc-events # https://github.com/haskell/ghc-events/issues/70
     - gitlab-haskell # https://github.com/commercialhaskell/stackage/issues/6088
     - hspec-junit-formatter # https://github.com/freckle/hspec-junit-formatter/issues/14
-    - markup-parse # 0.0.0.2 https://github.com/tonyday567/markup-parse/issues/1
     - persistent # https://github.com/commercialhaskell/stackage/issues/6037
     - reanimate-svg # https://github.com/commercialhaskell/stackage/issues/5688
     - wai-saml2 # 0.4 https://github.com/mbg/wai-saml2/issues/44
@@ -9232,7 +9232,6 @@ expected-test-failures:
     - nettle # https://github.com/stbuehler/haskell-nettle/issues/10
     - nri-observability # https://github.com/commercialhaskell/stackage/issues/6179
     - nri-prelude # https://github.com/commercialhaskell/stackage/issues/6179
-    - numhask-array
     - ochintin-daicho
     - openapi3
     - openssl-streams # 1.2.3.0 asn1 encoding wrong tag
@@ -9376,7 +9375,6 @@ expected-test-failures:
     - makefile # Doctests require hidden Glob package
     - model
     - multiset # Doctests require hidden Glob package
-    - perf
     - servant-openapi3
     - xml-indexed-cursor
     - yesod-paginator


### PR DESCRIPTION
* Added chart-svg to my list.
* Moved numhask-prelude to the grandfathered section. It's long deprecated and I have no idea what might depend on it - I would be surpised it's anything.
* Deleted markup-parse from expected test failures.
* Deleted numhask-array from expected test failures.
* Deleted perf from expected test failures.


