### PR TITLE
Re #7205: reenable hledger-iadd

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7195,7 +7195,6 @@ packages:
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
         - hledger < 0 # tried hledger-1.32.2, but its *library* requires base >=4.14 && < 4.19 and the snapshot contains base-4.19.0.0
-        - hledger-iadd < 0 # tried hledger-iadd-1.3.19, but its *library* requires megaparsec >=7.0 && < 9.6 and the snapshot contains megaparsec-9.6.1
         - hledger-interest < 0 # tried hledger-interest-1.6.6, but its *executable* requires the disabled package: hledger-lib
         - hledger-lib < 0 # tried hledger-lib-1.32.2, but its *library* requires base >=4.14 && < 4.19 and the snapshot contains base-4.19.0.0
         - hledger-stockquotes < 0 # tried hledger-stockquotes-0.1.2.1, but its *library* requires the disabled package: hledger-lib
@@ -7535,7 +7534,6 @@ packages:
         - linear-generics < 0 # tried linear-generics-0.2.2, but its *library* requires template-haskell >=2.16 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - linear-generics < 0 # tried linear-generics-0.2.2, but its *library* requires th-abstraction >=0.5 && < 0.6 and the snapshot contains th-abstraction-0.6.0.0
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.6.1
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.2
         - list-witnesses < 0 # tried list-witnesses-0.1.4.0, but its *library* requires singletons-base >=3.0 && < 3.3 and the snapshot contains singletons-base-3.3
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires bytestring >=0.10 && < 0.11.3 and the snapshot contains bytestring-0.12.0.2


### PR DESCRIPTION
Oh, this PR seems invalid:

hledger-lib (Library and exe bounds failures, Simon Michael <simon@joyful.com> @simonmichael) (not present) depended on by:
- [ ] hledger-iadd-1.3.20 (>=1.29 && < 1.33). Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel. Used by: library

