### PR TITLE
Re-enable netwire-input-glfw.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1644,7 +1644,7 @@ packages:
     "Pavel Krajcevski <krajcevski@gmail.com> @Mokosha":
         - netwire
         - netwire-input
-        - netwire-input-glfw < 0 # 0.0.11 compile fail https://github.com/Mokosha/netwire-input-glfw/issues/5
+        - netwire-input-glfw
         - yoga < 0 # Compilation failure with GHC 9.8.1, /usr/bin/ar: .stack-work/dist/x86_64-linux-tinfo6/ghc-9.8.1/build/yoga/YGNodePrint.o: No such file or directory
         - freetype2
         - HCodecs


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
