### PR TITLE
Remove ejconlon from maintainership

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4897,18 +4897,6 @@ packages:
         - tasty-test-reporter
         - pretty-diff
 
-    "Eric Conlon <ejconlon@gmail.com> @ejconlon":
-        - blanks
-        - climb
-        - linenoise
-        - little-rio
-        - little-logger
-        # Maintainership with @23Skidoo
-        - ekg
-        - ekg-core
-        - ekg-json
-        - ekg-statsd
-
     "Jorah Gao <jorah@version.cloud> @gqk007":
         - aeson-default
         - vformat

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5860,6 +5860,10 @@ packages:
         - curl
         - docopt # #6326/closed
         - dynamic-state # #6326/closed
+        - ekg
+        - ekg-core
+        - ekg-json
+        - ekg-statsd
         - first-class-patterns # #5965/closed
         - ghc-trace-events # #6326/closed
         - hashing # #6271


### PR DESCRIPTION
I no longer have commit access to ekg, so I can't maintain it. Also removed packages with 0 reverse deps.