### PR TITLE
Re-enable hakyll-convert

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6909,7 +6909,6 @@ packages:
         - hadolint < 0 # tried hadolint-2.12.0, but its *library* requires the disabled package: language-docker
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.0.2
         - hadoop-streaming < 0 # tried hadoop-streaming-0.2.0.3, but its *library* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.1
-        - hakyll-convert < 0 # tried hakyll-convert-0.3.0.4, but its *library* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires bytestring >=0.11.3 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires text >=2.0.2 && < 2.1 and the snapshot contains text-2.1
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0


### PR DESCRIPTION
0.3.0.4@rev:7 allows text-2.1.

`./verify-package hakyll-convert-0.3.0.4@rev:7` fails because `feed` is currently disabled too.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
