### PR TITLE
lsp

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -961,12 +961,13 @@ packages:
 
     "Alan Zimmerman @alanz":
         - ghc-exactprint
-        - haskell-lsp
         - hjsmin
         - language-javascript
         - Strafunski-StrategyLib
 
-    "Luke  Lau <luke_lau@icloud.com> @bubba":
+    "Michael Peyton Jones <me@michaelpj.com>":
+        - lsp-types
+        - lsp
         - lsp-test
 
     "Alfredo Di Napoli <alfredo.dinapoli@gmail.com> @adinapoli":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -446,7 +446,7 @@ packages:
         - safe-foldable
 
     "Jaro Reinders <jaro.reinders@gmail.com> @Noughtmare":
-        - haskell-lsp-client
+        - haskell-lsp-client < 0
 
     "Florian Knupfer <fknupfer@gmail.com> @knupfer":
         - type-of-html
@@ -5488,7 +5488,6 @@ packages:
         - harp
         - hashable
         - haskell-gi-overloading
-        - haskell-lsp-types
         - haskell-src-exts
         - haskell-src-exts-simple
         - haskell-tools-builtin-refactorings
@@ -5568,8 +5567,6 @@ packages:
         - log-base
         - logging-facade
         - lrucache
-        - lsp
-        - lsp-types
         - lukko
         - lz4
         - lzma
@@ -6764,11 +6761,6 @@ packages:
         - harp < 0 # tried harp-0.4.3.6, but its *library* requires base < 4.18 and the snapshot contains base-4.18.1.0
         - hasbolt < 0 # tried hasbolt-0.1.6.3, but its *library* requires the disabled package: connection
         - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.18.1.0
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires aeson >=1.0.0.0 && < 1.6 and the snapshot contains aeson-2.1.2.1
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.1.0
-        - haskell-lsp < 0 # tried haskell-lsp-0.24.0.0, but its *library* requires sorted-list ==0.2.1.* and the snapshot contains sorted-list-0.2.2.0
-        - haskell-lsp-client < 0 # tried haskell-lsp-client-1.0.0.1, but its *library* requires the disabled package: haskell-lsp
-        - haskell-lsp-types < 0 # tried haskell-lsp-types-0.24.0.0, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.18.1.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.1.2.1
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.11.5.2
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -8653,7 +8645,6 @@ skipped-tests:
     - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.2
     - lrucaching # tried lrucaching-0.3.3, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
     - lrucaching # tried lrucaching-0.3.3, but its *test-suite* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-    - lsp # tried lsp-2.2.0.0, but its *test-suite* requires sorted-list >=0.2.1 && < 0.2.2 and the snapshot contains sorted-list-0.2.2.0
     - lxd-client # tried lxd-client-0.1.0.6, but its *test-suite* requires turtle >=1.3.6 && < 1.6 and the snapshot contains turtle-1.6.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires Glob >=0.7 && < 0.9 and the snapshot contains Glob-0.10.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires QuickCheck >=2.9.2 && < 2.11 and the snapshot contains QuickCheck-2.14.3
@@ -8986,7 +8977,6 @@ expected-test-failures:
     - jvm
     - katip-elasticsearch # elasticsearch
     - log # ElasticSearch
-    - lsp-test
     - lxd-client # Needs LXD, not available on debian
     - lz4 # executable not found https://github.com/commercialhaskell/stackage/issues/6226
     - mangopay # https://github.com/prowdsponsor/mangopay/issues/30


### PR DESCRIPTION
- Add michaelpj as the maintainer for lsp packages (PR #7184)
- Clean up haskell-lsp-* (deprecated) and left-over constraints on lsp*
