### PR TITLE
Add michaelpj as the maintainer for lsp packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -961,12 +961,13 @@ packages:
 
     "Alan Zimmerman @alanz":
         - ghc-exactprint
-        - haskell-lsp
         - hjsmin
         - language-javascript
         - Strafunski-StrategyLib
 
-    "Luke  Lau <luke_lau@icloud.com> @bubba":
+    "Michael Peyton Jones <me@michaelpj.com>":
+        - lsp-types
+        - lsp
         - lsp-test
 
     "Alfredo Di Napoli <alfredo.dinapoli@gmail.com> @adinapoli":


### PR DESCRIPTION
I'd like to get the lsp packages into stackage. I'm not sure what I'm doing, so let's see how this goes!

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package
