### PR TITLE
remove bounds for symparsec -> type-level-show

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8459,11 +8459,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/7426
         - emacs-module < 0.2.1.1
 
-        # https://github.com/commercialhaskell/stackage/issues/7441
-        - type-level-show < 0.3
-        - singleraeh < 0.3
-        - symparsec < 1.1
-
 
     # end of Stackage upper bounds
 # end of packages


### PR DESCRIPTION
Resolves #7441 . (I left one library out of a set of updates.)

I don't know how to test this with Stackage tools. rerefined, type-level-show and symparsec all build with the latest versions of each other.