### PR TITLE
Re-enable trie-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8704,7 +8704,6 @@ packages:
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires network >=2.8.0.0 && < 3.0.0.0 and the snapshot contains network-3.1.4.0
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: TCache
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: transient
-        - trie-simple < 0 # tried trie-simple-0.4.2, but its *library* requires deepseq >=1.4.2.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
         - triplesec < 0 # tried triplesec-0.2.2.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - true-name < 0 # tried true-name-0.1.0.3, but its *library* requires template-haskell >=2.7 && < 2.15 and the snapshot contains template-haskell-2.21.0.0


### PR DESCRIPTION
See: https://github.com/viercc/trie-simple/pull/13

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
