### PR TITLE
Use lens-5.3, disable servant-auth and some Chart, diagrams packages, etc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6189,6 +6189,9 @@ packages:
         - BiobaseXNA < 0 # tried BiobaseXNA-0.11.1.1, but its *library* requires the disabled package: PrimitiveArray
         - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires network ==2.8.0.0 and the snapshot contains network-3.2.1.0
         - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseBlast
+        - Chart < 0 # tried Chart-1.9.5, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
+        - Chart-cairo < 0 # tried Chart-cairo-1.9.4.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
+        - Chart-diagrams < 0 # tried Chart-diagrams-1.9.5.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
         - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
         - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.19.1.0
@@ -6227,6 +6230,7 @@ packages:
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
         - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: hierarchical-clustering
+        - SpatialMath < 0 # tried SpatialMath-0.2.7.1, but its *library* requires lens >=5.2.3 && < 5.3 and the snapshot contains lens-5.3.2
         - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-lucid < 0 # tried Spock-lucid-0.4.0.1, but its *library* requires the disabled package: Spock
@@ -6649,6 +6653,8 @@ packages:
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - dhall-yaml < 0 # tried dhall-yaml-1.2.12, but its *library* requires text >=0.11.1.0 && < 2.1 and the snapshot contains text-2.1.1
         - diagrams < 0 # tried diagrams-1.4.1, but its *library* requires the disabled package: diagrams-contrib
+        - diagrams-builder < 0 # tried diagrams-builder-0.8.0.6, but its *library* requires lens >=4.0 && < 5.3 and the snapshot contains lens-5.3.2
+        - diagrams-canvas < 0 # tried diagrams-canvas-1.4.1.2, but its *library* requires lens >=4.0 && < 5.3 and the snapshot contains lens-5.3.2
         - diagrams-contrib < 0 # tried diagrams-contrib-1.4.5.1, but its *library* requires linear >=1.11.3 && < 1.23 and the snapshot contains linear-1.23
         - diagrams-gtk < 0 # tried diagrams-gtk-1.4, but its *library* requires base >=4.2 && < 4.19 and the snapshot contains base-4.19.1.0
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires base >=4.7 && < 4.19 and the snapshot contains base-4.19.1.0
@@ -7436,6 +7442,7 @@ packages:
         - medea < 0 # tried medea-1.2.0, but its *library* requires mtl ^>=2.2.2 and the snapshot contains mtl-2.3.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.1.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires vector ^>=0.12.0.3 and the snapshot contains vector-0.13.1.0
+        - melf < 0 # tried melf-1.3.1, but its *library* requires lens >=5.0.1 && < 5.3 and the snapshot contains lens-5.3.2
         - memfd < 0 # tried memfd-1.0.1.3, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
         - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
@@ -7588,6 +7595,7 @@ packages:
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires monads-tf >=0.1 && < 0.2 and the snapshot contains monads-tf-0.3.0.1
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell >=2.15 && < 2.16 and the snapshot contains template-haskell-2.21.0.0
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - parameterized-utils < 0 # tried parameterized-utils-2.1.8.0, but its *library* requires lens >=4.16 && < 5.3 and the snapshot contains lens-5.3.2
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires parser-combinators >=1.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
         - paripari < 0 # tried paripari-0.7.0.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.1.1
@@ -7875,6 +7883,7 @@ packages:
         - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
         - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.1
+        - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires lens >=4.16.1 && < 5.3 and the snapshot contains lens-5.3.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cookie >=0.4.1 && < 0.5 and the snapshot contains cookie-0.5.0
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
@@ -8419,9 +8428,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/7403
         - base-compat < 0.14
         - base-compat-batteries < 0.14
-
-        # https://github.com/commercialhaskell/stackage/issues/7408
-        - lens < 5.3
 
         # https://github.com/commercialhaskell/stackage/issues/7414
         - ghc-lib-parser < 9.10

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6423,6 +6423,8 @@ packages:
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
         - bench < 0 # tried bench-1.0.13, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
+        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart
+        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart-diagrams
         - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.19.1.0
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
@@ -6483,6 +6485,7 @@ packages:
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires websockets >=0.12.7.2 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.1.9
+        - bv-sized < 0 # tried bv-sized-1.0.5, but its *library* requires the disabled package: parameterized-utils
         - bytehash < 0 # tried bytehash-0.1.1.2, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - cabal-flatpak < 0 # tried cabal-flatpak-0.1.1, but its *executable* requires zlib >=0.5.3 && < 0.7 and the snapshot contains zlib-0.7.1.0
@@ -6590,6 +6593,10 @@ packages:
         - console-style < 0 # tried console-style-0.0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
         - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.8
+        - copilot < 0 # tried copilot-3.20, but its *library* requires the disabled package: copilot-theorem
+        - copilot-language < 0 # tried copilot-language-3.20, but its *library* requires the disabled package: copilot-theorem
+        - copilot-libraries < 0 # tried copilot-libraries-3.20, but its *library* requires the disabled package: copilot-language
+        - copilot-theorem < 0 # tried copilot-theorem-3.20, but its *library* requires the disabled package: parameterized-utils
         - country < 0 # tried country-0.2.4.2, but its *library* requires the disabled package: bytehash
         - cprng-aes < 0 # tried cprng-aes-0.6.1, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
         - cprng-aes < 0 # tried cprng-aes-0.6.1, but its *library* requires the disabled package: crypto-random
@@ -7884,6 +7891,7 @@ packages:
         - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.1
         - servant-auth < 0 # tried servant-auth-0.4.1.0, but its *library* requires lens >=4.16.1 && < 5.3 and the snapshot contains lens-5.3.2
+        - servant-auth-client < 0 # tried servant-auth-client-0.4.1.1, but its *library* requires the disabled package: servant-auth
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.3
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cookie >=0.4.1 && < 0.5 and the snapshot contains cookie-0.5.0
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
@@ -7895,6 +7903,9 @@ packages:
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.20
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
         - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
+        - servant-auth-docs < 0 # tried servant-auth-docs-0.2.10.1, but its *library* requires the disabled package: servant-auth
+        - servant-auth-server < 0 # tried servant-auth-server-0.4.8.0, but its *library* requires the disabled package: servant-auth
+        - servant-auth-swagger < 0 # tried servant-auth-swagger-0.2.10.2, but its *library* requires the disabled package: servant-auth
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires servant-server >=0.14 && < 0.20 and the snapshot contains servant-server-0.20
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: wordpress-auth
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.13.1
@@ -8132,6 +8143,7 @@ packages:
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.1, but its *library* requires network ^>=3.1.2 and the snapshot contains network-3.2.1.0
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.1, but its *library* requires text ^>=1.2.4 || ^>=2.0 and the snapshot contains text-2.1.1
         - taffybar < 0 # tried taffybar-4.0.2, but its *library* requires scotty >=0.11 && < 0.22 and the snapshot contains scotty-0.22
+        - tasty-checklist < 0 # tried tasty-checklist-1.0.6.0, but its *library* requires the disabled package: parameterized-utils
         - tasty-hunit-compat < 0 # tried tasty-hunit-compat-0.2.0.1, but its *library* requires tasty < 1.5 and the snapshot contains tasty-1.5
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.6.8
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.5
@@ -8335,6 +8347,7 @@ packages:
         - webby < 0 # tried webby-1.1.1, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1.1
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires language-javascript >=0.6 && < 0.7 and the snapshot contains language-javascript-0.7.1.0
         - webdriver-angular < 0 # tried webdriver-angular-0.1.11, but its *library* requires webdriver >=0.6 && < 0.9 and the snapshot contains webdriver-0.12.0.0
+        - what4 < 0 # tried what4-1.6, but its *library* requires the disabled package: parameterized-utils
         - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires bytestring >=0.10.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires text >=0.11.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - wikicfp-scraper < 0 # tried wikicfp-scraper-0.1.0.13, but its *library* requires time >=1.4.0 && < 1.12 and the snapshot contains time-1.12.2
@@ -8850,6 +8863,7 @@ skipped-tests:
     - cleff # tried cleff-0.3.3.0, but its *test-suite* requires template-haskell >=2.14 && < 2.19 and the snapshot contains template-haskell-2.21.0.0
     - colour # tried colour-2.3.6, but its *test-suite* requires random >=1.0 && < 1.2 and the snapshot contains random-1.2.1.2
     - construct # tried construct-0.3.1.2, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
+    - copilot-libraries # tried copilot-libraries-3.20, but its *test-suite* requires the disabled package: copilot-theorem
     - cryptohash-sha512 # tried cryptohash-sha512-0.11.102.0, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - csg # tried csg-0.1.0.6, but its *test-suite* requires doctest < 0.17 and the snapshot contains doctest-0.22.6
     - csg # tried csg-0.1.0.6, but its *test-suite* requires tasty < 1.3 and the snapshot contains tasty-1.5


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

Fixes #7408 which has been open for a while now, and people have had a long time to upgrade.
