### PR TITLE
Add back `distributed-process` + dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -18,7 +18,6 @@ packages:
         - network-transport-tcp
         - network-transport-inmemory
         - distributed-process
-        - distributed-process-async
 
     "Julian Ospald <hasufell@posteo.de> @hasufell":
         - os-string >= 2.0.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9388,6 +9388,7 @@ expected-test-failures:
     - prettyprinter-ansi-terminal
     - product-profunctors # 0.11.0.3 executable not found
     - rando # https://github.com/commercialhaskell/stackage/issues/4249
+    - rank1dynamic
     - readline # 1.0.3.0
     - req # https://github.com/commercialhaskell/stackage/issues/6904
     - rescue

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5457,8 +5457,6 @@ packages:
         - dictionary-sharing
         - direct-sqlite
         - discount
-        - distributed-process
-        - distributed-static
         - djot
         - dlist
         - dlist-instances
@@ -5637,7 +5635,6 @@ packages:
         - network-ip
         - network-multicast
         - network-run
-        - network-transport
         - network-uri < 2.7.0.0 || > 2.7.0.0 # 2.7.0.0 was deprecated, don't remove bound until >2.7.0.0 is released.
         - next-ref
         - nicify-lib
@@ -5684,7 +5681,6 @@ packages:
         - random
         - random-shuffle
         - range-set-list
-        - rank1dynamic
         - ratio-int
         - raw-strings-qq
         - readable
@@ -6593,17 +6589,10 @@ packages:
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.2.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires hashable >=1.2.0.5 && < 1.3 and the snapshot contains hashable-1.4.3.0
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.2
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires stm >=2.4 && < 2.5 and the snapshot contains stm-2.5.2.1
-        - distributed-process < 0 # tried distributed-process-0.7.4, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process
-        - distributed-static < 0 # tried distributed-static-0.3.9, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.2
         - diversity < 0 # tried diversity-0.8.1.0, but its *library* requires the disabled package: fasta
@@ -9168,7 +9157,6 @@ expected-test-failures:
     - concurrent-extra # https://github.com/basvandijk/concurrent-extra/issues/12
     - crypto-numbers
     - css-text # https://github.com/yesodweb/css-text/issues/10
-    - distributed-process
     - distributed-process-execution # https://github.com/haskell-distributed/distributed-process-execution/issues/2
     - distributed-process-task
     - dl-fedora # status 404 on http download
@@ -9400,7 +9388,6 @@ expected-test-failures:
     - prettyprinter-ansi-terminal
     - product-profunctors # 0.11.0.3 executable not found
     - rando # https://github.com/commercialhaskell/stackage/issues/4249
-    - rank1dynamic
     - readline # 1.0.3.0
     - req # https://github.com/commercialhaskell/stackage/issues/6904
     - rescue
@@ -9659,7 +9646,6 @@ skipped-benchmarks:
     - cmark-gfm # tried cmark-gfm-0.2.6, but its *benchmarks* requires the disabled package: cheapskate
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires criterion < 1.6 and the snapshot contains criterion-1.6.3.0
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.1.0
-    - distributed-process # tried distributed-process-0.7.4, but its *benchmarks* requires the disabled package: network-transport-tcp
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires criterion >=0.8 && < 1.2 and the snapshot contains criterion-1.6.3.0
     - ed25519 # tried ed25519-0.0.5.0, but its *benchmarks* requires deepseq >=1.3 && < 1.5 and the snapshot contains deepseq-1.5.0.0
     - extensible-effects # tried extensible-effects-5.0.0.1, but its *benchmarks* requires the disabled package: test-framework-th

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -10,6 +10,15 @@ cabal-format-version: "3.0"
 
 # Constraints for brand new builds
 packages:
+    "David Simmons-Duffin <dsd@caltech.edu> @davidsd":
+        - rank1dynamic
+        - distributed-static
+        - network-transport
+        - network-transport-tcp
+        - network-transport-inmemory
+        - distributed-process
+        - distributed-process-async
+
     "Julian Ospald <hasufell@posteo.de> @hasufell":
         - os-string >= 2.0.2
         - file-io >= 0.1.1

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -14,6 +14,7 @@ packages:
         - rank1dynamic
         - distributed-static
         - network-transport
+        - network-transport-tests
         - network-transport-tcp
         - network-transport-inmemory
         - distributed-process
@@ -6592,7 +6593,7 @@ packages:
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process
+        - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process # revisit, now that distributed-process has been re-enabled
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.2
         - diversity < 0 # tried diversity-0.8.1.0, but its *library* requires the disabled package: fasta
@@ -8809,7 +8810,7 @@ skipped-tests:
     - dhall-yaml # tried dhall-yaml-1.2.12, but its *test-suite* requires tasty < 1.5 and the snapshot contains tasty-1.5
     - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec >=2.7.1 && < 2.9.0 and the snapshot contains hspec-2.11.7
     - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec-discover >=2.7.1 && < 2.9.0 and the snapshot contains hspec-discover-2.11.7
-    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: network-transport-tcp
+    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: network-transport-tcp # revisit, now that network-transport-tcp has been re-enabled
     - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: rematch
     - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-th
     - drawille # tried drawille-0.1.3.0, but its *test-suite* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
@@ -8987,7 +8988,7 @@ skipped-tests:
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.20
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.7
-    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires the disabled package: network-transport-tcp
+    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires the disabled package: network-transport-tcp # revisit, now that network-transport-tcp has been re-enabled
     - sexpr-parser # tried sexpr-parser-0.2.2.0, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.7
     - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.11.7
     - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-1.0.2


### PR DESCRIPTION
This pull request adds the following packages associated with `distributed-process` under my curatorship:

- `rank1dynamic`
- `distributed-static`
- `network-transport`
- `network-transport-tests`
- `network-transport-tcp`
- `network-transport-inmemory`
- `distributed-process`
- ~~`distributed-process-async`~~

I removed some of these packages (`rank1dynamic`, `distributed-process`, `distributed-static`, `network-transport`) from the "Grandfathered in" section.

I also removed constraints coming from build failures for `distributed-process`, and added comments about revisiting some of the build failures from other packages (that I am not curating) that depend on `distributed-process` and `network-transport-tcp`.

Apologies that some of my commit titles refer to `build-constraints.yaml` -- there is meaningful information in the full commit messages.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
 I ran `verify-package` for the packages whose dependencies are available in stackage. The package `rank1dynamic` has a test suite failure which is already accounted for in `build-constraints.yaml`. The packages `distributed-static` and `network-transport` were verified. But I wasn't able to verify the others because their dependencies aren't in stackage. (Probably I just don't know how to use the script). However, I have been able to build them all with the latest resolver and their latest versions on hackage.
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
