### PR TITLE
re-enable hledger-web tests / troubleshoot terminfo error

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9184,7 +9184,6 @@ expected-test-failures:
     - hexml-lens # Access to web.archive.org is unreliable.
     - hie-bios # cabal, stack, ghc; see https://github.com/commercialhaskell/stackage/issues/5025
     - hjsmin # Test-runner expects a cabal-style 'dist-newstyle' directory
-    - hledger-web # 1.33.1 test: setupTerm: Couldn't look up terminfo entry "unknown"
     - hocilib # oracle
     - http-client # httpbin issues, https://github.com/snoyberg/http-client/issues/439
     - http-client-tls # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).


### PR DESCRIPTION
Trying to reproduce terminfo-related error when running tests. https://github.com/simonmichael/hledger/issues/2157
