### PR TITLE
chore: Add myself as a maintainer of tasty-html

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1445,12 +1445,14 @@ packages:
         - tasty-hunit
         - tasty-quickcheck
         - tasty-smallcheck
-        - tasty-html
         - time-lens
         - timezone-olson
         - timezone-series
         - traverse-with-class
         - tuples-homogenous-h98
+
+    "Owen Shepherd <owen+stackage@owen.cafe> @414owen":
+        - tasty-html
 
     "George Giorgidze <giorgidze@gmail.com> @giorgidze":
         - YampaSynth < 0 # 0.2 compile fail

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1445,7 +1445,7 @@ packages:
         - tasty-hunit
         - tasty-quickcheck
         - tasty-smallcheck
-        - tasty-html < 0 # fails https://github.com/commercialhaskell/stackage/issues/7242
+        - tasty-html
         - time-lens
         - timezone-olson
         - timezone-series


### PR DESCRIPTION
This changeset adds myself as the maintainer of
tasty-html, following a discussion in
https://github.com/UnkindPartition/tasty-html/issues/24

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
