### PR TITLE
Re-add wai-saml2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5077,6 +5077,7 @@ packages:
         - time-units-types
         - wai-rate-limit
         - wai-rate-limit-redis
+        - wai-saml2
 
     "Jun Narumi <narumij@gmail.com> @narumij":
         - matrix-as-xyz


### PR DESCRIPTION
wai-saml2 was removed in https://github.com/commercialhaskell/stackage/pull/7431 before it got crypton-x509 compatible.

Now wai-saml2-0.6 is out, and it has the compatibility. Since the package was
removed by a curator, and not by the author, I am allowing myself to re-add the
package to the author's section, given that the package author originally added
it themselves in #5492.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
