### PR TITLE
re-enable strongweak

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8070,8 +8070,6 @@ packages:
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires text ^>=1.2.5 || ^>=2.0 and the snapshot contains text-2.1.1
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires hashable >=1.3 && < 1.4 and the snapshot contains hashable-1.4.4.0
         - strong-path < 0 # tried strong-path-1.1.4.0, but its *library* requires template-haskell >=2.16 && < 2.18 and the snapshot contains template-haskell-2.21.0.0
-        - strongweak < 0 # tried strongweak-0.7.0, but its *library* requires the disabled package: rerefined
-        - strongweak < 0 # tried strongweak-0.7.0, but its *library* requires vector-sized >=1.5.0 && < 1.6 and the snapshot contains vector-sized-1.6.1
         - structured-cli < 0 # tried structured-cli-2.7.0.1, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive


### PR DESCRIPTION
Added all dependencies to Stackage past few weeks, and fixed some bounds.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] ~If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)~
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)