### PR TITLE
Reenable Agda, disable simple-session

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -75,7 +75,7 @@ packages:
         - geniplate-mirror
 
     "Andreas Abel <andreas.abel@gu.se> @andreasabel":
-        - Agda < 0
+        - Agda
         - agda2lagda
         - BNFC
         - cabal-clean
@@ -8421,6 +8421,7 @@ packages:
         - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - simple-media-timestamp-formatting < 0 # tried simple-media-timestamp-formatting-0.1.1.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - simple-pango < 0 # tried simple-pango-0.1.0.1, but its *library* requires the disabled package: simple-cairo
+        - simple-session < 0 # tried simple-session-2.0.0, but its *library* requires the disabled package: simple
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.21.0.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1


### PR DESCRIPTION
This fixes the current breakage, as reported by `./check`:

simple (Amit Levy <amit@amitlevy.com> @alevy, Library and exe bounds failures) (not present) depended on by:
- [ ] simple-session-2.0.0 (>=2.0.0). Amit Levy <amit@amitlevy.com> @alevy. Used by: library

See: https://github.com/commercialhaskell/stackage/actions/runs/7359241495/job/20033709607