### PR TITLE
Set crypton flag for 'password' package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8597,6 +8597,10 @@ package-flags:
     zlib:
       pkg-config: false
 
+    # See https://github.com/commercialhaskell/stackage/issues/7474
+    password:
+      crypton: true
+
 # end of package-flags
 
 # Special configure options for individual packages


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

As noted in [the changelog of
password](https://github.com/cdepillabout/password/blob/master/password/ChangeLog.md#3040),
this newly added flag allows us to enable to crypton support. That way, we can
proactively stop worrying about the use of cryptonite here. We are trying to migrate away
from cryptonite, see #7474
