### PR TITLE
restore lens-family-th to stackage nightlies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7533,7 +7533,6 @@ packages:
         - learn-physics < 0 # tried learn-physics-0.6.6, but its *library* requires the disabled package: vector-space
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.2.3
-        - lens-family-th < 0 # tried lens-family-th-0.5.2.1, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.21.0.0
         - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.2.3
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family >=1.2 && < 1.3 and the snapshot contains lens-family-2.1.2
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family-core >=1.2 && < 1.3 and the snapshot contains lens-family-core-2.1.2


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
