### PR TITLE
Re-enable squeal-postgresql

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4181,7 +4181,7 @@ packages:
 
     "Eitan Chatav <eitan@gmail.com> @echatav":
         - free-categories
-        - squeal-postgresql < 0 # 0.9.1.0 fails to compile
+        - squeal-postgresql
 
     "Sam Quinn <lazersmoke@gmail.com> @Lazersmoke":
         - ghost-buster


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
