### PR TITLE
Remove context-wai-middleware from expected failing tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9166,7 +9166,6 @@ expected-test-failures:
     - character-cases # 0.1.0.6 https://github.com/aiya000/hs-character-cases/issues/3
     - codec-beam # 0.2.0 posix_spawnp: does not exist
     - colonnade # 1.2.0.2 https://github.com/andrewthad/colonnade/issues/31
-    - context-wai-middleware # 0.2.0.1 https://github.com/jship/context/issues/3
     - control-dsl # 0.2.1.3
     - crypt-sha512 # 0 Use -p '/crypt.$6$rounds=10$roundstoolow/' to rerun this test only.
     - curl-runnings # 0.17.0


### PR DESCRIPTION
This reverts commit 9558c7fb987378e2c03aa453587489efe903f1c5, so that `context-wai-middleware` is no longer listed under the expected failing tests section per 0.2.0.2 being released to Hackage.

---

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
