### PR TITLE
string-interpolate: re-enable at 0.3.3.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8400,9 +8400,6 @@ packages:
         - strict-tuple-lens < 0 # tried strict-tuple-lens-0.2, but its *library* requires lens ^>=5 and the snapshot contains lens-5.2.3
         - string-class < 0 # tried string-class-0.1.7.1, but its *library* requires bytestring >=0.10.0.0 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - string-class < 0 # tried string-class-0.1.7.1, but its *library* requires text >=0.11.0.1 && < 2.1 and the snapshot contains text-2.1
-        - string-interpolate < 0 # tried string-interpolate-0.3.2.1, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.0.2
-        - string-interpolate < 0 # tried string-interpolate-0.3.2.1, but its *library* requires template-haskell < 2.21 and the snapshot contains template-haskell-2.21.0.0
-        - string-interpolate < 0 # tried string-interpolate-0.3.2.1, but its *library* requires text < 2.1 and the snapshot contains text-2.1
         - string-random < 0 # tried string-random-0.1.4.3, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1
         - string-variants < 0 # tried string-variants-0.3.0.0, but its *library* requires the disabled package: refinery
         - stripe-concepts < 0 # tried stripe-concepts-1.0.3.3, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.0.0
@@ -10226,7 +10223,6 @@ skipped-benchmarks:
     - serialise # tried serialise-0.2.6.1, but its *benchmarks* requires the disabled package: store
     - servant-auth-cookie # tried servant-auth-cookie-0.6.0.3, but its *benchmarks* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.3.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *benchmarks* requires shelly >=1.6.8 && < 1.10 and the snapshot contains shelly-1.12.1
-    - string-interpolate # tried string-interpolate-0.3.2.1, but its *benchmarks* requires deepseq < 1.5 and the snapshot contains deepseq-1.5.0.0
     - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires criterion < 1.3 and the snapshot contains criterion-1.6.3.0
     - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires the disabled package: buffer-builder
     - sv # tried sv-1.4.0.1, but its *benchmarks* requires criterion >=1.3 && < 1.6 and the snapshot contains criterion-1.6.3.0


### PR DESCRIPTION
I'd also like to re-enable a bunch of packages that depend on this, but I'll do that in a follow-up PR for clarity.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [N/A] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
