### PR TITLE
Added `serversession-backend-acid-state`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1304,6 +1304,7 @@ packages:
         - fb
         - nonce
         - serversession
+        - serversession-backend-acid-state
         - serversession-backend-persistent
         - serversession-backend-redis
         - serversession-frontend-wai
@@ -9317,6 +9318,7 @@ expected-test-failures:
     - sendgrid-v3 # Requires sendgrid API key in env #5951/closed
     - serialport # "The tests need two serial ports as command line arguments" https://github.com/jputcu/serialport/issues/30
     - servant-rate-limit # redis
+    - serversession-backend-acid-state
     - serversession-backend-persistent # persistent, see https://github.com/commercialhaskell/stackage/pull/6655#issuecomment-1198868074
     - serversession-backend-redis # redis
     - shake # Needs ghc on $PATH with some installed haskell packages


### PR DESCRIPTION
Hi @meteficha, could/should we add this package? I mean more for consistency reasons - the other backends are also present. However, the tests are currently failing. Just want to collect your feedback - and as a handle to discuss this I created this PR. No pressure.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
