### PR TITLE
Bring hexpat Back Into Nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4763,6 +4763,7 @@ packages:
         - cointracking-imports
         - binance-exports
         - gemini-exports
+        - hexpat
 
     "David Baynard <haskell@baynard.dev> @dbaynard":
         - time-qq
@@ -7034,8 +7035,6 @@ packages:
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires semigroups >=0.18.3 && < 0.19 and the snapshot contains semigroups-0.20
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires vty >=5.15 && < =5.23 and the snapshot contains vty-6.2
         - hetzner < 0 # tried hetzner-0.6.0.0, but its *library* requires base >=4.16 && < 4.19 and the snapshot contains base-4.19.0.0
-        - hexpat < 0 # tried hexpat-0.20.13, but its *library* requires deepseq >=1.1.0.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - hexpat < 0 # tried hexpat-0.20.13, but its *library* requires text >=0.5.0.0 && < 1.3 || >=2 && < 2.1 and the snapshot contains text-2.1
         - hgeometry < 0 # tried hgeometry-0.14, but its *library* requires the disabled package: vector-circular
         - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.14, but its *library* requires the disabled package: vector-circular
         - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.2.1.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
