### PR TITLE
re-enable scotty and projects that depend on it

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7185,6 +7185,7 @@ packages:
         - haskoin-core < 0 # tried haskoin-core-1.0.2, but its *library* requires the disabled package: secp256k1-haskell
         - haskoin-node < 0 # tried haskoin-node-1.0.1, but its *library* requires the disabled package: haskoin-core
         - haskoin-store < 0 # tried haskoin-store-1.2.3, but its *library* requires the disabled package: statsd-rupp
+        - haskoin-store-data < 0 # tried haskoin-store-data-1.2.2, but its *library* requires the disabled package: scotty
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6391,7 +6391,6 @@ packages:
         - bits-extra < 0 # tried bits-extra-0.0.2.3, but its *library* requires ghc-prim >=0.5 && < 0.10 and the snapshot contains ghc-prim-0.11.0
         - blake2 < 0 # tried blake2-0.3.0.1, but its *library* requires base ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.0.0
         - blake2 < 0 # tried blake2-0.3.0.1, but its *library* requires bytestring ^>=0.10.12 || ^>=0.11 and the snapshot contains bytestring-0.12.0.2
-        - blank-canvas < 0 # tried blank-canvas-0.7.4, but its *library* requires the disabled package: scotty
         - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
         - blaze-colonnade < 0 # tried blaze-colonnade-1.2.2.1, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1
         - blaze-svg < 0 # tried blaze-svg-0.3.7, but its *library* requires base >=4 && < 4.19 and the snapshot contains base-4.19.0.0
@@ -6816,7 +6815,6 @@ packages:
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires fsnotify >=0.3 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
         - filecache < 0 # tried filecache-0.4.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - filepath-bytestring < 0 # tried filepath-bytestring-1.4.2.1.13, but its *library* requires base >=4 && < 4.19 and the snapshot contains base-4.19.0.0
-        - filter-logger < 0 # tried filter-logger-0.6.0.0, but its *executable* requires the disabled package: scotty
         - finite-typelits < 0 # tried finite-typelits-0.1.6.0, but its *library* requires base >=4.7 && < 4.19 and the snapshot contains base-4.19.0.0
         - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - fix-whitespace < 0 # tried fix-whitespace-0.1, but its *library* requires text >=1.2.3.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
@@ -7187,7 +7185,6 @@ packages:
         - haskoin-core < 0 # tried haskoin-core-1.0.2, but its *library* requires the disabled package: secp256k1-haskell
         - haskoin-node < 0 # tried haskoin-node-1.0.1, but its *library* requires the disabled package: haskoin-core
         - haskoin-store < 0 # tried haskoin-store-1.2.3, but its *library* requires the disabled package: statsd-rupp
-        - haskoin-store-data < 0 # tried haskoin-store-data-1.2.2, but its *library* requires the disabled package: scotty
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
@@ -7570,7 +7567,6 @@ packages:
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
         - kanji < 0 # tried kanji-3.5.0, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.2.1.0
-        - kansas-comet < 0 # tried kansas-comet-0.4.2, but its *library* requires the disabled package: scotty
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires aeson >=1.2 && < 1.3 and the snapshot contains aeson-2.2.1.0
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires async >=2.1 && < 2.2 and the snapshot contains async-2.2.5
         - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.8.0
@@ -7646,7 +7642,6 @@ packages:
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg-core
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.2.0
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.19.0.0
-        - line < 0 # tried line-4.0.1, but its *library* requires the disabled package: scotty
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
         - linear-base < 0 # tried linear-base-0.4.0, but its *library* requires the disabled package: linear-generics
         - linear-circuit < 0 # tried linear-circuit-0.1.0.4, but its *library* requires the disabled package: lapack
@@ -8275,7 +8270,6 @@ packages:
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires text >=1.2.0.0 && < 2 and the snapshot contains text-2.1
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires aeson >=1 && < 1.4.3.0 and the snapshot contains aeson-2.2.1.0
         - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: validationt
-        - scotty < 0 # tried scotty-0.21, but its *library* requires text >=0.11.3.1 && < 2.1 and the snapshot contains text-2.1
         - sdl2 < 0 # tried sdl2-2.5.5.0, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - sdl2 < 0 # tried sdl2-2.5.5.0, but its *library* requires text >=1.1.0.0 && < 2.1 and the snapshot contains text-2.1
         - sdl2-gfx < 0 # tried sdl2-gfx-0.3.0.0, but its *library* requires the disabled package: sdl2
@@ -9722,8 +9716,6 @@ skipped-tests:
     - wai-cors # tried wai-cors-0.2.7, but its *test-suite* requires the disabled package: websockets
     - wai-middleware-bearer # tried wai-middleware-bearer-1.0.3, but its *test-suite* requires the disabled package: hspec-wai
     - wai-middleware-delegate # tried wai-middleware-delegate-0.1.4.0, but its *test-suite* requires the disabled package: hspec-tmp-proc
-    - wai-middleware-metrics # tried wai-middleware-metrics-0.2.4, but its *test-suite* requires the disabled package: scotty
-    - wai-middleware-static # tried wai-middleware-static-0.9.2, but its *test-suite* requires the disabled package: scotty
     - wai-session-redis # tried wai-session-redis-0.1.0.5, but its *test-suite* requires hspec < 2.10 and the snapshot contains hspec-2.11.7
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.1


### PR DESCRIPTION
I removed the <0 build constraints. I know this should be done automatically but I was in a hurry :D

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage


