### PR TITLE
Reenable disabled packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4835,7 +4835,7 @@ packages:
         - unboxing-vector
 
     "Brandon Chinn <brandonchinn178@gmail.com> @brandonchinn178":
-        - aeson-schemas < 0 # fails
+        - aeson-schemas
         - fourmolu
         - github-rest
         - graphql-client
@@ -7001,7 +7001,6 @@ packages:
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires text >=1.2.3.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
         - gothic < 0 # tried gothic-0.1.8.1, but its *library* requires vector >=0.12.0.1 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - graphql-client < 0 # tried graphql-client-1.2.3, but its *executable* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.0.2
         - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires aeson >=2.0.2.0 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires base >=4.9.0.0 && < 4.17 and the snapshot contains base-4.19.0.0
         - greskell < 0 # tried greskell-2.0.3.0, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1
@@ -9796,7 +9795,6 @@ expected-test-failures:
     - hie-bios # cabal, stack, ghc; see https://github.com/commercialhaskell/stackage/issues/5025
     - hjsmin # Test-runner expects a cabal-style 'dist-newstyle' directory
     - hocilib # oracle
-    - http-api-data-qq # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
     - http-client # httpbin issues, https://github.com/snoyberg/http-client/issues/439
     - http-client-tls # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
     - http-directory # httpbin issues, https://github.com/juhp/http-directory/issues/1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
