### PR TITLE
Allow hackage-security 0.6.2.6, restore testing it

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -143,7 +143,7 @@ packages:
         - test-framework
         - c2hs
         - cabal-doctest
-        - hackage-security < 0.6.2.5 # https://github.com/commercialhaskell/stackage/issues/7357
+        - hackage-security
         - haskell-lexer
         - lifted-async
         - polyparse
@@ -9069,8 +9069,6 @@ skipped-tests:
     - do-list # 1.0.1 test:  executable not found https://github.com/tserduke/do-list/issues/3
     - incremental-parser # Main: executable not found
     - streamt # executable not found
-
-    - hackage-security # https://github.com/commercialhaskell/stackage/issues/7365
 
 # end of skipped-tests
 


### PR DESCRIPTION
This closes #7365 and should help with #7357.
- #7365
- #7357
