### PR TITLE
Re-enable conduit-algorithms

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6485,7 +6485,6 @@ packages:
         - compressed < 0 # tried compressed-3.11, but its *library* requires containers >=0.3 && < 0.6 and the snapshot contains containers-0.6.8
         - compressed < 0 # tried compressed-3.11, but its *library* requires hashable >=1.1.2.1 && < 1.3 and the snapshot contains hashable-1.4.3.0
         - compressed < 0 # tried compressed-3.11, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
-        - conduit-algorithms < 0 # tried conduit-algorithms-0.0.13.0, but its *library* requires the disabled package: lzma-conduit
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0


### PR DESCRIPTION
Version 0.0.14.0 no longer requires the problematic lzma-conduit

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
