### PR TITLE
Bump crypton-connection to 0.4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8156,6 +8156,7 @@ packages:
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires the disabled package: x509-system
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires the disabled package: x509-validation
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.0.6
+        - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.7.0.0, but its *library* requires amqp >=0.22.1 && < 0.23 and the snapshot contains amqp-0.23.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.19.1.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - tonaparser < 0 # tried tonaparser-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.19.1.0
@@ -8463,10 +8464,6 @@ packages:
         - emacs-module < 0.2.1.1
         - json-spec-elm-servant < 0.4.1.0
 
-        # https://github.com/commercialhaskell/stackage/issues/7425
-        - crypton-connection < 0.4.0
-        - amqp < 0.23
-
         # https://github.com/commercialhaskell/stackage/issues/7447
         - attoparsec-framer < 0.1.0.5
 
@@ -8476,9 +8473,6 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/7449
         - fourmolu < 0.16
-
-        # https://github.com/commercialhaskell/stackage/issues/7455
-        - req < 3.13.3
 
         # https://github.com/commercialhaskell/stackage/issues/7456
         - json-spec-openapi < 0.3.1


### PR DESCRIPTION
All dependencies have been updated, except tmp-proc-rabbitmq-0.7.0.0 which doesn't accept amqp-0.23.0. @adetokunbo seems inactive since there was no response for my ping in

* https://github.com/commercialhaskell/stackage/pull/7454

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
