### PR TITLE
reenable test for simple-cairo and cairo-image

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3429,7 +3429,7 @@ packages:
         - dyre
         - jose
 
-    "Yoshikuni Jujo <PAF01143@nifty.ne.jp> @YoshikuniJujo":
+    "Yoshikuni Jujo <yoshikuni.jujo@gmail.com> @YoshikuniJujo":
         - zot
         - yjtools
         - io-machine
@@ -8714,8 +8714,6 @@ expected-test-failures:
     - butter # 0.1.0.6
     - cabal-file-th # 0.2.7
     - cacophony # 0.10.1 https://github.com/centromere/cacophony/issues/15
-    - cairo-image # 0.1.0.0 https://github.com/YoshikuniJujo/cairo-image/issues/2
-    - simple-cairo # 0.1.0.5
     - cereal # 0.5.8.3 https://github.com/GaloisInc/cereal/issues/109
     - conduit-aeson # https://github.com/commercialhaskell/stackage/issues/6469
     - conduit-connection # 0.1.0.5


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
