### PR TITLE
Add `monoidmap`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3867,6 +3867,7 @@ packages:
         - bech32
         - bech32-th
         - cardano-coin-selection
+        - monoidmap
         - quickcheck-groups
         - quickcheck-monoid-subclasses
         - quiet


### PR DESCRIPTION
This PR adds the [`monoidmap`](https://hackage.haskell.org/package/monoidmap) package to `build-constraints.yaml`.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
