### PR TITLE
Re-enabled `jsaddle`(#7249), reverted  242c5e5067f9432a9807165d7325ce…

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1889,7 +1889,7 @@ packages:
         - gtk3
         - ghcjs-codemirror
         - ghcjs-dom
-        - jsaddle < 0 # 0.9.8.3 fails https://github.com/commercialhaskell/stackage/issues/7249
+        - jsaddle
         - vado
         - vcswrapper
         - ShellCheck
@@ -6093,8 +6093,7 @@ packages:
     # for compilation failures as we need to build those packages to
     # verify if they have been fixeq.
     # Recheck with: commenter clear && commenter add-loop
-    # (renamed from "Library and exe bounds failures")
-    "Large scale package bounds failures":
+    "Library and exe bounds failures":
         - Allure < 0 # tried Allure-0.11.0.0, but its *library* requires the disabled package: LambdaHack
         - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
         - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
@@ -6122,7 +6121,7 @@ packages:
         - IPv6DB < 0 # tried IPv6DB-0.3.3.1, but its *executable* requires wai-logger >=2.2.7 && < 2.4 and the snapshot contains wai-logger-2.4.0
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires text-show >=3.7 && < 3.9 and the snapshot contains text-show-3.10.4
         - JuicyPixels-blp < 0 # tried JuicyPixels-blp-0.2.0.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
         - JuicyPixels-blurhash < 0 # tried JuicyPixels-blurhash-0.1.0.3, but its *executable* requires optparse-applicative >=0.14.3 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
@@ -6145,8 +6144,6 @@ packages:
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: hierarchical-clustering
-        - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - Spintax < 0 # tried Spintax-0.3.6, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.1.1
         - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-lucid < 0 # tried Spock-lucid-0.4.0.1, but its *library* requires the disabled package: Spock
@@ -6219,7 +6216,7 @@ packages:
         - amqp-utils < 0 # tried amqp-utils-0.6.4.0, but its *executable* requires the disabled package: filepath-bytestring
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-1.0.2
+        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-1.1
         - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.19.1.0
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka-dynamodb
@@ -6330,7 +6327,7 @@ packages:
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires beam-core >=0.8 && < 0.9 and the snapshot contains beam-core-0.10.1.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires hashable >=1.1 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires hashable >=1.1 && < 1.3 and the snapshot contains hashable-1.4.4.0
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mysql >=0.1 && < 0.2 and the snapshot contains mysql-0.2.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
@@ -6344,7 +6341,7 @@ packages:
         - beam-sqlite < 0 # tried beam-sqlite-0.5.3.0, but its *library* requires aeson >=0.11 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - beam-sqlite < 0 # tried beam-sqlite-0.5.3.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - beam-sqlite < 0 # tried beam-sqlite-0.5.3.0, but its *library* requires text >=1.0 && < 2.1 and the snapshot contains text-2.1.1
-        - bench < 0 # tried bench-1.0.12, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
+        - bench < 0 # tried bench-1.0.13, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
         - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.19.1.0
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
@@ -6406,17 +6403,14 @@ packages:
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires websockets >=0.12.7.2 && < 0.13 and the snapshot contains websockets-0.13.0.0
-        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.7
+        - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.8
         - bytehash < 0 # tried bytehash-0.1.1.2, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - bytehash < 0 # tried bytehash-0.1.1.2, but its *library* requires primitive >=0.9 && < 0.10 and the snapshot contains primitive-0.8.0.0
         - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - bytestring-trie < 0 # tried bytestring-trie-0.2.7.2, but its *library* requires base >=4.5 && < 4.19 and the snapshot contains base-4.19.1.0
         - bytestring-trie < 0 # tried bytestring-trie-0.2.7.2, but its *library* requires bytestring >=0.9.2 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - bytestring-trie < 0 # tried bytestring-trie-0.2.7.2, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - cabal-flatpak < 0 # tried cabal-flatpak-0.1.1, but its *executable* requires the disabled package: cabal-plan
-        - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *library* requires base ^>=4.10.0.0 || ^>=4.11.0.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0 || ^>=4.16.0.0 || ^>=4.17.0.0 || ^>=4.18.0.0 and the snapshot contains base-4.19.1.0
-        - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *library* requires bytestring ^>=0.10.8.0 || ^>=0.11.1.0 and the snapshot contains bytestring-0.12.1.0
-        - cabal-plan < 0 # tried cabal-plan-0.7.3.0, but its *library* requires text ^>=1.2.3 || ^>=2.0.1 and the snapshot contains text-2.1.1
+        - cabal-flatpak < 0 # tried cabal-flatpak-0.1.1, but its *executable* requires zlib >=0.5.3 && < 0.7 and the snapshot contains zlib-0.7.0.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.2.3
@@ -6449,14 +6443,14 @@ packages:
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.6
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.16
+        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.17
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires req >=1.0.0 && < 1.3.0 and the snapshot contains req-3.13.2
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires text >=0.9 && < 1.3 and the snapshot contains text-2.1.1
         - cheapskate-highlight < 0 # tried cheapskate-highlight-0.1.0.0, but its *library* requires the disabled package: highlighting-kate
         - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
-        - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.19.1.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.19.1.0
         - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
@@ -6496,7 +6490,7 @@ packages:
         - composite-tuple < 0 # tried composite-tuple-0.1.2.0, but its *library* requires the disabled package: composite-base
         - composite-xstep < 0 # tried composite-xstep-0.1.0.0, but its *library* requires the disabled package: composite-base
         - compressed < 0 # tried compressed-3.11, but its *library* requires containers >=0.3 && < 0.6 and the snapshot contains containers-0.6.8
-        - compressed < 0 # tried compressed-3.11, but its *library* requires hashable >=1.1.2.1 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - compressed < 0 # tried compressed-3.11, but its *library* requires hashable >=1.1.2.1 && < 1.3 and the snapshot contains hashable-1.4.4.0
         - compressed < 0 # tried compressed-3.11, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.0.1
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - conduit-connection < 0 # tried conduit-connection-0.1.0.5, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
@@ -6512,7 +6506,7 @@ packages:
         - conferer-hspec < 0 # tried conferer-hspec-1.1.0.0, but its *library* requires text >=1.1 && < 2.1 and the snapshot contains text-2.1.1
         - conferer-snap < 0 # tried conferer-snap-1.0.0.0, but its *library* requires conferer >=1.0.0.0 && < 1.1.0.0 and the snapshot contains conferer-1.1.0.0
         - conferer-warp < 0 # tried conferer-warp-1.1.0.1, but its *library* requires text >=1.1 && < 2.1 and the snapshot contains text-2.1.1
-        - connection < 0 # tried connection-0.3.1, but its *library* requires tls >=1.4 && < 1.7 and the snapshot contains tls-2.0.1
+        - connection < 0 # tried connection-0.3.1, but its *library* requires tls >=1.4 && < 1.7 and the snapshot contains tls-2.0.2
         - console-style < 0 # tried console-style-0.0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
         - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.8
@@ -6544,8 +6538,8 @@ packages:
         - cusolver < 0 # tried cusolver-0.3.0.0, but its *library* requires the disabled package: cusparse
         - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.19.1.0
         - czipwith < 0 # tried czipwith-1.0.1.4, but its *library* requires template-haskell >=2.9 && < 2.19 and the snapshot contains template-haskell-2.21.0.0
-        - darcs < 0 # tried darcs-2.18.1, but its *library* requires the disabled package: strict-identity
-        - darcs < 0 # tried darcs-2.18.1, but its *library* requires tls < 2.0.0 and the snapshot contains tls-2.0.1
+        - darcs < 0 # tried darcs-2.18.2, but its *library* requires the disabled package: strict-identity
+        - darcs < 0 # tried darcs-2.18.2, but its *library* requires tls < 2.0.0 and the snapshot contains tls-2.0.2
         - data-accessor-template < 0 # tried data-accessor-template-0.2.1.16, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
         - data-compat < 0 # tried data-compat-0.1.0.4, but its *library* requires base >=4.12.0.0 && < 4.18 and the snapshot contains base-4.19.1.0
         - data-compat < 0 # tried data-compat-0.1.0.4, but its *library* requires constraints >=0.10 && < 0.14 and the snapshot contains constraints-0.14
@@ -6561,8 +6555,10 @@ packages:
         - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires deepseq >=1.4.0.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - dependent-sum-template < 0 # tried dependent-sum-template-0.2.0.1, but its *library* requires template-haskell >=2.11 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - dhall < 0 # tried dhall-1.42.1, but its *library* requires Diff >=0.2 && < 0.5 and the snapshot contains Diff-0.5
+        - dhall < 0 # tried dhall-1.42.1, but its *library* requires ansi-terminal >=0.6.3.1 && < 1.1 and the snapshot contains ansi-terminal-1.1
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires text >=0.2 && < 2.1 and the snapshot contains text-2.1.1
+        - dhall-json < 0 # tried dhall-json-1.7.12, but its *executable* requires ansi-terminal >=0.6.3.1 && < 1.1 and the snapshot contains ansi-terminal-1.1
         - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires aeson >=1.4.6.0 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - dhall-json < 0 # tried dhall-json-1.7.12, but its *library* requires text >=0.11.1.0 && < 2.1 and the snapshot contains text-2.1.1
@@ -6575,6 +6571,7 @@ packages:
         - dhall-lsp-server < 0 # tried dhall-lsp-server-1.1.3, but its *library* requires transformers >=0.5.5.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires text >=0.8.0.0 && < 2.1 and the snapshot contains text-2.1.1
         - dhall-nix < 0 # tried dhall-nix-1.1.26, but its *library* requires the disabled package: hnix
+        - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *executable* requires ansi-terminal >=0.6.3.1 && < 1.1 and the snapshot contains ansi-terminal-1.1
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires aeson >=1.0.0.0 && < 2.2 and the snapshot contains aeson-2.2.1.0
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires text >=0.11.1.0 && < 2.1 and the snapshot contains text-2.1.1
@@ -6596,18 +6593,18 @@ packages:
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
         - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.2.0
+        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires zlib >=0.6.1.2 && < 0.7 and the snapshot contains zlib-0.7.0.0
+        - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.3.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - distributed-process-monad-control < 0 # tried distributed-process-monad-control-0.5.1.3, but its *library* requires the disabled package: distributed-process # revisit, now that distributed-process has been re-enabled
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - distribution < 0 # tried distribution-1.1.1.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.2
         - diversity < 0 # tried diversity-0.8.1.0, but its *library* requires the disabled package: fasta
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires bytestring >=0.10.0 && < 0.12.0 and the snapshot contains bytestring-0.12.1.0
         - docker < 0 # tried docker-0.7.0.1, but its *library* requires text >=1.0.0 && < 2.0.0 and the snapshot contains text-2.1.1
-        - docker < 0 # tried docker-0.7.0.1, but its *library* requires tls >=1.3.7 && < 1.7.0 and the snapshot contains tls-2.0.1
+        - docker < 0 # tried docker-0.7.0.1, but its *library* requires tls >=1.3.7 && < 1.7.0 and the snapshot contains tls-2.0.2
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires the disabled package: language-docker
         - dom-parser < 0 # tried dom-parser-3.2.0, but its *library* requires the disabled package: xml-lens
         - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.19.1.0
@@ -6637,8 +6634,6 @@ packages:
         - ekg-wai < 0 # tried ekg-wai-0.1.1.0, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - elliptic-curve < 0 # tried elliptic-curve-0.3.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.4
         - elm-street < 0 # tried elm-street-0.2.2.0, but its *library* requires text >=1.2 && < =2.1 and the snapshot contains text-2.1.1
-        - envy < 0 # tried envy-2.1.2.0, but its *library* requires bytestring >=0.10 && < 0.11 || >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - envy < 0 # tried envy-2.1.2.0, but its *library* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
         - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
         - essence-of-live-coding-pulse < 0 # tried essence-of-live-coding-pulse-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
         - essence-of-live-coding-quickcheck < 0 # tried essence-of-live-coding-quickcheck-0.2.7, but its *library* requires the disabled package: essence-of-live-coding
@@ -6690,7 +6685,7 @@ packages:
         - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
         - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1.1
-        - fourmolu < 0 # tried fourmolu-0.15.0.0, but its *library* requires the disabled package: MemoTrie
+        - fourmolu < 0 # tried fourmolu-0.15.0.0, but its *library* requires ansi-terminal >=0.10 && < 1.1 and the snapshot contains ansi-terminal-1.1
         - freer-simple < 0 # tried freer-simple-1.2.1.2, but its *library* requires template-haskell >=2.11 && < 2.19 and the snapshot contains template-haskell-2.21.0.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
         - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2.1
@@ -6712,16 +6707,12 @@ packages:
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.42.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires ghc >=8.8.2 && < 8.11 and the snapshot contains ghc-9.8.2
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text >=1.2.3.2 && < 1.3 and the snapshot contains text-2.1.1
-        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.4
+        - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires text-icu >=0.7.0 && < 0.8 and the snapshot contains text-icu-0.8.0.5
         - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires base >=4.9.0 && < 4.19 and the snapshot contains base-4.19.1.0
         - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires bytestring >=0.10.6.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - ghc-compact < 0 # tried ghc-compact-0.1.0.0, but its *library* requires ghc-prim >=0.5.3 && < 0.11 and the snapshot contains ghc-prim-0.11.0
         - ghc-prof < 0 # tried ghc-prof-1.4.1.12, but its *library* requires base >=4.6 && < 4.18 and the snapshot contains base-4.19.1.0
-        - ghc-source-gen < 0 # tried ghc-source-gen-0.4.4.1, but its *library* requires ghc >=8.4 && < 9.7 and the snapshot contains ghc-9.8.2
         - ghc-syb-utils < 0 # tried ghc-syb-utils-0.3.0.0, but its *library* requires ghc >=7.10 && < 8.6 and the snapshot contains ghc-9.8.2
-        - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.1.1
-        - ghcjs-dom < 0 # tried ghcjs-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - ghcjs-dom-jsaddle < 0 # tried ghcjs-dom-jsaddle-0.9.5.0, but its *library* requires the disabled package: jsaddle-dom
         - gi-cairo-connector < 0 # tried gi-cairo-connector-0.1.1, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - gi-gsk < 0 # tried gi-gsk-4.0.7, but its *library* requires gi-gdk >=4.0 && < 4.1 and the snapshot contains gi-gdk-3.0.28
         - ginger < 0 # tried ginger-0.10.5.2, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -6842,7 +6833,7 @@ packages:
         - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* requires base >=4.4 && < 4.11 and the snapshot contains base-4.19.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.6
-        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.16
+        - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.17
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - gothic < 0 # tried gothic-0.1.8.2, but its *library* requires the disabled package: connection
@@ -6878,7 +6869,7 @@ packages:
         - gtk3 < 0 # tried gtk3-0.15.8, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - gtk3 < 0 # tried gtk3-0.15.8, but its *library* requires text >=0.11.0.6 && < 2.1 and the snapshot contains text-2.1.1
         - hOpenPGP < 0 # tried hOpenPGP-2.9.8, but its *library* requires the disabled package: ixset-typed
-        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant >=0.9 && < 0.13 and the snapshot contains servant-0.20.1
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires servant-client >=0.9 && < 0.13 and the snapshot contains servant-client-0.20
         - hackernews < 0 # tried hackernews-1.4.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
@@ -6889,7 +6880,7 @@ packages:
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires bytestring >=0.11.3 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - hakyllbars < 0 # tried hakyllbars-1.0.1.0, but its *library* requires text >=2.0.2 && < 2.1 and the snapshot contains text-2.1.1
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *executable* requires optparse-applicative >=0.11 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
-        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires ansi-terminal >=0.9 && < 0.12 and the snapshot contains ansi-terminal-1.0.2
+        - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires ansi-terminal >=0.9 && < 0.12 and the snapshot contains ansi-terminal-1.1
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path >=0.5 && < 0.9 and the snapshot contains path-0.9.5
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires path-io >=1.2 && < 1.7 and the snapshot contains path-io-1.8.1
         - hapistrano < 0 # tried hapistrano-0.4.8.0, but its *library* requires time >=1.5 && < 1.11 and the snapshot contains time-1.12.2
@@ -6921,7 +6912,7 @@ packages:
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
         - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
+        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.3.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
         - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -6937,7 +6928,7 @@ packages:
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5
         - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
+        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.3.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Diff >=0.3 && < 0.4 and the snapshot contains Diff-0.5
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
@@ -6968,7 +6959,7 @@ packages:
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
+        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.3.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
         - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
@@ -6980,10 +6971,9 @@ packages:
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
-        - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires stm-containers >=0.2 && < 1 || >=1.1 && < 1.2 and the snapshot contains stm-containers-1.2.0.3
-        - haskey-btree < 0 # tried haskey-btree-0.3.0.1, but its *library* requires text >=1.2.1 && < 2 and the snapshot contains text-2.1.1
+        - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires unix >=2.7.1.0 && < 2.8 and the snapshot contains unix-2.8.4.0
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
-        - haskoin-store < 0 # tried haskoin-store-1.3.0, but its *library* requires the disabled package: statsd-rupp
+        - haskoin-store < 0 # tried haskoin-store-1.5.0, but its *library* requires the disabled package: statsd-rupp
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires bytestring >=0.10.2.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *executable* requires optparse-applicative >=0.11 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - hasmin < 0 # tried hasmin-1.0.3, but its *library* requires attoparsec >=0.12 && < 0.14 and the snapshot contains attoparsec-0.14.4
@@ -6992,7 +6982,7 @@ packages:
         - hasql-queue < 0 # tried hasql-queue-1.2.0.2, but its *executable* requires the disabled package: tmp-postgres
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires aeson >=0.6 && < 2.1 and the snapshot contains aeson-2.2.1.0
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires text >=1.2.1.0 && < 1.3 and the snapshot contains text-2.1.1
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires time >=1.4 && < 1.10 and the snapshot contains time-1.12.2
         - haxl < 0 # tried haxl-2.4.0.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
@@ -7000,7 +6990,7 @@ packages:
         - hedgehog-fakedata < 0 # tried hedgehog-fakedata-0.0.1.5, but its *library* requires hedgehog >=0.1 && < 1.3 and the snapshot contains hedgehog-1.4
         - hedgehog-optics < 0 # tried hedgehog-optics-1.0.0.3, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - hedgehog-optics < 0 # tried hedgehog-optics-1.0.0.3, but its *library* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
-        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-1.0.2
+        - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-1.1
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-2.3.1
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
@@ -7028,16 +7018,16 @@ packages:
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
         - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires aeson >=0.7 && < 1.4 and the snapshot contains aeson-2.2.1.0
-        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.4.0
         - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires QuickCheck >=2.8 && < 2.11 and the snapshot contains QuickCheck-2.14.3
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires aeson >=0.11 && < 1.4 and the snapshot contains aeson-2.2.1.0
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.4.0
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hjsonpointer >=1.1 && < 1.4 and the snapshot contains hjsonpointer-1.5.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-client >=0.4.30 && < 0.6 and the snapshot contains http-client-0.7.16
+        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-client >=0.4.30 && < 0.6 and the snapshot contains http-client-0.7.17
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-types >=0.8 && < 0.10 and the snapshot contains http-types-0.12.4
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires profunctors >=5.0 && < 5.3 and the snapshot contains profunctors-5.6.2
         - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires protolude >=0.1.10 && < 0.3 and the snapshot contains protolude-0.3.4
@@ -7060,6 +7050,7 @@ packages:
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires split < =0.2.3.4 and the snapshot contains split-0.2.5
         - holy-project < 0 # tried holy-project-0.2.0.1, but its *library* requires the disabled package: hastache
         - hopfli < 0 # tried hopfli-0.2.2.1, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
+        - hopfli < 0 # tried hopfli-0.2.2.1, but its *library* requires zlib >=0.5.4 && < 0.7 and the snapshot contains zlib-0.7.0.0
         - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires hpack >=0.35 && < 0.36 and the snapshot contains hpack-0.36.0
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires aeson >=0.7.1 && < 1.3 and the snapshot contains aeson-2.2.1.0
         - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -7082,7 +7073,7 @@ packages:
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires time >=1.9.0.0 && < 1.10.0.0 and the snapshot contains time-1.12.2
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector >=0.11.0.0 && < 0.13.0.0 and the snapshot contains vector-0.13.1.0
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector-algorithms >=0.8.0.0 && < 0.9.0.0 and the snapshot contains vector-algorithms-0.9.0.1
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.10.2.0
+        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.10.3.0
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.19.1.0
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.8.2
         - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7099,7 +7090,7 @@ packages:
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.8.2
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser >=8.10 && < 8.11 and the snapshot contains ghc-lib-parser-9.8.2.20240223
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires hlint >=3.0.0 && < 3.3.0 and the snapshot contains hlint-3.8
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.16
+        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.17
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.2.3
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
         - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7150,9 +7141,9 @@ packages:
         - hw-succinct < 0 # tried hw-succinct-0.1.0.1, but its *library* requires the disabled package: hw-rankselect
         - hw-xml < 0 # tried hw-xml-0.5.1.2, but its *library* requires the disabled package: hw-balancedparens
         - hw-xml < 0 # tried hw-xml-0.5.1.2, but its *library* requires the disabled package: hw-rankselect
-        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.10.2.0
+        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.10.3.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.2.1.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-terminal < 0.12 and the snapshot contains ansi-terminal-1.0.2
+        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-terminal < 0.12 and the snapshot contains ansi-terminal-1.1
         - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-wl-pprint < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - idris < 0 # tried idris-1.3.4, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.12.1.0
         - idris < 0 # tried idris-1.3.4, but its *library* requires deepseq < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -7201,12 +7192,12 @@ packages:
         - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
         - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.1
-        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.1
+        - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.2
         - irc-client < 0 # tried irc-client-1.1.2.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires network-conduit-tls >=1.1 && < 1.4 and the snapshot contains network-conduit-tls-1.4.0
         - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.1
+        - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.2
         - irc-conduit < 0 # tried irc-conduit-0.3.0.6, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires attoparsec >=0.13.0.1 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - irc-dcc < 0 # tried irc-dcc-2.0.1, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -7224,17 +7215,10 @@ packages:
         - javascript-extras < 0 # tried javascript-extras-0.5.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - jmacro-rpc-happstack < 0 # tried jmacro-rpc-happstack-0.3.2, but its *library* requires the disabled package: jmacro-rpc
         - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: jmacro-rpc
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires Cabal >=2.4 && < 3.7 and the snapshot contains Cabal-3.10.2.0
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base >=4.5 && < 4.17 and the snapshot contains base-4.19.1.0
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires base-compat >=0.9.0 && < 0.12 and the snapshot contains base-compat-0.13.1
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires lens >=4.12.3 && < 4.20 and the snapshot contains lens-5.2.3
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires text >=0.11.0.6 && < 1.3 and the snapshot contains text-2.1.1
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires the disabled package: jsaddle
-        - jsaddle-dom < 0 # tried jsaddle-dom-0.9.5.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - json-alt < 0 # tried json-alt-1.0.0, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.2.1.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires lens >=4.1 && < 4.20 and the snapshot contains lens-5.2.3
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires smallcheck >=1.0 && < 1.2 and the snapshot contains smallcheck-1.2.1.1
@@ -7257,7 +7241,7 @@ packages:
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.16
+        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.17
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
         - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires websockets >0.10 && < 0.13 and the snapshot contains websockets-0.13.0.0
@@ -7303,7 +7287,6 @@ packages:
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
         - language-python < 0 # tried language-python-0.5.8, but its *library* requires the disabled package: monads-tf
-        - language-thrift < 0 # tried language-thrift-0.12.0.1, but its *library* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.21.0.0
         - learn-physics < 0 # tried learn-physics-0.6.6, but its *library* requires the disabled package: vector-space
         - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
@@ -7326,8 +7309,10 @@ packages:
         - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires transformers ^>=0.5.6.2 and the snapshot contains transformers-0.6.1.0
         - libmpd < 0 # tried libmpd-0.10.0.0, but its *library* requires text >=0.11 && < 2 and the snapshot contains text-2.1.1
         - libraft < 0 # tried libraft-0.5.0.0, but its *library* requires the disabled package: ekg
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.2.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.3.0
         - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.19.1.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires tar >=0.5.1 && < 0.6 and the snapshot contains tar-0.6.2.0
+        - licensor < 0 # tried licensor-0.5.0, but its *library* requires zlib >=0.6.2 && < 0.7 and the snapshot contains zlib-0.7.0.0
         - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
         - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.6.1
@@ -7337,7 +7322,7 @@ packages:
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - loc < 0 # tried loc-0.2.0.0, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires aeson ^>=1.4 and the snapshot contains aeson-2.2.1.0
-        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires ansi-terminal >=0.7 && < 1.0 and the snapshot contains ansi-terminal-1.0.2
+        - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires ansi-terminal >=0.7 && < 1.0 and the snapshot contains ansi-terminal-1.1
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mmorph ^>=1.1 and the snapshot contains mmorph-1.2.0
         - log-warper < 0 # tried log-warper-1.9.0, but its *library* requires mtl ^>=2.2.1 and the snapshot contains mtl-2.3.1
@@ -7354,7 +7339,7 @@ packages:
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.20.1
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant-client >=0.11 && < 0.14 and the snapshot contains servant-client-0.20
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires text >=1.2.2.2 && < 2 and the snapshot contains text-2.1.1
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires tls >=1.3.9 && < 2 and the snapshot contains tls-2.0.1
+        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires tls >=1.3.9 && < 2 and the snapshot contains tls-2.0.2
         - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires websockets >=0.10.0.0 && < 0.11 || >=0.12.2.0 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - lxd-client-config < 0 # tried lxd-client-config-0.1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
         - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires bytestring >=0.9.1 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -7363,7 +7348,6 @@ packages:
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires the disabled package: machines-io
         - machines-directory < 0 # tried machines-directory-7.0.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: ekg-wai
-        - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: envy
         - magicbane < 0 # tried magicbane-0.5.1, but its *library* requires the disabled package: refined
         - mail-pool < 0 # tried mail-pool-2.2.3, but its *library* requires the disabled package: HaskellNet
         - mail-pool < 0 # tried mail-pool-2.2.3, but its *library* requires the disabled package: HaskellNet-SSL
@@ -7372,16 +7356,16 @@ packages:
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.6.1
         - mandrill < 0 # tried mandrill-0.5.7.0, but its *library* requires text >=1.0.0.0 && < 2.1 and the snapshot contains text-2.1.1
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires aeson >=0.11 && < 1.3 and the snapshot contains aeson-2.2.1.0
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.16
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.17
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.2.3
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires text-icu >=0.6 && < 0.8 and the snapshot contains text-icu-0.8.0.4
+        - marvin < 0 # tried marvin-0.2.5, but its *library* requires text-icu >=0.6 && < 0.8 and the snapshot contains text-icu-0.8.0.5
         - marvin < 0 # tried marvin-0.2.5, but its *library* requires the disabled package: marvin-interpolate
         - massiv-persist < 0 # tried massiv-persist-1.0.0.3, but its *library* requires the disabled package: persist
         - mbox < 0 # tried mbox-0.3.4, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires extra >=1.6.14 && < 1.7 and the snapshot contains extra-1.7.14
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires formatting >=6.3.7 && < 6.4 and the snapshot contains formatting-7.2.0
-        - mbug < 0 # tried mbug-1.3.2, but its *library* requires http-client >=0.5.14 && < 0.6 and the snapshot contains http-client-0.7.16
+        - mbug < 0 # tried mbug-1.3.2, but its *library* requires http-client >=0.5.14 && < 0.6 and the snapshot contains http-client-0.7.17
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires optparse-applicative >=0.14.3.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - mbug < 0 # tried mbug-1.3.2, but its *library* requires scalpel-core >=0.5.1 && < 0.6 and the snapshot contains scalpel-core-0.6.2.2
@@ -7392,7 +7376,7 @@ packages:
         - medea < 0 # tried medea-1.2.0, but its *library* requires bytestring ^>=0.10.8.2 and the snapshot contains bytestring-0.12.1.0
         - medea < 0 # tried medea-1.2.0, but its *library* requires deepseq ^>=1.4.4.0 and the snapshot contains deepseq-1.5.0.0
         - medea < 0 # tried medea-1.2.0, but its *library* requires free ^>=5.1.3 and the snapshot contains free-5.2
-        - medea < 0 # tried medea-1.2.0, but its *library* requires hashable >=1.2.7.0 && < 1.4.0.0 and the snapshot contains hashable-1.4.3.0
+        - medea < 0 # tried medea-1.2.0, but its *library* requires hashable >=1.2.7.0 && < 1.4.0.0 and the snapshot contains hashable-1.4.4.0
         - medea < 0 # tried medea-1.2.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.1.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires vector ^>=0.12.0.3 and the snapshot contains vector-0.13.1.0
@@ -7406,7 +7390,7 @@ packages:
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires regex-tdfa >=1.2.3.1 && < 1.3 and the snapshot contains regex-tdfa-1.3.2.2
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *executable* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
-        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires ansi-terminal >=0.6.2.3 && < 0.12 and the snapshot contains ansi-terminal-1.0.2
+        - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires ansi-terminal >=0.6.2.3 && < 0.12 and the snapshot contains ansi-terminal-1.1
         - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires bytestring >=0.10.4 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -7414,7 +7398,7 @@ packages:
         - microlens-process < 0 # tried microlens-process-0.2.0.2, but its *library* requires microlens >=0.3 && < 0.4.13 and the snapshot contains microlens-0.4.13.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.6
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.1
@@ -7429,9 +7413,9 @@ packages:
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires resource-pool >=0.2.3.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires semigroups >=0.16.2.2 && < 0.19 and the snapshot contains semigroups-0.20
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - milena < 0 # tried milena-0.5.4.0, but its *library* requires zlib >=0.6.1.2 && < 0.7 and the snapshot contains zlib-0.7.0.0
         - mini-egison < 0 # tried mini-egison-1.0.0, but its *library* requires the disabled package: egison-pattern-src-th-mode
         - minio-hs < 0 # tried minio-hs-1.7.0, but its *library* requires the disabled package: connection
-        - miso < 0 # tried miso-1.8.3.0, but its *library* requires the disabled package: jsaddle
         - model < 0 # tried model-0.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *executable* requires the disabled package: pipes-text
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
@@ -7547,13 +7531,14 @@ packages:
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* requires numhask >=0.3 && < 0.6 and the snapshot contains numhask-0.11.1.0
         - ochintin-daicho < 0 # tried ochintin-daicho-0.3.4.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - oeis < 0 # tried oeis-0.3.10, but its *library* requires HTTP >=4000.2 && < 4000.4 and the snapshot contains HTTP-4000.4.1
-        - opaleye < 0 # tried opaleye-0.10.2.1, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
+        - opaleye < 0 # tried opaleye-0.10.3.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - opml-conduit < 0 # tried opml-conduit-0.9.0.0, but its *library* requires the disabled package: refined
         - options < 0 # tried options-1.2.1.2, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
-        - ormolu < 0 # tried ormolu-0.7.4.0, but its *library* requires the disabled package: MemoTrie
+        - ormolu < 0 # tried ormolu-0.7.4.0, but its *library* requires ansi-terminal >=0.10 && < 1.1 and the snapshot contains ansi-terminal-1.1
         - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
-        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.2.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.3.0
+        - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires tar >=0.4 && < 0.6 and the snapshot contains tar-0.6.2.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - pairing < 0 # tried pairing-1.1.0, but its *library* requires groups >=0.4.1 && < 0.5 and the snapshot contains groups-0.5.3
@@ -7593,11 +7578,11 @@ packages:
         - perfect-vector-shuffle < 0 # tried perfect-vector-shuffle-0.1.1.1, but its *library* requires vector >=0.12.0 && < 0.13 and the snapshot contains vector-0.13.1.0
         - persist < 0 # tried persist-0.1.1.5, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires mysql-haskell >=0.8.0.0 && < 1.0 and the snapshot contains mysql-haskell-1.1.4
-        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-2.0.1
+        - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-2.0.2
         - persistent-redis < 0 # tried persistent-redis-2.13.0.1, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires postgresql-simple >=0.6 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.2
-        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.21
+        - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires scotty >=0.11.0 && < 0.12 and the snapshot contains scotty-0.22
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires text >=1.1.0 && < 2 and the snapshot contains text-2.1.1
         - pg-harness-server < 0 # tried pg-harness-server-0.6.2, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - picedit < 0 # tried picedit-0.2.3.0, but its *executable* requires the disabled package: cli
@@ -7605,23 +7590,23 @@ packages:
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
         - picosat < 0 # tried picosat-0.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.2.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.3.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires aeson >=1.3 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires base >=4.11 && < 4.12 and the snapshot contains base-4.19.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires binary-orphans >=0.1 && < 0.2 and the snapshot contains binary-orphans-1.0.4.1
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.3.0
+        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.4.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires shake >=0.16 && < 0.17 and the snapshot contains shake-0.19.8
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - pier < 0 # tried pier-0.3.0.0, but its *executable* requires yaml >=0.8 && < 0.11 and the snapshot contains yaml-0.11.11.2
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.2.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.3.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base >=4.11 && < 4.12 and the snapshot contains base-4.19.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base64-bytestring >=1.0 && < 1.1 and the snapshot contains base64-bytestring-1.2.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.3.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.4.0
+        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires shake >=0.16.4 && < 0.17 and the snapshot contains shake-0.19.8
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
@@ -7674,8 +7659,8 @@ packages:
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires aeson >=1.4.7 && < 1.6 and the snapshot contains aeson-2.2.1.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.19.1.0
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql >=1.4 && < 1.5 and the snapshot contains hasql-1.6.4.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-dynamic-statements ==0.3.1 and the snapshot contains hasql-dynamic-statements-0.3.1.4
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql >=1.4 && < 1.5 and the snapshot contains hasql-1.6.4.3
+        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-dynamic-statements ==0.3.1 and the snapshot contains hasql-dynamic-statements-0.3.1.5
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-pool >=0.5 && < 0.6 and the snapshot contains hasql-pool-0.10.1
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-transaction >=1.0.1 && < 1.1 and the snapshot contains hasql-transaction-1.1.0.1
         - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires jose >=0.8.1 && < 0.9 and the snapshot contains jose-0.11
@@ -7699,23 +7684,6 @@ packages:
         - profiteur < 0 # tried profiteur-0.4.7.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - profiteur < 0 # tried profiteur-0.4.7.0, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.1
-        - proto-lens < 0 # tried proto-lens-0.7.1.4, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens < 0 # tried proto-lens-0.7.1.4, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - proto-lens < 0 # tried proto-lens-0.7.1.4, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - proto-lens < 0 # tried proto-lens-0.7.1.4, but its *library* requires ghc-prim >=0.4 && < 0.11 and the snapshot contains ghc-prim-0.11.0
-        - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.12, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-arbitrary < 0 # tried proto-lens-arbitrary-0.1.2.12, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - proto-lens-optparse < 0 # tried proto-lens-optparse-0.1.1.11, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.2.0, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.8.0.0, but its *executable* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.8.0.0, but its *executable* requires ghc >=8.2 && < 9.8 and the snapshot contains ghc-9.8.2
-        - proto-lens-protoc < 0 # tried proto-lens-protoc-0.8.0.0, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-runtime < 0 # tried proto-lens-runtime-0.7.0.5, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-runtime < 0 # tried proto-lens-runtime-0.7.0.5, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - proto-lens-runtime < 0 # tried proto-lens-runtime-0.7.0.5, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.7, but its *library* requires base >=4.10 && < 4.19 and the snapshot contains base-4.19.1.0
-        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.7, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.7, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
         - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.19.1.0
         - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.19.1.0
@@ -7729,7 +7697,7 @@ packages:
         - qrcode-core < 0 # tried qrcode-core-0.9.9, but its *library* requires text >=1.2.2.0 && < 2.1 and the snapshot contains text-2.1.1
         - qrcode-juicypixels < 0 # tried qrcode-juicypixels-0.8.5, but its *library* requires bytestring >=0.10.6.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - qrcode-juicypixels < 0 # tried qrcode-juicypixels-0.8.5, but its *library* requires text >=1.2.2.0 && < 2.1 and the snapshot contains text-2.1.1
-        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-1.0.2
+        - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-1.1
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires ansi-wl-pprint >=0.6 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - queue-sheet < 0 # tried queue-sheet-0.7.0.2, but its *executable* requires optparse-applicative >=0.14 && < 0.18 and the snapshot contains optparse-applicative-0.18.1.0
@@ -7748,7 +7716,7 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires constraints >=0.9.1 && < 0.11 and the snapshot contains constraints-0.14
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires extensible >=0.4.7.2 && < 0.4.11 and the snapshot contains extensible-0.9
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.6
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.16
+        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.17
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.2.3
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.2
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
@@ -7815,11 +7783,9 @@ packages:
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires time >=1.4.2 && < 1.10 and the snapshot contains time-1.12.2
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - riak-protobuf < 0 # tried riak-protobuf-0.25.0.0, but its *library* requires the disabled package: proto-lens
-        - riak-protobuf < 0 # tried riak-protobuf-0.25.0.0, but its *library* requires the disabled package: proto-lens-runtime
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires network >=2.6 && < 2.8 and the snapshot contains network-3.1.4.0
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
@@ -7875,7 +7841,7 @@ packages:
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.2.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires base >=4.11 && < 4.14 and the snapshot contains base-4.19.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires http-client >=0.5.6 && < 0.7 and the snapshot contains http-client-0.7.16
+        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires http-client >=0.5.6 && < 0.7 and the snapshot contains http-client-0.7.17
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires lens >=4.15 && < 4.20 and the snapshot contains lens-5.2.3
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires optparse-applicative >=0.12 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.1.1
@@ -8001,7 +7967,7 @@ packages:
         - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.19.1.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.2
         - smash < 0 # tried smash-0.1.3, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
-        - smash < 0 # tried smash-0.1.3, but its *library* requires hashable ^>=1.3 and the snapshot contains hashable-1.4.3.0
+        - smash < 0 # tried smash-0.1.3, but its *library* requires hashable ^>=1.3 and the snapshot contains hashable-1.4.4.0
         - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires aeson >=2.0 && < 2.1 and the snapshot contains aeson-2.2.1.0
         - smash-aeson < 0 # tried smash-aeson-0.2.0.1, but its *library* requires base >=4.1 && < 4.17 and the snapshot contains base-4.19.1.0
         - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.19.1.0
@@ -8015,7 +7981,7 @@ packages:
         - soap < 0 # tried soap-0.2.3.6, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
         - soap-openssl < 0 # tried soap-openssl-0.1.0.2, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
         - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
-        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires tls >=1.3.8 && < 2.0 and the snapshot contains tls-2.0.1
+        - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires tls >=1.3.8 && < 2.0 and the snapshot contains tls-2.0.2
         - socket < 0 # tried socket-0.8.3.0, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - socket-activation < 0 # tried socket-activation-0.1.0.2, but its *library* requires network >=2.3 && < 2.9 and the snapshot contains network-3.1.4.0
         - spacecookie < 0 # tried spacecookie-1.0.0.2, but its *library* requires the disabled package: filepath-bytestring
@@ -8024,11 +7990,12 @@ packages:
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires jvm >=0.4.0.1 && < 0.5 and the snapshot contains jvm-0.6.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: jni
         - sparse-linear-algebra < 0 # tried sparse-linear-algebra-0.3.1, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.19.1.0
-        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires Cabal >=1.24 && < 3.5 and the snapshot contains Cabal-3.10.2.0
+        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires Cabal >=1.24 && < 3.5 and the snapshot contains Cabal-3.10.3.0
         - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires ad >=4.2 && < 4.5 and the snapshot contains ad-4.5.5
         - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires Cabal ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0 || ^>=3.4.0.0 || ^>=3.6.0.0 and the snapshot contains Cabal-3.10.2.0
+        - sparse-tensor < 0 # tried sparse-tensor-0.2.1.5, but its *library* requires zlib >=0.6 && < 0.7 and the snapshot contains zlib-0.7.0.0
+        - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires Cabal ^>=2.4.0.1 || ^>=3.0.0.0 || ^>=3.2.0.0 || ^>=3.4.0.0 || ^>=3.6.0.0 and the snapshot contains Cabal-3.10.3.0
         - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires base >=4.3.0.0 && < 4.17 and the snapshot contains base-4.19.1.0
         - spdx < 0 # tried spdx-1.0.0.3, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - special-values < 0 # tried special-values-0.1.0.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -8095,11 +8062,11 @@ packages:
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires bytestring ^>=0.11 and the snapshot contains bytestring-0.12.1.0
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires text ^>=1.2.5 || ^>=2.0 and the snapshot contains text-2.1.1
-        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable >=1.3 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable >=1.3 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.21.0.0
-        - strongweak < 0 # tried strongweak-0.6.0, but its *library* requires text >=1.2.5.0 && < 2.1 and the snapshot contains text-2.1.1
-        - strongweak < 0 # tried strongweak-0.6.0, but its *library* requires the disabled package: refined1
-        - strongweak < 0 # tried strongweak-0.6.0, but its *library* requires vector-sized >=1.5.0 && < 1.6 and the snapshot contains vector-sized-1.6.1
+        - strongweak < 0 # tried strongweak-0.6.1, but its *library* requires text >=1.2.5.0 && < 2.1 and the snapshot contains text-2.1.1
+        - strongweak < 0 # tried strongweak-0.6.1, but its *library* requires the disabled package: refined1
+        - strongweak < 0 # tried strongweak-0.6.1, but its *library* requires vector-sized >=1.5.0 && < 1.6 and the snapshot contains vector-sized-1.6.1
         - structured-cli < 0 # tried structured-cli-2.7.0.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
@@ -8131,7 +8098,7 @@ packages:
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires containers >=0.5.0.0 && < 0.6 and the snapshot contains containers-0.6.8
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-api-data >=0.3.4 && < 0.4 and the snapshot contains http-api-data-0.6
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-media >=0.4 && < 0.8 and the snapshot contains http-media-0.8.1.1
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires katip >=0.4 && < 0.6 and the snapshot contains katip-0.8.8.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires network >=2.6.2 && < 2.8 and the snapshot contains network-3.1.4.0
@@ -8143,12 +8110,12 @@ packages:
         - sydtest-persistent-postgresql < 0 # tried sydtest-persistent-postgresql-0.2.0.3, but its *library* requires the disabled package: tmp-postgres
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.1, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.1, but its *library* requires text ^>=1.2.4 || ^>=2.0 and the snapshot contains text-2.1.1
-        - taffybar < 0 # tried taffybar-4.0.1, but its *library* requires scotty >=0.11 && < 0.13 and the snapshot contains scotty-0.21
+        - taffybar < 0 # tried taffybar-4.0.1, but its *library* requires scotty >=0.11 && < 0.13 and the snapshot contains scotty-0.22
         - tasty-hunit-compat < 0 # tried tasty-hunit-compat-0.2.0.1, but its *library* requires tasty < 1.5 and the snapshot contains tasty-1.5
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.8
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.5
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires time >=1.5 && < 1.9 and the snapshot contains time-1.12.2
-        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires ansi-terminal >=0.8 && < 0.12 and the snapshot contains ansi-terminal-1.0.2
+        - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires ansi-terminal >=0.8 && < 0.12 and the snapshot contains ansi-terminal-1.1
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires tasty >=0.1 && < 1.5 and the snapshot contains tasty-1.5
         - tasty-test-reporter < 0 # tried tasty-test-reporter-0.1.1.4, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
@@ -8162,7 +8129,7 @@ packages:
         - text-all < 0 # tried text-all-0.4.2, but its *library* requires text-format >=0.3.1 && < 0.3.2 and the snapshot contains text-format-0.3.2.1
         - text-format < 0 # tried text-format-0.3.2.1, but its *library* requires base >=4.3 && < 4.19 and the snapshot contains base-4.19.1.0
         - text-generic-pretty < 0 # tried text-generic-pretty-1.2.1, but its *library* requires wl-pprint-text < 1.2 and the snapshot contains wl-pprint-text-1.2.0.2
-        - th-deepstrict < 0 # tried th-deepstrict-0.1.0.0, but its *library* requires th-abstraction >=0.7.0 && < 0.8 and the snapshot contains th-abstraction-0.6.0.0
+        - th-deepstrict < 0 # tried th-deepstrict-0.1.1.0, but its *library* requires th-abstraction >=0.7.0 && < 0.8 and the snapshot contains th-abstraction-0.6.0.0
         - th-to-exp < 0 # tried th-to-exp-0.0.1.1, but its *library* requires template-haskell >=2.11.0.0 && < 2.13 and the snapshot contains template-haskell-2.21.0.0
         - these-skinny < 0 # tried these-skinny-0.7.5, but its *library* requires base >=4.4 && < 4.19 and the snapshot contains base-4.19.1.0
         - through-text < 0 # tried through-text-0.1.0.0, but its *library* requires base >=4.3 && < 4.17 and the snapshot contains base-4.19.1.0
@@ -8172,7 +8139,7 @@ packages:
         - thyme < 0 # tried thyme-0.4, but its *library* requires template-haskell >=2.7 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - time-parsers < 0 # tried time-parsers-0.2, but its *library* requires base >=4.6 && < 4.19 and the snapshot contains base-4.19.1.0
         - time-parsers < 0 # tried time-parsers-0.2, but its *library* requires template-haskell >=2.8.0.0 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
-        - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.1
+        - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.2
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.19.1.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - tonaparser < 0 # tried tonaparser-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.19.1.0
@@ -8197,7 +8164,7 @@ packages:
         - tries < 0 # tried tries-0.0.6.1, but its *library* requires the disabled package: rose-trees
         - triplesec < 0 # tried triplesec-0.2.2.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - true-name < 0 # tried true-name-0.1.0.3, but its *library* requires template-haskell >=2.7 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.3.0
+        - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
@@ -8223,7 +8190,6 @@ packages:
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
         - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires timerep >=2.0.0.2 && < 2.1 and the snapshot contains timerep-2.1.0.0
-        - unbound-generics < 0 # tried unbound-generics-0.4.3, but its *library* requires ansi-wl-pprint >=0.6.7.2 && < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
         - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
         - unfork < 0 # tried unfork-1.0.0.1, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
@@ -8282,7 +8248,7 @@ packages:
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.2.1.0
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.16
+        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
@@ -8334,7 +8300,7 @@ packages:
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.16
+        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.17
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
         - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
@@ -8394,7 +8360,7 @@ packages:
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires yeshql-core ==4.1.1.2 and the snapshot contains yeshql-core-4.2.0.0
         - yesod-alerts < 0 # tried yesod-alerts-0.1.3.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.1.1
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires persistent >=2.1 && < 2.8 and the snapshot contains persistent-2.14.6.1
-        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-auth >=1.4.18 && < 1.5 and the snapshot contains yesod-auth-1.6.11.2
+        - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-auth >=1.4.18 && < 1.5 and the snapshot contains yesod-auth-1.6.11.3
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-core >=1.4 && < 1.5 and the snapshot contains yesod-core-1.6.25.1
         - yesod-auth-bcryptdb < 0 # tried yesod-auth-bcryptdb-0.3.0.1, but its *library* requires yesod-form >=1.4 && < 1.5 and the snapshot contains yesod-form-1.7.6
         - yesod-fb < 0 # tried yesod-fb-0.6.1, but its *library* requires the disabled package: fb
@@ -8424,6 +8390,7 @@ packages:
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data >=0.3 && < 0.4 and the snapshot contains http-api-data-0.6
         - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.20.1
         - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
+        - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires zlib >=0.5.4 && < 0.7 and the snapshot contains zlib-0.7.0.0
         - zm < 0 # tried zm-0.3.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - zm < 0 # tried zm-0.3.2, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - zm < 0 # tried zm-0.3.2, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -8433,7 +8400,7 @@ packages:
         - zot < 0 # tried zot-0.0.3, but its *executable* requires the disabled package: monads-tf
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
-        - zxcvbn-hs < 0 # tried zxcvbn-hs-0.3.6, but its *executable* requires the disabled package: pipes-text
+        - zxcvbn-hs < 0 # tried zxcvbn-hs-0.3.6, but its *library* requires zlib ^>=0.6 and the snapshot contains zlib-0.7.0.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.19.1.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires storable-record >=0.0.5 && < 0.0.6 and the snapshot contains storable-record-0.0.7
@@ -8785,10 +8752,9 @@ skipped-tests:
     - bugzilla-redhat # tried bugzilla-redhat-1.0.1.1, but its *test-suite* requires aeson >=0.7 && < 2.2 and the snapshot contains aeson-2.2.1.0
     - buttplug-hs-core # tried buttplug-hs-core-0.1.0.1, but its *test-suite* requires hspec >=2.7.8 && < 2.9 and the snapshot contains hspec-2.11.7
     - bytestring-trie # tried bytestring-trie-0.2.7.2, but its *test-suite* requires tasty >=0.10.1.2 && < 1.5 and the snapshot contains tasty-1.5
-    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires tasty >=1.2.3 && < 1.5 and the snapshot contains tasty-1.5
-    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-QuickCheck
-    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-described
-    - cabal-install # tried cabal-install-3.10.2.1, but its *test-suite* requires the disabled package: Cabal-tree-diff
+    - cabal-install # tried cabal-install-3.10.3.0, but its *test-suite* requires the disabled package: Cabal-QuickCheck
+    - cabal-install # tried cabal-install-3.10.3.0, but its *test-suite* requires the disabled package: Cabal-described
+    - cabal-install # tried cabal-install-3.10.3.0, but its *test-suite* requires the disabled package: Cabal-tree-diff
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires QuickCheck >=2.12 && < 2.13 and the snapshot contains QuickCheck-2.14.3
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires bytestring >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.1.0
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
@@ -8810,7 +8776,7 @@ skipped-tests:
     - dhall-yaml # tried dhall-yaml-1.2.12, but its *test-suite* requires tasty < 1.5 and the snapshot contains tasty-1.5
     - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec >=2.7.1 && < 2.9.0 and the snapshot contains hspec-2.11.7
     - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec-discover >=2.7.1 && < 2.9.0 and the snapshot contains hspec-discover-2.11.7
-    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: network-transport-tcp # revisit, now that network-transport-tcp has been re-enabled
+    - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.3
     - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: rematch
     - doldol # tried doldol-0.4.1.2, but its *test-suite* requires the disabled package: test-framework-th
     - drawille # tried drawille-0.1.3.0, but its *test-suite* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
@@ -8848,7 +8814,6 @@ skipped-tests:
     - geojson # tried geojson-4.1.1, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.7
     - geojson # tried geojson-4.1.1, but its *test-suite* requires tasty >=0.8 && < 0.13 || >=1.0 && < 1.5 and the snapshot contains tasty-1.5
     - ghc-prof # tried ghc-prof-1.4.1.12, but its *test-suite* requires tasty < 1.5 and the snapshot contains tasty-1.5
-    - ghc-source-gen # tried ghc-source-gen-0.4.4.1, but its *test-suite* requires tasty >=1.0 && < 1.5 and the snapshot contains tasty-1.5
     - ginger # tried ginger-0.10.5.2, but its *test-suite* requires tasty >=1.2 && < 1.5 and the snapshot contains tasty-1.5
     - greskell # tried greskell-2.0.3.0, but its *test-suite* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.1.0
     - hasbolt # tried hasbolt-0.1.7.0, but its *test-suite* requires hspec >=2.4.1 && < 2.11 and the snapshot contains hspec-2.11.7
@@ -8867,7 +8832,6 @@ skipped-tests:
     - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
     - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
     - haskell-tools-rewrite # tried haskell-tools-rewrite-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskey # tried haskey-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires lens >=4.12 && < 5 and the snapshot contains lens-5.2.3
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
     - haskoin-core # tried haskoin-core-1.1.0, but its *test-suite* requires base64 >=0.4 && < 0.5 and the snapshot contains base64-1.0
@@ -8907,7 +8871,6 @@ skipped-tests:
     - linear-accelerate # tried linear-accelerate-0.7.0.0, but its *test-suite* requires doctest >=0.11.1 && < 0.17 and the snapshot contains doctest-0.22.2
     - loc # tried loc-0.2.0.0, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
     - loc # tried loc-0.2.0.0, but its *test-suite* requires hspec-hedgehog ^>=0.0.1 and the snapshot contains hspec-hedgehog-0.1.1.0
-    - logict # tried logict-0.8.1.0, but its *test-suite* requires tasty < 1.5 and the snapshot contains tasty-1.5
     - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.3
     - lxd-client # tried lxd-client-0.1.0.6, but its *test-suite* requires turtle >=1.3.6 && < 1.6 and the snapshot contains turtle-1.6.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires Glob >=0.7 && < 0.9 and the snapshot contains Glob-0.10.2
@@ -8924,12 +8887,11 @@ skipped-tests:
     - monad-peel # tried monad-peel-0.3, but its *test-suite* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - mwc-random # tried mwc-random-0.15.0.2, but its *test-suite* requires doctest >=0.15 && < 0.20 and the snapshot contains doctest-0.22.2
     - nakadi-client # tried nakadi-client-0.7.0.0, but its *test-suite* requires classy-prelude >=1.4.0 && < 1.5.0 and the snapshot contains classy-prelude-1.5.0.3
-    - network-messagepack-rpc-websocket # tried network-messagepack-rpc-websocket-0.1.1.1, but its *test-suite* requires the disabled package: envy
     - next-ref # tried next-ref-0.1.0.2, but its *test-suite* requires hspec >=2 && < 2.3 and the snapshot contains hspec-2.11.7
     - numhask-prelude # tried numhask-prelude-0.5.0, but its *test-suite* requires doctest >=0.13 && < 0.17 and the snapshot contains doctest-0.22.2
     - o-clock # tried o-clock-1.4.0, but its *test-suite* requires the disabled package: tasty-hunit-compat
     - oops # tried oops-0.2.0.1, but its *test-suite* requires doctest >=0.16.2 && < 0.22 and the snapshot contains doctest-0.22.2
-    - opaleye # tried opaleye-0.10.2.1, but its *test-suite* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
+    - opaleye # tried opaleye-0.10.3.0, but its *test-suite* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
     - options # tried options-1.2.1.2, but its *test-suite* requires the disabled package: patience
     - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.7
     - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec-discover >=2.2 && < 2.8 and the snapshot contains hspec-discover-2.11.7
@@ -8986,12 +8948,11 @@ skipped-tests:
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
     - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.20
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.7
-    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires the disabled package: network-transport-tcp # revisit, now that network-transport-tcp has been re-enabled
+    - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.3
     - sexpr-parser # tried sexpr-parser-0.2.2.0, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.7
     - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.11.7
-    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-1.0.2
+    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-1.1
     - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
-    - skews # tried skews-0.1.0.3, but its *test-suite* requires the disabled package: envy
     - slack-web # tried slack-web-1.6.1.0, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.11 and the snapshot contains hspec-discover-2.11.7
     - sparse-tensor # tried sparse-tensor-0.2.1.5, but its *test-suite* requires tasty >=0.11 && < 1.5 and the snapshot contains tasty-1.5
     - spdx # tried spdx-1.0.0.3, but its *test-suite* requires base-compat ^>=0.10.5 || ^>=0.11.1 || ^>=0.12.1 and the snapshot contains base-compat-0.13.1
@@ -9005,8 +8966,6 @@ skipped-tests:
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires hspec >=2.7 && < 2.10 and the snapshot contains hspec-2.11.7
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty-discover >=4.2 && < 4.3 and the snapshot contains tasty-discover-5.0.0
-    - strongweak # tried strongweak-0.6.0, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.7
-    - strongweak # tried strongweak-0.6.0, but its *test-suite* requires hspec-discover >=2.7 && < 2.10 and the snapshot contains hspec-discover-2.11.7
     - sv # tried sv-1.4.0.1, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.4
     - sv # tried sv-1.4.0.1, but its *test-suite* requires lens >=4 && < 4.20 and the snapshot contains lens-5.2.3
     - sv # tried sv-1.4.0.1, but its *test-suite* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
@@ -9020,7 +8979,6 @@ skipped-tests:
     - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell-quickcheck
-    - tar # tried tar-0.5.1.1, but its *test-suite* requires the disabled package: bytestring-handle
     - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.7
     - tasty-discover # tried tasty-discover-5.0.0, but its *test-suite* requires hspec-core >=2.7.10 && < 2.11 and the snapshot contains hspec-core-2.11.7
     - tdigest # tried tdigest-0.3, but its *test-suite* requires tasty >=0.11.0.4 && < 1.5 and the snapshot contains tasty-1.5
@@ -9681,7 +9639,6 @@ skipped-benchmarks:
     - tz # tried tz-0.1.3.6, but its *benchmarks* requires the disabled package: thyme
     - vectortiles # tried vectortiles-1.5.1, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
     - xeno # tried xeno-0.6, but its *benchmarks* requires the disabled package: bytestring-mmap
-    - xxhash-ffi # tried xxhash-ffi-0.2.0.0, but its *benchmarks* requires the disabled package: xxhash
     # End of Benchmark bounds issues
 
 # end of skipped-benchmarks


### PR DESCRIPTION
…06cac94ba0 ("Library and exe bounds failures" renamed to "Large scale package bounds failures") and regenerated bounds.

Since the automatic boundaries have not been updated in a while (around three weeks), problems may be revealed in other packages.
