### PR TITLE
Re-enable sbv and crackNum

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6565,7 +6565,6 @@ packages:
         - cprng-aes < 0 # tried cprng-aes-0.6.1, but its *library* requires the disabled package: crypto-random
         - cpuinfo < 0 # tried cpuinfo-0.1.0.2, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - cpuinfo < 0 # tried cpuinfo-0.1.0.2, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - crackNum < 0 # tried crackNum-3.4, but its *executable* requires the disabled package: sbv
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-numbers
         - crypto-pubkey < 0 # tried crypto-pubkey-0.2.8, but its *library* requires the disabled package: crypto-random
         - cryptocipher < 0 # tried cryptocipher-0.6.2, but its *library* requires the disabled package: cipher-blowfish
@@ -8146,7 +8145,6 @@ packages:
         - sandwich-slack < 0 # tried sandwich-slack-0.1.2.0, but its *library* requires the disabled package: string-interpolate
         - sandwich-webdriver < 0 # tried sandwich-webdriver-0.2.3.1, but its *library* requires the disabled package: microlens-aeson
         - sandwich-webdriver < 0 # tried sandwich-webdriver-0.2.3.1, but its *library* requires the disabled package: string-interpolate
-        - sbv < 0 # tried sbv-10.2, but its *library* requires base >=4.16 && < 4.19 and the snapshot contains base-4.19.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.0.0
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0


### PR DESCRIPTION
Re-enable `sbv` as the newly released `sbv-10.3` removed the upper bound on `base-4.19`.

Re-enable `crackNum` which depends on `sbv`.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
