### PR TITLE
Dev reenable packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -381,7 +381,7 @@ packages:
 
     "Manuel Bärenz <programming@manuelbaerenz.de> @turion":
         - dunai < 0 # 0.12.1 compile fail
-        - essence-of-live-coding < 0 # 0.2.7 compile fail https://github.com/turion/essence-of-live-coding/issues/107
+        - essence-of-live-coding
         - essence-of-live-coding-gloss
         - essence-of-live-coding-pulse
         - essence-of-live-coding-quickcheck
@@ -6655,10 +6655,6 @@ packages:
         - emd < 0 # tried emd-0.2.0.0, but its *library* requires the disabled package: finite-typelits
         - envy < 0 # tried envy-2.1.2.0, but its *library* requires bytestring >=0.10 && < 0.11 || >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.0.2
         - envy < 0 # tried envy-2.1.2.0, but its *library* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1
-        - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
-        - essence-of-live-coding-pulse < 0 # tried essence-of-live-coding-pulse-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
-        - essence-of-live-coding-quickcheck < 0 # tried essence-of-live-coding-quickcheck-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
-        - essence-of-live-coding-warp < 0 # tried essence-of-live-coding-warp-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
         - euler-tour-tree < 0 # tried euler-tour-tree-0.1.1.0, but its *library* requires the disabled package: Unique
         - event < 0 # tried event-0.1.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - event < 0 # tried event-0.1.4, but its *library* requires semigroups >=0.16 && < 0.19 and the snapshot contains semigroups-0.20

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -388,6 +388,7 @@ packages:
         - essence-of-live-coding-warp
         - finite-typelits
         - has-transformers
+        - monad-bayes
         - monad-schedule
         - pulse-simple
         - rhine


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [ ] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
