### PR TITLE
network-run-0.3 and http2-5.2.3

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5703,7 +5703,7 @@ packages:
         - network-info
         - network-ip
         - network-multicast
-        - network-run < 0.3.0 # https://github.com/commercialhaskell/stackage/issues/7444
+        - network-run
         - network-uri < 2.7.0.0 || > 2.7.0.0 # 2.7.0.0 was deprecated, don't remove bound until >2.7.0.0 is released.
         - next-ref
         - nicify-lib
@@ -6322,6 +6322,7 @@ packages:
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* requires unliftio-core >=0.1.1.0 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
+        - attoparsec-framer < 0 # tried attoparsec-framer-0.1.0.5, but its *executable* requires QuickCheck >=2.15 && < 2.16 and the snapshot contains QuickCheck-2.14.3
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires bytestring ^>=0.10.12 || ^>=0.11 and the snapshot contains bytestring-0.12.1.0
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires text ^>=1.2.4 || ^>=2.0 and the snapshot contains text-2.1.1
@@ -8464,13 +8465,6 @@ packages:
         - emacs-module < 0.2.1.1
         - json-spec-elm-servant < 0.4.1.0
 
-        # https://github.com/commercialhaskell/stackage/issues/7447
-        - attoparsec-framer < 0.1.0.5
-
-        # https://github.com/commercialhaskell/stackage/issues/7448
-        - http2 < 5.2.3
-        - http-semantics < 0.1
-
         # https://github.com/commercialhaskell/stackage/issues/7449
         - fourmolu < 0.16
 
@@ -8987,6 +8981,7 @@ skipped-tests:
     - pasta-curves # tried pasta-curves-0.0.1.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5
     - peregrin # tried peregrin-0.4.2, but its *test-suite* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - pg-transact # tried pg-transact-0.3.2.0, but its *test-suite* requires the disabled package: tmp-postgres
+    - pinch # tried pinch-0.5.1.0, but its *test-suite* requires network-run >=0.2.4 && < 0.3 and the snapshot contains network-run-0.3.0
     - pipes-category # tried pipes-category-0.3.0.0, but its *test-suite* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - pipes-extras # tried pipes-extras-1.0.15, but its *test-suite* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6322,7 +6322,6 @@ packages:
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - asciidiagram < 0 # tried asciidiagram-1.3.3.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - async-timer < 0 # tried async-timer-0.2.0.0, but its *library* requires unliftio-core >=0.1.1.0 && < 0.2 and the snapshot contains unliftio-core-0.2.1.0
-        - attoparsec-framer < 0 # tried attoparsec-framer-0.1.0.5, but its *executable* requires QuickCheck >=2.15 && < 2.16 and the snapshot contains QuickCheck-2.14.3
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires bytestring ^>=0.10.12 || ^>=0.11 and the snapshot contains bytestring-0.12.1.0
         - attoparsec-run < 0 # tried attoparsec-run-0.0.2.0, but its *library* requires text ^>=1.2.4 || ^>=2.0 and the snapshot contains text-2.1.1


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
Had to disable attoparsec-framer. But many packages use http2, so I thought it is worth it.

Fixes #7448 and #7444
