### PR TITLE
replace spatial-math with SpatialMath

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -353,10 +353,10 @@ packages:
     "Scott N. Walck <walck@lvc.edu> @walck":
         - cyclotomic
         - learn-physics
+        - SpatialMath
 
         # @ghorn
         - not-gloss
-        - spatial-math
 
     "Phil de Joux <phil.dejoux@blockscope.com> @philderbeast":
         - siggy-chardust


### PR DESCRIPTION
Replace a package that depends on deprecated packages with one that only depends on currently maintained packages.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
