### PR TITLE
Re-enable rawfilepath

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3835,7 +3835,7 @@ packages:
         - termcolor
 
     "XT <e@xtendo.org> @xtendo-org":
-        - rawfilepath < 0 # 1.0.1 compile fail https://github.com/xtendo-org/rawfilepath/issues/8
+        - rawfilepath
 
     "Konstantin Zudov <co@zudov.me> @zudov":
         - html-email-validate


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

Hi! The rawfilepath package has been updated to support both ghc 9.6 and ghc until 9.4. It should therefore work on both Stackage LTS and Stackage Nightly.

I ran the above script and it seems to work fine. Please let me know if there's any issue.