### PR TITLE
Re-enable yoga

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1647,7 +1647,7 @@ packages:
         - netwire
         - netwire-input
         - netwire-input-glfw
-        - yoga < 0 # Compilation failure with GHC 9.8.1, /usr/bin/ar: .stack-work/dist/x86_64-linux-tinfo6/ghc-9.8.1/build/yoga/YGNodePrint.o: No such file or directory
+        - yoga
         - freetype2
         - HCodecs
         - netcode-io


### PR DESCRIPTION
The only caveat is that the package requires a C/C++ compiler that supports at least C++20.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
