### PR TITLE
Bump `megaparsec` to <9.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8046,9 +8046,9 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/7086
         - tagged < 0.8.8
 
-        # https://github.com/commercialhaskell/stackage/issues/7103
-        - megaparsec < 9.5.0
-        - megaparsec-tests < 9.5.0
+        # https://github.com/commercialhaskell/stackage/issues/7205
+        - megaparsec < 9.6
+        - megaparsec-tests < 9.6
 
         # https://github.com/commercialhaskell/stackage/issues/7106
         - tls < 1.9


### PR DESCRIPTION
Closes #7103.
