### PR TITLE
Re-add github-rest

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4905,6 +4905,7 @@ packages:
     "Brandon Chinn <brandonchinn178@gmail.com> @brandonchinn178":
         - aeson-schemas
         - fourmolu
+        - github-rest
         - graphql-client
         - hpc-lcov
         - http-api-data-qq


### PR DESCRIPTION
Removed in #7431, new version 1.2.0 replaces jwt with jose-jwt, which has been updated with crypton

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] ~If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)~
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
