### PR TITLE
Re-enable aeson-typescript (closes #7297)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -416,7 +416,7 @@ packages:
         - buchhaltung
 
     "Tom McLaughlin <tom@codedown.io> @thomasjm":
-        - aeson-typescript < 0 # 0.6.2.0 https://github.com/commercialhaskell/stackage/issues/7297
+        - aeson-typescript
         - fsnotify
         - myers-diff
         - sandwich


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

(Tests fail but this is under `expected-test-failures`)