### PR TITLE
Re-enable snap-server

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3668,6 +3668,7 @@ packages:
         - tasty-bench-fit
         - alex-tools
         - language-lua
+        - snap-server
 
     "Ashley Yakeley <ashley@semantic.org> @AshleyYakeley":
         - countable
@@ -5912,7 +5913,6 @@ packages:
         - prim-array < 0 # 0.2.2 bounds
         - proto-lens-combinators < 0 # 0.4.0.1 deprecated https://github.com/commercialhaskell/stackage/pull/4358
         - shortcut-links < 0 # 0.5.1.1 #5965/closed
-        - snap-server < 0 # 1.1.2.1 #6271
         - tinytemplate < 0 # 0.1.2.0 compile fail
         - tomland < 0 # 1.3.3.2 #5965/closed
         - type-combinators < 0 # 0.2.4.3 compile fail https://github.com/kylcarte/type-combinators/issues/8


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
