### PR TITLE
Re-enable http2 and some revdeps, servant-multipart-*

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6436,9 +6436,6 @@ packages:
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: hledger
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: hledger-lib
         - buchhaltung < 0 # tried buchhaltung-0.0.7, but its *library* requires the disabled package: regex-tdfa-text
-        - bugsnag-haskell < 0 # tried bugsnag-haskell-0.0.4.4, but its *executable* requires the disabled package: warp
-        - bugsnag-wai < 0 # tried bugsnag-wai-1.0.0.1, but its *library* requires the disabled package: warp
-        - bugsnag-yesod < 0 # tried bugsnag-yesod-1.0.1.0, but its *executable* requires the disabled package: warp
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: elliptic-curve
         - bulletproofs < 0 # tried bulletproofs-1.1.0, but its *library* requires the disabled package: galois-field
         - burrito < 0 # tried burrito-2.0.1.7, but its *library* requires bytestring >=0.11.3 && < 0.12 and the snapshot contains bytestring-0.12.0.2
@@ -6836,7 +6833,6 @@ packages:
         - flac-picture < 0 # tried flac-picture-0.1.2, but its *library* requires bytestring >=0.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - fn < 0 # tried fn-0.3.0.2, but its *library* requires the disabled package: wai-extra
         - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.19.0.0
         - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
@@ -7056,7 +7052,6 @@ packages:
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.15
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - gopher-proxy < 0 # tried gopher-proxy-0.1.1.3, but its *executable* requires the disabled package: warp
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires aeson >=2.0 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires text >=1.2.3.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
@@ -7104,7 +7099,6 @@ packages:
         - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires language-docker >=11.0.0 && < 12 and the snapshot contains language-docker-12.1.0
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.1
-        - hakyll < 0 # tried hakyll-4.16.2.0, but its *library* requires the disabled package: warp
         - hakyll-convert < 0 # tried hakyll-convert-0.3.0.4, but its *library* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires bytestring >=0.11.3 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires text >=2.0.2 && < 2.1 and the snapshot contains text-2.1
@@ -7394,8 +7388,6 @@ packages:
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.19.0.0
         - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core >=2.7 && < 2.8 and the snapshot contains hspec-core-2.11.7
         - hspec-tmp-proc < 0 # tried hspec-tmp-proc-0.5.2.0, but its *library* requires the disabled package: tmp-proc
-        - hspec-wai < 0 # tried hspec-wai-0.11.1, but its *library* requires the disabled package: wai-extra
-        - hspec-wai-json < 0 # tried hspec-wai-json-0.11.0, but its *library* requires the disabled package: hspec-wai
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires the disabled package: hsp
@@ -7409,7 +7401,6 @@ packages:
         - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.1
         - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires template-haskell >=2.14 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires text >=1.2.3.1 && < 2.1 and the snapshot contains text-2.1
-        - http2 < 0 # tried http2-5.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *executable* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *library* requires deepseq >=1.4.2.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -7607,7 +7598,6 @@ packages:
         - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1
         - katip-wai < 0 # tried katip-wai-0.1.2.2, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - katip-wai < 0 # tried katip-wai-0.1.2.2, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1
-        - keter < 0 # tried keter-2.1.2, but its *library* requires the disabled package: warp
         - keyed-vals < 0 # tried keyed-vals-0.2.2.0, but its *library* requires the disabled package: redis-glob
         - keyed-vals-hspec-tests < 0 # tried keyed-vals-hspec-tests-0.2.2.0, but its *library* requires the disabled package: keyed-vals
         - keyed-vals-mem < 0 # tried keyed-vals-mem-0.2.2.0, but its *library* requires the disabled package: keyed-vals
@@ -7961,7 +7951,6 @@ packages:
         - pandoc-lua-marshal < 0 # tried pandoc-lua-marshal-0.2.2, but its *library* requires aeson >=1.5 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - pandoc-lua-marshal < 0 # tried pandoc-lua-marshal-0.2.2, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - pandoc-lua-marshal < 0 # tried pandoc-lua-marshal-0.2.2, but its *library* requires text >=1.1.1.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
-        - pandoc-server < 0 # tried pandoc-server-0.1.0.4, but its *library* requires the disabled package: servant-server
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.1.3, but its *library* requires bytestring >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.1.3, but its *library* requires hegg >=0.3.0 && < 0.4 and the snapshot contains hegg-0.5.0.0
         - pango < 0 # tried pango-0.13.10.0, but its *library* requires text >=0.11.0.6 && < 2.1 and the snapshot contains text-2.1
@@ -8342,7 +8331,6 @@ packages:
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
         - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1
-        - servant-JuicyPixels < 0 # tried servant-JuicyPixels-0.3.1.1, but its *executable* requires the disabled package: warp
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.7
@@ -8353,20 +8341,17 @@ packages:
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.20
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - servant-auth-server < 0 # tried servant-auth-server-0.4.8.0, but its *library* requires the disabled package: servant-server
         - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.2, but its *library* requires the disabled package: swagger2
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires servant-server >=0.14 && < 0.20 and the snapshot contains servant-server-0.20
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: wordpress-auth
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.13.1
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires servant >=0.7 && < 0.20 and the snapshot contains servant-0.20.1
-        - servant-checked-exceptions < 0 # tried servant-checked-exceptions-2.2.0.1, but its *executable* requires the disabled package: warp
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.20.1
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.19.0.0
-        - servant-exceptions-server < 0 # tried servant-exceptions-server-0.2.1, but its *library* requires the disabled package: servant-server
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.6.8
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires formatting >=6.2 && < 6.4 and the snapshot contains formatting-7.2.0
@@ -8382,12 +8367,6 @@ packages:
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.20.1
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.20
         - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.0.2
-        - servant-multipart < 0 # tried servant-multipart-0.12.1, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1
-        - servant-multipart-api < 0 # tried servant-multipart-api-0.12.1, but its *library* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.0.2
-        - servant-multipart-api < 0 # tried servant-multipart-api-0.12.1, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.2, but its *library* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.0.2
-        - servant-multipart-client < 0 # tried servant-multipart-client-0.12.2, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1
         - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.6, but its *library* requires the disabled package: openapi3
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
@@ -8406,11 +8385,8 @@ packages:
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.20
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1
         - servant-quickcheck < 0 # tried servant-quickcheck-0.0.10.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
-        - servant-rate-limit < 0 # tried servant-rate-limit-0.2.0.0, but its *library* requires the disabled package: servant-server
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1
-        - servant-server < 0 # tried servant-server-0.20, but its *executable* requires the disabled package: warp
-        - servant-static-th < 0 # tried servant-static-th-1.0.0.0, but its *executable* requires the disabled package: warp
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.0.0
         - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.1
         - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.0.0
@@ -8438,8 +8414,6 @@ packages:
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.20.1
         - serversession-backend-persistent < 0 # tried serversession-backend-persistent-2.0.1, but its *library* requires persistent >=2.13 && < 2.14 and the snapshot contains persistent-2.14.6.0
-        - serversession-frontend-yesod < 0 # tried serversession-frontend-yesod-1.0.1, but its *library* requires the disabled package: yesod-core
-        - servius < 0 # tried servius-1.2.3.0, but its *executable* requires the disabled package: wai-app-static
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.7
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
@@ -8456,7 +8430,6 @@ packages:
         - shikensu < 0 # tried shikensu-0.4.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.3
         - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.19.0.0
-        - simple < 0 # tried simple-2.0.0, but its *library* requires the disabled package: wai-extra
         - simple-cairo < 0 # tried simple-cairo-0.1.0.6, but its *library* requires the disabled package: cairo-image
         - simple-cairo < 0 # tried simple-cairo-0.1.0.6, but its *library* requires the disabled package: exception-hierarchy
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -8467,7 +8440,6 @@ packages:
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - simple-media-timestamp-formatting < 0 # tried simple-media-timestamp-formatting-0.1.1.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - simple-pango < 0 # tried simple-pango-0.1.0.1, but its *library* requires the disabled package: simple-cairo
-        - simple-session < 0 # tried simple-session-2.0.0, but its *library* requires the disabled package: wai-extra
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.21.0.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1
@@ -8687,7 +8659,6 @@ packages:
         - sydtest-servant < 0 # tried sydtest-servant-0.2.0.2, but its *library* requires the disabled package: sydtest
         - sydtest-typed-process < 0 # tried sydtest-typed-process-0.0.0.0, but its *library* requires the disabled package: sydtest
         - sydtest-wai < 0 # tried sydtest-wai-0.2.0.1, but its *library* requires the disabled package: sydtest
-        - sydtest-wai < 0 # tried sydtest-wai-0.2.0.1, but its *library* requires the disabled package: warp
         - sydtest-webdriver < 0 # tried sydtest-webdriver-0.0.0.1, but its *library* requires the disabled package: sydtest
         - sydtest-webdriver-screenshot < 0 # tried sydtest-webdriver-screenshot-0.0.0.2, but its *library* requires the disabled package: sydtest
         - sydtest-webdriver-yesod < 0 # tried sydtest-webdriver-yesod-0.0.0.1, but its *library* requires the disabled package: sydtest
@@ -8710,7 +8681,6 @@ packages:
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires tasty >=0.1 && < 1.5 and the snapshot contains tasty-1.5
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1
-        - tasty-wai < 0 # tried tasty-wai-0.1.2.0, but its *library* requires the disabled package: wai-extra
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires network >=2.3 && < 3.0 and the snapshot contains network-3.1.4.0
         - tcp-streams-openssl < 0 # tried tcp-streams-openssl-1.0.1.0, but its *library* requires the disabled package: tcp-streams
         - telegram-bot-api < 0 # tried telegram-bot-api-6.7.1, but its *library* requires the disabled package: cron
@@ -8737,7 +8707,6 @@ packages:
         - time-parsers < 0 # tried time-parsers-0.2, but its *library* requires template-haskell >=2.8.0.0 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - tldr < 0 # tried tldr-0.9.2, but its *library* requires the disabled package: cmark
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-1.9.0
-        - tmp-proc < 0 # tried tmp-proc-0.5.3.0, but its *library* requires the disabled package: warp
         - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.5.3.1, but its *library* requires text >=1.2.3.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
         - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.5.3.1, but its *library* requires the disabled package: tmp-proc
         - tmp-proc-redis < 0 # tried tmp-proc-redis-0.5.3.1, but its *library* requires the disabled package: tmp-proc
@@ -8857,14 +8826,9 @@ packages:
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector-algorithms >=0.6.0.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.1
         - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vty >=5.13 && < 5.29 and the snapshot contains vty-6.1
-        - wai-app-static < 0 # tried wai-app-static-3.1.8, but its *library* requires the disabled package: warp
         - wai-cli < 0 # tried wai-cli-0.2.3, but its *library* requires the disabled package: monads-tf
         - wai-cli < 0 # tried wai-cli-0.2.3, but its *library* requires the disabled package: options
         - wai-control < 0 # tried wai-control-0.2.0.0, but its *library* requires the disabled package: websockets
-        - wai-enforce-https < 0 # tried wai-enforce-https-1.0.0.0, but its *executable* requires the disabled package: warp
-        - wai-extra < 0 # tried wai-extra-3.1.13.0, but its *library* requires the disabled package: warp
-        - wai-feature-flags < 0 # tried wai-feature-flags-0.1.0.7, but its *executable* requires the disabled package: warp
-        - wai-handler-launch < 0 # tried wai-handler-launch-3.0.3.1, but its *library* requires the disabled package: warp
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - wai-middleware-metrics < 0 # tried wai-middleware-metrics-0.2.4, but its *library* requires the disabled package: ekg-core
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.2.1.0
@@ -8880,8 +8844,6 @@ packages:
         - wai-session-redis < 0 # tried wai-session-redis-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - wai-transformers < 0 # tried wai-transformers-0.1.0, but its *library* requires the disabled package: websockets
         - wai-websockets < 0 # tried wai-websockets-3.0.1.2, but its *library* requires the disabled package: websockets
-        - warp < 0 # tried warp-3.3.31, but its *library* requires the disabled package: http2
-        - warp-tls < 0 # tried warp-tls-3.4.3, but its *library* requires the disabled package: warp
         - wavefront < 0 # tried wavefront-0.7.1.5, but its *library* requires base >=4.8 && < 4.18 and the snapshot contains base-4.19.0.0
         - wavefront < 0 # tried wavefront-0.7.1.5, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1
         - web-plugins < 0 # tried web-plugins-0.4.1, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.0.2
@@ -9014,7 +8976,6 @@ packages:
         - xmonad-extras < 0 # tried xmonad-extras-0.17.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires yeshql-core ==4.1.1.2 and the snapshot contains yeshql-core-4.2.0.0
-        - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: warp
         - yesod < 0 # tried yesod-1.6.2.1, but its *library* requires the disabled package: yesod-form
         - yesod-alerts < 0 # tried yesod-alerts-0.1.3.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.1
         - yesod-auth < 0 # tried yesod-auth-1.6.11.2, but its *library* requires the disabled package: email-validate
@@ -9026,33 +8987,19 @@ packages:
         - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: yesod-auth
         - yesod-auth-hashdb < 0 # tried yesod-auth-hashdb-1.7.1.7, but its *library* requires the disabled package: yesod-form
         - yesod-auth-oauth2 < 0 # tried yesod-auth-oauth2-0.7.1.3, but its *library* requires the disabled package: hoauth2
-        - yesod-core < 0 # tried yesod-core-1.6.25.1, but its *library* requires the disabled package: warp
-        - yesod-eventsource < 0 # tried yesod-eventsource-1.6.0.1, but its *library* requires the disabled package: wai-extra
-        - yesod-eventsource < 0 # tried yesod-eventsource-1.6.0.1, but its *library* requires the disabled package: yesod-core
-        - yesod-fb < 0 # tried yesod-fb-0.6.1, but its *library* requires the disabled package: yesod-core
+        - yesod-fb < 0 # tried yesod-fb-0.6.1, but its *library* requires the disabled package: fb
         - yesod-form < 0 # tried yesod-form-1.7.6, but its *library* requires the disabled package: email-validate
         - yesod-form-bootstrap4 < 0 # tried yesod-form-bootstrap4-3.0.1.1, but its *library* requires the disabled package: yesod-form
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
         - yesod-form-richtext < 0 # tried yesod-form-richtext-0.1.0.2, but its *library* requires yesod-form >=1.4.4.1 && < 1.5 and the snapshot contains yesod-form-1.7.6
-        - yesod-gitrepo < 0 # tried yesod-gitrepo-0.3.0, but its *library* requires the disabled package: yesod-core
-        - yesod-gitrev < 0 # tried yesod-gitrev-0.2.2, but its *library* requires the disabled package: yesod-core
         - yesod-markdown < 0 # tried yesod-markdown-0.12.6.13, but its *library* requires the disabled package: yesod-form
         - yesod-middleware-csp < 0 # tried yesod-middleware-csp-1.2.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.0.2
-        - yesod-newsfeed < 0 # tried yesod-newsfeed-1.7.0.0, but its *library* requires the disabled package: yesod-core
-        - yesod-page-cursor < 0 # tried yesod-page-cursor-2.0.1.0, but its *library* requires the disabled package: yesod-core
-        - yesod-paginator < 0 # tried yesod-paginator-1.1.2.2, but its *executable* requires the disabled package: warp
-        - yesod-persistent < 0 # tried yesod-persistent-1.6.0.8, but its *library* requires the disabled package: yesod-core
+        - yesod-paginator < 0 # tried yesod-paginator-1.1.2.2, but its *executable* requires the disabled package: yesod
         - yesod-recaptcha2 < 0 # tried yesod-recaptcha2-1.0.2.1, but its *library* requires the disabled package: yesod-form
-        - yesod-routes-flow < 0 # tried yesod-routes-flow-3.0.0.2, but its *library* requires the disabled package: yesod-core
-        - yesod-sitemap < 0 # tried yesod-sitemap-1.6.0, but its *library* requires the disabled package: yesod-core
-        - yesod-static < 0 # tried yesod-static-1.6.1.0, but its *library* requires the disabled package: wai-app-static
-        - yesod-static < 0 # tried yesod-static-1.6.1.0, but its *library* requires the disabled package: yesod-core
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *executable* requires yesod >=1.2 && < 1.5 and the snapshot contains yesod-1.6.2.1
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-core >=1.2 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
         - yesod-static-angular < 0 # tried yesod-static-angular-0.1.8, but its *library* requires yesod-static >=1.2.1 && < 1.6 and the snapshot contains yesod-static-1.6.1.0
-        - yesod-test < 0 # tried yesod-test-1.6.16, but its *library* requires the disabled package: wai-extra
-        - yesod-test < 0 # tried yesod-test-1.6.16, but its *library* requires the disabled package: yesod-core
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires aeson >=0.7 && < 2.0 and the snapshot contains aeson-2.2.1.0
         - yesod-text-markdown < 0 # tried yesod-text-markdown-0.1.10, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.1
         - yesod-websockets < 0 # tried yesod-websockets-0.3.0.3, but its *library* requires the disabled package: websockets
@@ -9411,7 +9358,6 @@ skipped-tests:
     - aura # tried aura-3.2.9, but its *test-suite* requires tasty >=0.11 && < 1.5 and the snapshot contains tasty-1.5
     - avro # tried avro-0.6.1.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
     - aws-cloudfront-signed-cookies # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
-    - aws-sns-verify # tried aws-sns-verify-0.0.0.3, but its *test-suite* requires the disabled package: warp
     - barrier # tried barrier-0.1.1, but its *test-suite* requires tasty >=0.10 && < 1.5 and the snapshot contains tasty-1.5
     - beam-postgres # tried beam-postgres-0.5.3.1, but its *test-suite* requires the disabled package: tmp-postgres
     - bench-show # tried bench-show-0.3.2, but its *test-suite* requires text >=1.1.1 && < 2.1 and the snapshot contains text-2.1
@@ -9452,8 +9398,6 @@ skipped-tests:
     - config-ini # tried config-ini-0.2.7.0, but its *test-suite* requires the disabled package: hedgehog
     - configurator-pg # tried configurator-pg-0.2.9, but its *test-suite* requires bytestring >=0.10.6 && < 0.12 and the snapshot contains bytestring-0.12.0.2
     - construct # tried construct-0.3.1.2, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
-    - context-http-client # tried context-http-client-0.2.0.2, but its *test-suite* requires the disabled package: warp
-    - context-wai-middleware # tried context-wai-middleware-0.2.0.2, but its *test-suite* requires the disabled package: warp
     - crc32c # tried crc32c-0.1.0, but its *test-suite* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.12.0.2
     - csg # tried csg-0.1.0.6, but its *test-suite* requires doctest < 0.17 and the snapshot contains doctest-0.22.2
     - csg # tried csg-0.1.0.6, but its *test-suite* requires tasty < 1.3 and the snapshot contains tasty-1.5
@@ -9559,9 +9503,7 @@ skipped-tests:
     - hslua-list # tried hslua-list-1.1.1, but its *test-suite* requires the disabled package: tasty-lua
     - hspec-need-env # tried hspec-need-env-0.1.0.10, but its *test-suite* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* requires hspec >=2.7 && < 2.8 and the snapshot contains hspec-2.11.7
-    - http-conduit # tried http-conduit-2.3.8.3, but its *test-suite* requires the disabled package: warp
     - http-io-streams # tried http-io-streams-0.1.6.3, but its *test-suite* requires the disabled package: snap-core
-    - http-reverse-proxy # tried http-reverse-proxy-0.6.0.2, but its *test-suite* requires the disabled package: warp
     - hw-balancedparens # tried hw-balancedparens-0.4.1.3, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
     - hw-balancedparens # tried hw-balancedparens-0.4.1.3, but its *test-suite* requires hedgehog >=1.0 && < 1.3 and the snapshot contains hedgehog-1.4
     - hw-bits # tried hw-bits-0.7.2.2, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.2
@@ -9712,27 +9654,21 @@ skipped-tests:
     - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
     - scalendar # tried scalendar-1.2.0, but its *test-suite* requires the disabled package: SCalendar
     - schematic # tried schematic-0.5.1.0, but its *test-suite* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.0.0
-    - servant-auth-client # tried servant-auth-client-0.4.1.1, but its *test-suite* requires the disabled package: warp
     - servant-auth-cookie # tried servant-auth-cookie-0.6.0.3, but its *test-suite* requires deepseq >=1.3 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-    - servant-auth-server # tried servant-auth-server-0.4.8.0, but its *test-suite* requires the disabled package: warp
-    - servant-blaze # tried servant-blaze-0.9.1, but its *test-suite* requires the disabled package: warp
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.20 and the snapshot contains servant-server-0.20
-    - servant-client # tried servant-client-0.20, but its *test-suite* requires the disabled package: warp
-    - servant-conduit # tried servant-conduit-0.16, but its *test-suite* requires the disabled package: warp
+    - servant-checked-exceptions # tried servant-checked-exceptions-2.2.0.1, but its *test-suite* requires the disabled package: hspec-wai
     - servant-docs # tried servant-docs-0.13, but its *test-suite* requires tasty >=1.1.0.4 && < 1.5 and the snapshot contains tasty-1.5
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.11.7
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9 and the snapshot contains hspec-core-2.11.7
-    - servant-http-streams # tried servant-http-streams-0.20, but its *test-suite* requires the disabled package: warp
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.7
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires http-api-data >=0.3.7 && < 0.4.2 and the snapshot contains http-api-data-0.6
-    - servant-lucid # tried servant-lucid-0.9.0.6, but its *test-suite* requires the disabled package: warp
-    - servant-machines # tried servant-machines-0.16, but its *test-suite* requires the disabled package: warp
     - servant-mock # tried servant-mock-0.8.7, but its *test-suite* requires hspec-wai >=0.9.0 && < 0.11 and the snapshot contains hspec-wai-0.11.1
-    - servant-pipes # tried servant-pipes-0.16, but its *test-suite* requires the disabled package: warp
     - servant-quickcheck # tried servant-quickcheck-0.0.10.0, but its *test-suite* requires hspec-core >=2.5.5 && < 2.8 and the snapshot contains hspec-core-2.11.7
     - servant-rate-limit # tried servant-rate-limit-0.2.0.0, but its *test-suite* requires the disabled package: wai-rate-limit-redis
+    - servant-server # tried servant-server-0.20, but its *test-suite* requires the disabled package: hspec-wai
+    - servant-static-th # tried servant-static-th-1.0.0.0, but its *test-suite* requires the disabled package: hspec-wai
     - servant-streaming # tried servant-streaming-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.13 and the snapshot contains QuickCheck-2.14.3
     - servant-streaming-client # tried servant-streaming-client-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
     - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
@@ -9810,11 +9746,9 @@ skipped-tests:
     - utf8-light # tried utf8-light-0.4.4.0, but its *test-suite* requires hspec >=2.3 && < 2.11 and the snapshot contains hspec-2.11.7
     - wai-cors # tried wai-cors-0.2.7, but its *test-suite* requires the disabled package: websockets
     - wai-middleware-bearer # tried wai-middleware-bearer-1.0.3, but its *test-suite* requires the disabled package: hspec-wai
-    - wai-middleware-clacks # tried wai-middleware-clacks-0.1.0.1, but its *test-suite* requires the disabled package: tasty-wai
-    - wai-middleware-delegate # tried wai-middleware-delegate-0.1.4.0, but its *test-suite* requires the disabled package: warp
+    - wai-middleware-delegate # tried wai-middleware-delegate-0.1.4.0, but its *test-suite* requires the disabled package: hspec-tmp-proc
     - wai-middleware-metrics # tried wai-middleware-metrics-0.2.4, but its *test-suite* requires the disabled package: scotty
     - wai-middleware-static # tried wai-middleware-static-0.9.2, but its *test-suite* requires the disabled package: scotty
-    - wai-middleware-throttle # tried wai-middleware-throttle-0.3.0.1, but its *test-suite* requires the disabled package: wai-extra
     - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.11.7
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.1
@@ -9830,17 +9764,12 @@ skipped-tests:
     - web3-polkadot # tried web3-polkadot-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
     - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.7
     - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.7
-    - webex-teams-api # tried webex-teams-api-0.2.0.1, but its *test-suite* requires the disabled package: warp
-    - webex-teams-conduit # tried webex-teams-conduit-0.2.0.1, but its *test-suite* requires the disabled package: warp
     - webgear-server # tried webgear-server-1.0.5, but its *test-suite* requires tasty >=1.2 && < 1.5 and the snapshot contains tasty-1.5
     - wide-word # tried wide-word-0.1.6.0, but its *test-suite* requires the disabled package: hedgehog
     - wild-bind-x11 # tried wild-bind-x11-0.2.0.15, but its *test-suite* requires time >=1.5.0 && < 1.12 and the snapshot contains time-1.12.2
     - wreq # tried wreq-0.5.4.2, but its *test-suite* requires the disabled package: snap-core
     - wss-client # tried wss-client-0.3.0.0, but its *test-suite* requires the disabled package: envy
-    - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: wai-extra
     - yesod-page-cursor # tried yesod-page-cursor-2.0.1.0, but its *test-suite* requires the disabled package: yesod
-    - yesod-persistent # tried yesod-persistent-1.6.0.8, but its *test-suite* requires the disabled package: wai-extra
-    - yesod-static # tried yesod-static-1.6.1.0, but its *test-suite* requires the disabled package: wai-extra
     - yesod-static-angular # tried yesod-static-angular-0.1.8, but its *test-suite* requires yesod-test >=1.2 && < 1.6 and the snapshot contains yesod-test-1.6.16
     - yesod-test # tried yesod-test-1.6.16, but its *test-suite* requires the disabled package: yesod-form
     - zm # tried zm-0.3.2, but its *test-suite* requires doctest >=0.11.1 && < 0.14 and the snapshot contains doctest-0.22.2


### PR DESCRIPTION
These were fixed with revisions within the last day, should be possible to re-enable.
