### PR TITLE
Re-enable packages: aeson-typescript, prettyprinter-interp, sandwich, call-alloy

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6200,7 +6200,6 @@ packages:
         - aeson-optics < 0 # tried aeson-optics-1.2.1, but its *library* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - aeson-optics < 0 # tried aeson-optics-1.2.1, but its *library* requires text >=1.2.2.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
         - aeson-picker < 0 # tried aeson-picker-0.1.0.6, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1
-        - aeson-typescript < 0 # tried aeson-typescript-0.6.1.0, but its *library* requires the disabled package: string-interpolate
         - airship < 0 # tried airship-0.9.5, but its *library* requires mime-types >=0.1.0 && < 0.1.1 and the snapshot contains mime-types-0.1.2.0
         - airship < 0 # tried airship-0.9.5, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.3.0
         - al < 0 # tried al-0.1.4.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7946,7 +7945,6 @@ packages:
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires Diff >=0.3 && < 0.5 and the snapshot contains Diff-0.5
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1
-        - prettyprinter-interp < 0 # tried prettyprinter-interp-0.2.0.0, but its *library* requires the disabled package: string-interpolate
         - primitive-extras < 0 # tried primitive-extras-0.10.1.10, but its *library* requires the disabled package: primitive-unlifted
         - primitive-unlifted < 0 # tried primitive-unlifted-2.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - printcess < 0 # tried printcess-0.1.0.3, but its *library* requires containers >=0.5.6 && < 0.6 and the snapshot contains containers-0.6.8
@@ -8114,7 +8112,6 @@ packages:
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires text ^>=1.2 || ^>=2.0 and the snapshot contains text-2.1
-        - sandwich < 0 # tried sandwich-0.2.1.0, but its *library* requires the disabled package: string-interpolate
         - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.3.0, but its *library* requires the disabled package: hedgehog
         - sandwich-hedgehog < 0 # tried sandwich-hedgehog-0.1.3.0, but its *library* requires the disabled package: string-interpolate
         - sandwich-quickcheck < 0 # tried sandwich-quickcheck-0.1.0.7, but its *library* requires the disabled package: sandwich
@@ -9176,7 +9173,6 @@ skipped-tests:
     - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-described
     - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-tree-diff
     - cacophony # tried cacophony-0.10.1, but its *test-suite* requires the disabled package: hlint
-    - call-alloy # tried call-alloy-0.4.0.3, but its *test-suite* requires the disabled package: string-interpolate
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires QuickCheck >=2.12 && < 2.13 and the snapshot contains QuickCheck-2.14.3
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires bytestring >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.0.2
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1


### PR DESCRIPTION
These can be re-enabled now that `string-interpolate` works.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
