### PR TITLE
automation: Temporarily push to both buckets

### DIFF
--- a/automated/build.sh
+++ b/automated/build.sh
@@ -153,6 +153,15 @@ docker run $ARGS_UPLOAD $IMAGE /bin/bash -c "exec curator check-target-available
 # * Upload the new snapshot .yaml file to the appropriate Github repo, also upload its constraints
 docker run $ARGS_UPLOAD $IMAGE /bin/bash -c "curator upload-docs --target $TARGET ${DOCS_BUCKET:+--bucket $DOCS_BUCKET} && curator upload-github --target $TARGET"
 
+# For testing, temporarily push to the new HF bucket directly.
+# Use a subshell to temporarily get new creds and allow failure.
+(
+    source work/aws-hf.sh
+    # Regenerate docs-specific upload args
+    ARGS_UPLOAD_DOCS="$ARGS_COMMON -u $USERID -e HOME=$C_HOME -v $DOT_STACKAGE_DIR:$C_HOME/.stackage -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ${AWS_ENDPOINT_URL:+-e AWS_ENDPOINT_URL=$AWS_ENDPOINT_URL} -v $DOT_STACKAGE_DIR:/dot-stackage"
+    docker run "$ARGS_UPLOAD_DOCS" "$IMAGE" /bin/bash -c "curator upload-docs --target $TARGET ${DOCS_BUCKET:+--bucket $DOCS_BUCKET}"
+)
+
 # fixed in https://github.com/commercialhaskell/curator/pull/24
 docker run $ARGS_UPLOAD $IMAGE /bin/bash -c "exec curator hackage-distro --target $TARGET"
 


### PR DESCRIPTION
Once this is merged, someone can deploy it to the server and it will automatically attempt to write to the new bucket (as well as continuing to write to the old bucket). I can check on the results after a nightly has run.

If it has worked, I can just update the config on the server and all systems will be using the new bucket by default!