### PR TITLE
reenable cairo-image, exception-hierarchy and simple-cairo

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6471,7 +6471,6 @@ packages:
         - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *library* requires text ^>=1.2.3 || ^>=2.0.1 and the snapshot contains text-2.1
         - cairo < 0 # tried cairo-0.13.10.0, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.0.2
         - cairo < 0 # tried cairo-0.13.10.0, but its *library* requires text >=1.0.0.0 && < 2.1 and the snapshot contains text-2.1
-        - cairo-image < 0 # tried cairo-image-0.1.0.2, but its *library* requires template-haskell >=2.18.0 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - capability < 0 # tried capability-0.5.0.1, but its *library* requires constraints >=0.1 && < 0.14 and the snapshot contains constraints-0.14
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.0.2
@@ -6808,7 +6807,6 @@ packages:
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventsource-store-specs
         - eventsource-geteventstore-store < 0 # tried eventsource-geteventstore-store-1.2.1, but its *library* requires the disabled package: eventstore
         - eventsource-stub-store < 0 # tried eventsource-stub-store-1.1.1, but its *library* requires the disabled package: eventsource-api
-        - exception-hierarchy < 0 # tried exception-hierarchy-0.1.0.10, but its *library* requires template-haskell >=2.18 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - exception-via < 0 # tried exception-via-0.2.0.0, but its *library* requires template-haskell >=2.9.0.0 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - exon < 0 # tried exon-1.6.1.0, but its *library* requires the disabled package: incipit-base
         - failable < 0 # tried failable-1.2.4.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -8457,8 +8455,6 @@ packages:
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.3
         - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.19.0.0
         - simple < 0 # tried simple-2.0.0, but its *library* requires the disabled package: wai-extra
-        - simple-cairo < 0 # tried simple-cairo-0.1.0.6, but its *library* requires the disabled package: cairo-image
-        - simple-cairo < 0 # tried simple-cairo-0.1.0.6, but its *library* requires the disabled package: exception-hierarchy
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
