### PR TITLE
Add wherefrom-compat maintainer

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5219,6 +5219,7 @@ packages:
         - trie-simple
         - PSQueue
         - matchable # dep of trie-simple
+        - wherefrom-compat
 
     "Fabricio Olivetti de Franca <fabricio.olivetti@gmail.com> @folivetti":
         - hegg # dep of pandoc-symreg
@@ -5812,7 +5813,6 @@ packages:
         - web3-polkadot
         - web3-provider
         - web3-solidity
-        - wherefrom-compat
         - with-location
         - wizards
         - word-wrap


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [X] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
