### PR TITLE
Revert "Add an upper bound for boomwhacker, #7321"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8545,7 +8545,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/7321
         - HPDF < 1.7
-        - boomwhacker < 0.0.2
 
         # https://github.com/commercialhaskell/stackage/issues/7326
         - toml-parser < 2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8543,9 +8543,6 @@ packages:
         - tls < 2
         - tls-session-manager < 0.0.5
 
-        # https://github.com/commercialhaskell/stackage/issues/7321
-        - HPDF < 1.7
-
         # https://github.com/commercialhaskell/stackage/issues/7326
         - toml-parser < 2
 


### PR DESCRIPTION
This reverts commit 9113979a2201e001c7ca518b848a12d2dbd65d81.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
