### PR TITLE
Add fits-parse

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5246,6 +5246,9 @@ packages:
     "Alexander Esgen <amesgen@amesgen.de> @amesgen":
         - ghc-hs-meta
 
+    "Zac Slade <krakrjak@gmail.com> @krakrjak":
+        - fits-parse
+
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ --N/A-- ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

The script was tested against the `stack sdist` for version **0.3.4** that was uploaded to Hackage on or about 9:30pm CDT. A few testing weaknesses were found using version 0.3.3 (and earlier versions). Therefore, I'm asking to include version 0.3.4 and newer uploads for the `fits-parse` package to be included in future stackage releases.