### PR TITLE
Include `clash-*` packages again

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6353,22 +6353,6 @@ packages:
         - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.3.0
         - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.18.1.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.6.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires ghc-boot >=8.6.0 && < 9.1 and the snapshot contains ghc-boot-9.6.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires ghc-prim >=0.3.1.0 && < 0.8 and the snapshot contains ghc-prim-0.10.0
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires ghci >=8.6.0 && < 9.1 and the snapshot contains ghci-9.6.3
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires mtl >=2.1.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - clash-ghc < 0 # tried clash-ghc-1.6.6, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
-        - clash-lib < 0 # tried clash-lib-1.6.6, but its *library* requires ansi-terminal >=0.8.0.0 && < 0.12 and the snapshot contains ansi-terminal-1.0
-        - clash-lib < 0 # tried clash-lib-1.6.6, but its *library* requires ghc >=8.6.0 && < 9.1 and the snapshot contains ghc-9.6.3
-        - clash-lib < 0 # tried clash-lib-1.6.6, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-lib < 0 # tried clash-lib-1.6.6, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - clash-lib < 0 # tried clash-lib-1.6.6, but its *library* requires template-haskell >=2.8.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
-        - clash-prelude < 0 # tried clash-prelude-1.6.6, but its *library* requires ghc-bignum >=1.0 && < 1.3 and the snapshot contains ghc-bignum-1.3
-        - clash-prelude < 0 # tried clash-prelude-1.6.6, but its *library* requires ghc-prim >=0.5.1.0 && < 0.8 and the snapshot contains ghc-prim-0.10.0
-        - clash-prelude < 0 # tried clash-prelude-1.6.6, but its *library* requires template-haskell >=2.12.0.0 && < 2.18 and the snapshot contains template-haskell-2.20.0.0
-        - clash-prelude < 0 # tried clash-prelude-1.6.6, but its *library* requires th-abstraction >=0.2.10 && < 0.5.0 and the snapshot contains th-abstraction-0.5.0.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.18.1.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.20.0.0
         - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.18.1.0
@@ -8472,11 +8456,6 @@ skipped-tests:
     # Revision to package caused it to require bounds and break
     - htoml  # https://github.com/commercialhaskell/stackage/issues/6239
 
-    # was in expected test failures, but seems we may have to skip
-    # entirely for unknown reasons, previously:
-    # https://github.com/clash-lang/clash-compiler/issues/1622
-    - clash-prelude
-
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
     # Test bounds issues
@@ -9392,7 +9371,6 @@ skipped-benchmarks:
     - cipher-aes # tried cipher-aes-0.2.11, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
     - cipher-camellia # tried cipher-camellia-0.0.2, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
     - cipher-rc4 # tried cipher-rc4-0.1.4, but its *benchmarks* requires the disabled package: crypto-cipher-benchmarks
-    - clash-prelude # tried clash-prelude-1.6.6, but its *benchmarks* requires criterion >=1.3.0.0 && < 1.6 and the snapshot contains criterion-1.6.3.0
     - cmark-gfm # tried cmark-gfm-0.2.6, but its *benchmarks* requires the disabled package: cheapskate
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires criterion < 1.6 and the snapshot contains criterion-1.6.3.0
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.1.0


### PR DESCRIPTION
With the release of Clash 1.8.1, the packages build on GHC 9.6.3 and against all the packages currently included in `stackage-nightly`

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
