### PR TITLE
Remove learn-physics from list of packages with dependency failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7189,7 +7189,6 @@ packages:
         - language-python < 0 # tried language-python-0.5.8, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - language-thrift < 0 # tried language-thrift-0.12.0.1, but its *library* requires ansi-wl-pprint ==0.6.* and the snapshot contains ansi-wl-pprint-1.0.2
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.20.0.0
-        - learn-physics < 0 # tried learn-physics-0.6.5, but its *library* requires the disabled package: spatial-math
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens ==4.* and the snapshot contains lens-5.2.3
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.2.3
         - lens-family-th < 0 # tried lens-family-th-0.5.2.1, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.20.0.0


### PR DESCRIPTION
learn-physics no longer depends on deprecated packages

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
