### PR TITLE
Re-enable relational-record's packages by re-adding product-isomorphic

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3395,6 +3395,10 @@ packages:
     "Kei Hibino <ex8k.hibino@gmail.com> @khibino":
         - th-data-compat
         - th-reify-compat
+        - th-bang-compat
+        - th-constraint-compat
+        - product-isomorphic
+        - persistable-record
         - relational-query
         - relational-query-HDBC
         - persistable-types-HDBC-pg
@@ -3405,9 +3409,6 @@ packages:
         - json-rpc-generic
         - protocol-radius
         - protocol-radius-test
-        - th-bang-compat
-        - th-constraint-compat
-        - persistable-record
 
     "wren romano <wren@community.haskell.org> @wrengr":
         - bytestring-lexing
@@ -5642,7 +5643,6 @@ packages:
         - primitive < 0.9 # https://github.com/commercialhaskell/stackage/issues/7138
         - primitive-unaligned
         - process-extras
-        - product-isomorphic < 0 # 0.0.3.3
         - project-template
         - protobuf < 0.2.1.4 || > 0.2.1.4 # deprecated version
         - ptr


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
