### PR TITLE
Reinstates `ghc-typelits-presburger`, `singletons-presburger`, and `sized`(also removes test failure allowance for `subcategories`)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6904,7 +6904,6 @@ packages:
         - ghc-trace-events < 0 # tried ghc-trace-events-0.1.2.7, but its *library* requires base >=4.8 && < 4.19 and the snapshot contains base-4.19.0.0
         - ghc-trace-events < 0 # tried ghc-trace-events-0.1.2.7, but its *library* requires bytestring >=0.9.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - ghc-trace-events < 0 # tried ghc-trace-events-0.1.2.7, but its *library* requires text >=1.0.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
-        - ghc-typelits-presburger < 0 # tried ghc-typelits-presburger-0.7.2.0, but its *library* requires ghc < 9.7 and the snapshot contains ghc-9.8.1
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.1
         - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
@@ -8471,9 +8470,7 @@ packages:
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.21.0.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1
-        - singletons-presburger < 0 # tried singletons-presburger-0.7.2.0, but its *library* requires the disabled package: ghc-typelits-presburger
         - siphash < 0 # tried siphash-1.0.3, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.12.0.2
-        - sized < 0 # tried sized-1.1.0.0, but its *library* requires the disabled package: ghc-typelits-presburger
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.0.0
         - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires constraints >=0.9 && < 0.11 and the snapshot contains constraints-0.14
@@ -8773,7 +8770,6 @@ packages:
         - tuple-sop < 0 # tried tuple-sop-0.3.1.0, but its *library* requires the disabled package: generics-sop
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
         - type-errors-pretty < 0 # tried type-errors-pretty-0.0.1.2, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.19.0.0
-        - type-natural < 0 # tried type-natural-1.3.0.0, but its *library* requires the disabled package: ghc-typelits-presburger
         - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.19.0.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires attoparsec >=0.13.2.2 && < 0.14 and the snapshot contains attoparsec-0.14.4
@@ -10190,7 +10186,6 @@ expected-test-failures:
     - spatial-math
     - sqids
     - stateWriter # 0.4.0 https://github.com/bartavelle/stateWriter/issues/6
-    - subcategories
     - sydtest-yesod # https://github.com/commercialhaskell/stackage/issues/6798
     - tasty-fail-fast
     - tasty-html # https://github.com/commercialhaskell/stackage/issues/6966


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
