### PR TITLE
Remove unmaintained packages disabled since ghc-9.2, ie after lts-19

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -106,7 +106,6 @@ packages:
         - goldplate
         - hackage-cli
         - hasktags
-        - hs-tags
         - java-adt
         - Sit
 
@@ -171,9 +170,6 @@ packages:
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
 
-    "David James <dj112358@outlook.com> @davjam":
-        - MapWith
-
     "Bernie Pope <florbitous@gmail.com> @bjpop":
         - language-python
 
@@ -187,9 +183,6 @@ packages:
         - byte-count-reader
         - shellify
         - specup
-
-    "Allan Lukwago <epicallan.al@gmail.com> @epicallan":
-        - servant-errors
 
     "Christian Charukiewicz <charukiewicz@protonmail.com> @charukiewicz":
         - isbn
@@ -206,11 +199,6 @@ packages:
 
     "Jakob Schöttl <jakob.schoettl@intensovet.de> @schoettl":
         - bank-holiday-germany
-
-    "Marcin Rzeźnicki <marcin.rzeznicki@gmail.com> @marcin-rzeznicki":
-        - hspec-tables
-        - stackcollapse-ghc
-        - libjwt-typed
 
     "Mauricio Fierro <mauriciofierrom@gmail.com> @mauriciofierrom":
         - dialogflow-fulfillment
@@ -290,7 +278,6 @@ packages:
 
     "Robert Vollmert <rob@vllmrt.net> @robx":
         - configurator-pg
-        - postgrest
 
     "Sandy Maguire <sandy@sandymaguire.me> @isovector":
         - ecstasy
@@ -337,10 +324,6 @@ packages:
     "Joerg Winter <jwin1968@gmail.com> @clojj":
         - rosezipper
 
-    "Edward Wastell <edward@wastell.co.uk> @edwardwas":
-        - TotalMap
-        - sized-grid
-
     "Antonio Alonso Dominguez <alonso.domin@gmail.com> @alonsodomin":
         - hschema
         - hschema-aeson
@@ -374,12 +357,6 @@ packages:
 
     "Mateusz Karbowy <mateusz.karbowy@gmail.com> @obszczymucha":
         - parsec-numbers
-
-    "Joshua Grosso <jgrosso256@gmail.com> @jgrosso":
-        - axel
-
-    "Varun Gandhi <theindigamer15@gmail.com> @theindigamer":
-        - edit
 
     "Luka Hadžiegrić <reygoch@gmail.com> @reygoch":
         - valor
@@ -511,9 +488,6 @@ packages:
     "Jürgen Keck <jhyphenkeck@gmail.com> @j-keck":
         - wreq-stringless
 
-    "Olaf Chitil <oc@kent.ac.uk> @OlafChitil":
-        - FPretty
-
     "Maarten Faddegon <stackage@maartenfaddegon.nl> @MaartenFaddegon":
         - libgraph
         - Hoed
@@ -564,21 +538,11 @@ packages:
         - etc
         - capataz
 
-    "Richard Cook <rcook@rcook.org> @rcook":
-        - hidden-char
-        - oset
-        - req-url-extra
-        - sexpr-parser
-
     "Vanessa McHale <vmchale@gmail.com> @vmchale":
         - bz2
         - bzip2-clib # needed by bz2
 
     "Henning Thielemann <stackage@henning-thielemann.de> @thielema":
-        - accelerate-arithmetic
-        - accelerate-fftw
-        - accelerate-fourier
-        - accelerate-utility
         - align-audio
         - alsa-core
         - alsa-pcm
@@ -1010,7 +974,6 @@ packages:
         - ghc-exactprint < 1.9 # https://github.com/commercialhaskell/stackage/issues/7418
         - hjsmin
         - language-javascript
-        - Strafunski-StrategyLib
 
     "Michael Peyton Jones <me@michaelpj.com>":
         - lsp-types
@@ -1124,7 +1087,6 @@ packages:
         - lucid
         - lucid2
         - pdfinfo
-        - pure-io
         - sourcemap
         - descriptive
         - wrap
@@ -1187,7 +1149,6 @@ packages:
         - lens-aeson
         - lens-properties
         - linear
-        - linear-accelerate
         - log-domain
         - machines
         - monadic-arrays
@@ -1328,15 +1289,6 @@ packages:
         - ChannelT
 
     "Trevor L. McDonell <trevor.mcdonell@gmail.com> @tmcdonell":
-        - accelerate
-        - accelerate-bignum
-        - accelerate-blas
-        - accelerate-fft
-        - accelerate-io
-        - accelerate-llvm
-        - accelerate-llvm-native
-        - accelerate-llvm-ptx
-        - accelerate-examples
         - repa
         - repa-algorithms
         - repa-io
@@ -1345,11 +1297,6 @@ packages:
         - gloss-algorithms
         - gloss-examples
         - gloss-raster
-        - gloss-accelerate
-        - gloss-raster-accelerate
-        - colour-accelerate
-        - lens-accelerate
-        - mwc-random-accelerate
         - cuda
         - cufft < 0 # 0.10.0.0 compile fail (#7198)
         - cublas < 0 # 0.6.0.0 compile fail (#7198)
@@ -1480,7 +1427,6 @@ packages:
         - random-fu
 
     "Ben Gamari <ben@smart-cactus.org> @bgamari":
-        - vector-fftw
         - cborg-json
         - language-dot
 
@@ -1539,10 +1485,6 @@ packages:
         # dependencies:
         - monad-chronicle
 
-    "Piyush P Kurur <ppk@cse.iitk.ac.in> @piyush-kurur":
-        - raaz
-        - naqsha
-
     "Joey Hess <id@joeyh.name> @joeyh":
         - git-annex
         - concurrent-output
@@ -1562,43 +1504,18 @@ packages:
         - versions
         - vectortiles
 
-    "Ketil Malde @ketil-malde":
-        - biocore
-        - biofasta
-        - biofastq
-        - blastxml
-        - bioace
-        - biopsl
-        - seqloc
-        - bioalign
-        - BlastHTTP
-
     "Florian Eggenhofer <florian.eggenhofer@univie.ac.at> @eggzilla":
         - ClustalParser
-        - EntrezHTTP
-        - Genbank
-        - RNAlien
-        - biocore
         - bimaps
-        - BiobaseBlast
-        - BiobaseENA
-        - BiobaseEnsembl < 0
-        - BiobaseFasta
-        - BiobaseHTTP
-        - BiobaseTypes
-        - BiobaseXNA
         - DPutils
         - ForestStructures
         - OrderedBits
-        - PrimitiveArray < 0 # 0.10.1.1 compile fail
         - SciBaseTypes
-        - Taxonomy
         - ViennaRNAParser
         - either-unwrap
 
     "Silk <code@silk.co>":
         - attoparsec-expr
-        - generic-xmlpickler
         - imagesize-conduit
         - multipart
         - tostring
@@ -1834,7 +1751,6 @@ packages:
         - servant-js
         - servant-lucid
         - servant-machines
-        - servant-mock
         - servant-multipart
         - servant-multipart-api
         - servant-pipes
@@ -1860,9 +1776,6 @@ packages:
 
     "Aleksey Kliger <aleksey@lambdageek.org> @lambdageek":
         - unbound-generics
-        - indentation-core
-        - indentation-parsec
-        - clang-compilation-database
 
     "Alois Cochard <alois.cochard@gmail.com> @aloiscochard":
         - machines-binary
@@ -1924,7 +1837,6 @@ packages:
         - ghcjs-dom
         - jsaddle
         - vado
-        - vcswrapper
         - ShellCheck
         - binary-shared
         - xdg-userdirs
@@ -1983,19 +1895,7 @@ packages:
         - xmlbf
 
     "Tomas Carnecky @wereHamster":
-        - avers
-        - avers-api
-        - avers-server
-        - etcd
         - github-types
-        - github-webhook-handler
-        - github-webhook-handler-snap
-        - google-cloud
-        - kraken
-        - libinfluxdb
-        - mole
-        - publicsuffix
-        - rethinkdb-client-driver
         - snap-blaze
 
     "Adrian Cochrane <alcinnz@argonaut-constellation.org> @alcinnz":
@@ -2553,16 +2453,12 @@ packages:
         - pipes-csv
         - pipes-mongodb
         - servant-elm
-        - servant-streaming
-        - servant-streaming-client
-        - servant-streaming-server
         - skeletons
 
     "David Raymond Christiansen <david@davidchristiansen.dk> @david-christiansen":
         - annotated-wl-pprint
 
     "Yitz Gale <gale@sefer.org> @ygale":
-        - boolean-normal-forms
         - strict-concurrency
         - timezone-series
         - timezone-olson
@@ -2831,7 +2727,6 @@ packages:
         - range
 
     "Vladislav Zavialov <vlad.z.4096@gmail.com> @int-index":
-        - transformers-lift
         - union
         - named
         - inj
@@ -3107,10 +3002,8 @@ packages:
         - parsec-class
         - prim-uniq
         - random-fu
-        - random-source
         - rvar
         - SafeSemaphore
-        - streamproc
         - stringsearch # for cgi
         - titlecase
 
@@ -3213,10 +3106,6 @@ packages:
 
     "Robbin C. <robbinch33@gmail.com> @robbinch":
         - zim-parser
-
-    "David Wiltshire <david.wiltshire@metark.com> @dave77":
-        # on behalf of Alexey Karakulov @w3rs
-        - hashable-time
 
     "Yuras Shumovich <shumovichy@gmail.com> @Yuras":
         - pdf-toolbox-content
@@ -3336,7 +3225,6 @@ packages:
 
     "Denis Redozubov <denis.redozubov@gmail.com> @dredozubov":
         - hreader-lens
-        - schematic
 
     "Yuji Yamamoto <whosekiteneverfly@gmail.com> @igrep":
         - yes-precure5-command
@@ -3404,10 +3292,6 @@ packages:
         - mustache
         - exit-codes
 
-    "Cindy Wang <cindylinz@gmail.com> @CindyLinz":
-        - NoTrace
-        - linked-list-with-iterator
-
     "Jean-Philippe Bernardy <jean-philippe.bernardy@tweag.io> @jyp":
         - polynomials-bernstein
         - typography-geometry
@@ -3463,12 +3347,6 @@ packages:
 
     "Kazuo Koga <obiwanko@me.com> @kkazuo":
         - xlsx-tabular < 0 # 0.2.2.1 https://github.com/kkazuo/xlsx-tabular/issues/9
-
-    "Mikhail Glushenkov <mikhail.glushenkov@gmail.com> @23Skidoo":
-        - pointful
-
-    "Lennart Kolmodin <kolmodin@gmail.com> @kolmodin":
-        - binary-bits
 
     "Alex McLean <alex@slab.org> @yaxu":
         - tidal
@@ -3600,9 +3478,6 @@ packages:
 
     "George Wilson <george@wils.online> @gwils":
         - hedgehog-fn
-        - sv
-        - sv-cassava
-        - sv-core
         - tasty-hedgehog
 
     "Ismail Mustafa <ismailmustafa@rocketmail.com> @ismailmustafa":
@@ -3731,10 +3606,6 @@ packages:
         - xxhash-ffi
         - zeromq4-patterns
 
-    "Cliff Harvey <cs.hbar+hs@gmail.com> @BlackBrane":
-        - ansigraph
-        - microsoft-translator
-
     "Tebello Thejane <zyxoas+stackage@gmail.com> @tebello-thejane":
         - bitx-bitcoin < 0 # 0.12.0.0 compile fail
 
@@ -3796,7 +3667,6 @@ packages:
     "Patrick Chilton <chpatrick@gmail.com> @chpatrick":
         - webrtc-vad
         - clang-pure < 0 # 0.2.0.6 missing system libraries #3810/closed
-        - codec
 
     "Michal Konecny <mikkonecny@gmail.com> @michalkonecny":
         - hmpfr
@@ -3828,11 +3698,6 @@ packages:
     "Anton Gushcha <ncrashed@gmail.com> @ncrashed":
         - aeson-injector
         - JuicyPixels-blp
-
-    "Al Zohali <zohl@fmap.me> @zohl":
-        - servant-auth-cookie
-        - dictionaries
-        - cereal-time
 
     "Joachim Fasting <joachifm@fastmail.fm> @joachifm":
         - libmpd
@@ -3873,7 +3738,6 @@ packages:
         - lmdb
         - rdf
         - data-compat
-        - deepseq-instances
 
     "Michael Swan <mswan@fastmail.com> @michael-swan":
         - pcf-font < 0 # 0.2.2.1 https://github.com/commercialhaskell/stackage/issues/7247
@@ -3881,9 +3745,6 @@ packages:
 
     "Iago Abal <iagoabal+stack@gmail.com>":
         - bv
-
-    "Juan Pedro Villa Isaza @jpvillaisaza":
-        - licensor
 
     "Florian Hofmann fho@f12n.de @fhaust":
         - vector-split
@@ -4020,16 +3881,6 @@ packages:
     "Boldizsár Németh <nboldi@elte.hu> @nboldi":
         - instance-control
         - references < 0 # 0.3.3.1 compile fail
-        - classyplate
-        - haskell-tools-ast
-        - haskell-tools-backend-ghc
-        - haskell-tools-prettyprint
-        - haskell-tools-refactor
-        - haskell-tools-rewrite
-        - haskell-tools-demo
-        - haskell-tools-cli
-        - haskell-tools-daemon
-        - haskell-tools-debug
 
     "Michael Bock <no-day@posteo.net> @m-bock":
         - fields-and-cases
@@ -4043,8 +3894,6 @@ packages:
 
     "Mitsutoshi Aoe <maoe@foldr.in> @maoe":
         - influxdb
-        - sensu-run
-        - viewprof
 
     "Dylan Simon <dylan-stack@dylex.net> @dylex":
         - postgresql-typed
@@ -4186,8 +4035,6 @@ packages:
         - proto-lens-arbitrary
         - proto-lens-optparse
         - tensorflow-test
-        - pier-core
-        - pier
         - ghc-source-gen # tests disabled due to QuickCheck < 2.14
 
     "Christof Schramm <christof.schramm@campus.lmu.de>":
@@ -4547,9 +4394,6 @@ packages:
         - unliftio-pool
         - unliftio-streams
 
-    "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
-        - pomaps
-
     "Alexey Kotlyarov <a@koterpillar.com> @koterpillar":
         - appendmap
         - serverless-haskell < 0 # 0.12.6 https://github.com/seek-oss/serverless-haskell/issues/188
@@ -4601,10 +4445,8 @@ packages:
         - polysemy-extra
         - polysemy-fs
         - polysemy-fskvstore
-        - polysemy-kvstore-jsonfile
         - polysemy-kvstore
         - polysemy-methodology
-        - polysemy-path
         - polysemy-several
         - polysemy-socket
         - polysemy-uncontrolled
@@ -4708,9 +4550,6 @@ packages:
         - aeson-iproute < 0 # 0.3.0 Compilation failure, https://github.com/commercialhaskell/stackage/issues/7229
         - persistent-iproute < 0 # 0.2.5 via aeson-iproute
 
-    "Damian Nadales <damian.nadales@gmail.com> @capitanbatata":
-        - hierarchy
-
     "Kofi Gumbs <h.kofigumbs@gmail.com> @hkgumbs":
         - codec-beam
 
@@ -4741,26 +4580,15 @@ packages:
         - fuzzy-dates
 
     "Matthew Farkas-Dyck <strake888@gmail.com> @strake":
-        - Fin
-        - alg
-        - category
-        - constraint
         - dual < 0 # 0.1.1.1 compile fail deprecated (https://hackage.haskell.org/package/dual) and not ghc 9.6 ready
         - either-both < 0 # 0.1.1.1 compile fail deprecated (https://hackage.haskell.org/package/either-both) and not ghc 9.6 ready
         - filtrable
-        - foldable1
-        - hs-functors
-        - lenz
         - natural-induction
         - peano
         - unconstrained
-        - util < 0 # 0.1.17.1 compile fail needs DerivingVia enabled
 
     "Ben Sima <ben@bsima.me> @bensima":
         - yesod-text-markdown
-
-    "Alexander Krupenkin <mail@akru.me> @akru":
-        - web3
 
     "Georg Rudoy <0xd34df00d@gmail.com> @0xd34df00d":
         - binary-generic-combinators
@@ -4772,10 +4600,6 @@ packages:
         - sendfile
         - tomland
         - validation-selective
-
-    "Kristen Kozak <grayjay@wordroute.com> @grayjay":
-        - json-rpc-server
-        - json-rpc-client
 
     "Magnus Therning <magnus@therning.org> @magthe":
         - hsini
@@ -4795,13 +4619,9 @@ packages:
     "John Biesnecker <jbiesnecker@gmail.com> @biesnecker":
         - async-pool
 
-    "Zoltan Kelemen <kelemzol@elte.hu> @kelemzol":
-        - fswatch
-
     "Matthew Wraith <matt@bitnomial.com> @wraithm":
         - prometheus
         - prometheus-wai-middleware
-        - hgrev
         - seqid
         - seqid-streams
 
@@ -4881,20 +4701,12 @@ packages:
         - gemini-exports
         - hexpat
 
-    "David Baynard <haskell@baynard.dev> @dbaynard":
-        - time-qq
-        - ucam-webauth
-        - ucam-webauth-types
-
     "Erick Gonzalez <erick@codemonkeylabs.de> @codemonkeylabs-de":
         - eap
         - failable
         - ttl-hashtables
         - radius
         - structured-cli
-
-    "Jan Path <jan@jpath.de> @janpath":
-        - smallcheck-series
 
     "Taisuke Hikawa <23.prime.37@gmail.com> @23prime":
         - oeis2
@@ -4903,7 +4715,6 @@ packages:
         - chiphunk
         - reanimate-svg > 0.13.0.1 # https://github.com/reanimate/reanimate-svg/issues/41
         - reanimate
-        - earcut
         - vector-circular
         - hgeometry
         - hgeometry-combinatorial
@@ -4916,7 +4727,6 @@ packages:
 
     "Juri Chomé <juri.chome@gmail.com> @2mol":
         - msgpack
-        - msgpack-rpc
         - msgpack-idl
         - msgpack-aeson > 0.1.0.0 # compile fail https://github.com/commercialhaskell/stackage/issues/7135
         - int-cast
@@ -5141,9 +4951,6 @@ packages:
 
     "Alexander Batischev <eual.jp@gmail.com> @Minoru":
         - hakyll-convert
-
-    "Edward Nerd <nerded.nerded@gmail.com> @nerded1337":
-        - zydiskell
 
     "Alejandro Peralta Bazas <aleperaltabazas@gmail.com> @aleperaltabazas":
         - hocon
@@ -5432,7 +5239,6 @@ packages:
         - lsql-csv
 
     "Grandfathered dependencies":
-        - BiobaseNewick
         - Boolean
         - BoundedChan
         - Chart-cairo
@@ -5457,12 +5263,7 @@ packages:
         - QuickCheck
         - RSA
         - Stream
-        - TypeCompose
         - Yampa
-        - accelerate-io-bmp
-        - accelerate-io-bytestring
-        - accelerate-io-repa
-        - accelerate-io-vector
         - aeson-extra
         - aeson-optics
         - alsa-mixer
@@ -5634,7 +5435,6 @@ packages:
         - haskell-gi-overloading
         - haskell-src-exts
         - haskell-src-exts-simple
-        - haskell-tools-builtin-refactorings
         - haskoin-store-data
         - hasql-dynamic-statements
         - hasql-implicits
@@ -5691,7 +5491,6 @@ packages:
         - jsaddle-dom
         - json
         - json-alt
-        - jsonrpc-tinyclient
         - kansas-comet
         - kleene
         - knob
@@ -5718,7 +5517,6 @@ packages:
         - markov-chain-usage-model
         - math-functions
         - membership
-        - memory-hexstring
         - mersenne-random
         - mersenne-random-pure64
         - mfsolve
@@ -5819,7 +5617,6 @@ packages:
         - safecopy
         - samsort
         - sandi
-        - scale
         - scientific
         - securemem
         - selective
@@ -5828,7 +5625,6 @@ packages:
         - servant-client-core
         - servant-multipart-client
         - servant-swagger-ui-redoc
-        - servant-yaml
         - setenv
         - shakespeare
         - shakespeare-text
@@ -5950,12 +5746,6 @@ packages:
         - wai-session
         - warp
         - wcwidth
-        - web3-bignum
-        - web3-crypto
-        - web3-ethereum
-        - web3-polkadot
-        - web3-provider
-        - web3-solidity
         - with-location
         - wizards
         - word-wrap
@@ -6019,7 +5809,6 @@ packages:
         - shellmet # #5965/closed
         - slist # #5965/closed
         - syb-with-class
-        - type-errors-pretty # #5965/closed
         - unordered-intmap # #6326/closed
         - word-trie # #6326/closed
         - xdg-basedir # #6326/closed
@@ -6068,10 +5857,7 @@ packages:
     # it's clear that they must be built if we want to confirm that
     # they are working.
     "Compilation failures":
-        - BiobaseBlast < 0 # 0.3.3.0 compile fail aeson 2.0
-        - Fin < 0 # 0.2.9.0 `@' not in scope
         - HDBC-mysql < 0 # 0.7.1.0
-        - Taxonomy < 0 # 2.2.0 compile fail aeson 2.0
         - Workflow < 0 # 0.8.3
         - accuerr < 0 # 0.2.0.2
         - aeson-lens < 0 # 0.5.0.0
@@ -6096,7 +5882,6 @@ packages:
         - drinkery < 0 # 0.4
         - elm-export-persistent < 0 # 1.0.0 compile fail aeson 2.0
         - etc < 0 # 0.4.1.0 compile fail aeson 2.0
-        - etcd < 0 # 1.0.5
         - eve < 0 # 0.1.9.0
         - eventsource-api < 0 # 1.5.1 compile fail aeson 2.0
         - eventsource-store-specs < 0 # 1.2.1
@@ -6112,7 +5897,6 @@ packages:
         - hbeanstalk < 0 # 0.2.4
         - hexstring < 0 # 0.11.1
         - highjson < 0 # 0.5.0.0 compile fail aeson 2.0
-        - hs-functors < 0 # 0.1.7.1
         - hschema < 0 # 0.0.1.1
         - hsebaysdk < 0 # 0.4.1.0 compile fail aeson 2.0
         - hstatsd < 0 # 0.1
@@ -6143,7 +5927,6 @@ packages:
         - postgresql-transactional < 0 # 1.1.1
         - protocol-buffers < 0 # 2.4.17
         - pushbullet-types < 0 # 0.4.1.0 compile fail aeson 2.0
-        - raaz < 0 # 0.3.9 multiple libraries
         - record-wrangler < 0 # 0.1.1.0
         - regex-compat-tdfa < 0 # 0.95.1.4
         - rescue < 0 # 0.4.2.1
@@ -6162,7 +5945,6 @@ packages:
         - text-region < 0 # 0.3.1.0
         - throttle-io-stream < 0 # 0.2.0.1
         - throwable-exceptions < 0 # 0.1.0.9
-        - time-qq < 0 # 0.0.1.0
         - timemap < 0 # 0.0.7 https://github.com/athanclark/timemap/issues/1
         - tintin < 0 # 1.10.1
         - tinylog < 0 # 0.15.0
@@ -6191,25 +5973,13 @@ packages:
     # Recheck with: commenter clear && commenter add-loop
     "Library and exe bounds failures":
         - Allure < 0 # tried Allure-0.11.0.0, but its *library* requires the disabled package: LambdaHack
-        - BiobaseENA < 0 # tried BiobaseENA-0.0.0.2, but its *library* requires the disabled package: BiobaseTypes
-        - BiobaseFasta < 0 # tried BiobaseFasta-0.4.0.1, but its *library* requires the disabled package: BiobaseTypes
-        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.2.2.0
-        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: BiobaseEnsembl
-        - BiobaseHTTP < 0 # tried BiobaseHTTP-1.2.0, but its *library* requires the disabled package: Taxonomy
-        - BiobaseTypes < 0 # tried BiobaseTypes-0.2.1.0, but its *library* requires the disabled package: PrimitiveArray
-        - BiobaseXNA < 0 # tried BiobaseXNA-0.11.1.1, but its *library* requires the disabled package: PrimitiveArray
-        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires network ==2.8.0.0 and the snapshot contains network-3.2.2.0
-        - BlastHTTP < 0 # tried BlastHTTP-1.4.2, but its *library* requires the disabled package: BiobaseBlast
         - Chart < 0 # tried Chart-1.9.5, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
         - Chart-cairo < 0 # tried Chart-cairo-1.9.4.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
         - Chart-diagrams < 0 # tried Chart-diagrams-1.9.5.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
         - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
-        - EntrezHTTP < 0 # tried EntrezHTTP-1.0.4, but its *library* requires the disabled package: Taxonomy
-        - FPretty < 0 # tried FPretty-1.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.19.1.0
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.23
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - Genbank < 0 # tried Genbank-1.0.3, but its *library* requires the disabled package: biocore
         - H < 0 # tried H-1.0.0, but its *executable* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - HaskellNet < 0 # tried HaskellNet-0.6.1.2, but its *library* requires base >=4.3 && < 4.19 and the snapshot contains base-4.19.1.0
         - HaskellNet < 0 # tried HaskellNet-0.6.1.2, but its *library* requires base64 < 0.5 and the snapshot contains base64-1.0
@@ -6232,58 +6002,11 @@ packages:
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: monadloc
         - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* requires base >=4.9.1 && < 4.15 and the snapshot contains base-4.19.1.0
         - Network-NineP < 0 # tried Network-NineP-0.4.7.4, but its *library* requires network >=3.0 && < 3.2 and the snapshot contains network-3.2.2.0
-        - NoTrace < 0 # tried NoTrace-0.3.0.4, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.1.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseFasta >=0.3.0 && < 0.3.1 and the snapshot contains BiobaseFasta-0.4.0.1
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseHTTP ==1.1.0 and the snapshot contains BiobaseHTTP-1.2.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires BiobaseTypes >=0.2.0 && < 0.2.1 and the snapshot contains BiobaseTypes-0.2.1.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires aeson < =1.4.2.0 and the snapshot contains aeson-2.2.3.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires network < =2.8.0.0 and the snapshot contains network-3.2.2.0
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: BiobaseBlast
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: Taxonomy
-        - RNAlien < 0 # tried RNAlien-1.7.0, but its *library* requires the disabled package: hierarchical-clustering
         - SpatialMath < 0 # tried SpatialMath-0.2.7.1, but its *library* requires lens >=5.2.3 && < 5.3 and the snapshot contains lens-5.3.2
         - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-api-server < 0 # tried Spock-api-server-0.14.0.0, but its *library* requires the disabled package: Spock-core
         - Spock-lucid < 0 # tried Spock-lucid-0.4.0.1, but its *library* requires the disabled package: Spock
         - Spock-worker < 0 # tried Spock-worker-0.3.1.0, but its *library* requires the disabled package: Spock
-        - Strafunski-StrategyLib < 0 # tried Strafunski-StrategyLib-5.0.1.0, but its *library* requires base >4.4 && < 4.14 and the snapshot contains base-4.19.1.0
-        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
-        - TotalMap < 0 # tried TotalMap-0.1.1.1, but its *library* requires lens >=4.16 && < 4.20 and the snapshot contains lens-5.3.2
-        - TypeCompose < 0 # tried TypeCompose-0.9.14, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.19.1.0
-        - accelerate < 0 # tried accelerate-1.3.0.0, but its *library* requires base >=4.12 && < 4.15 and the snapshot contains base-4.19.1.0
-        - accelerate-arithmetic < 0 # tried accelerate-arithmetic-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
-        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm
-        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm-native
-        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: accelerate-llvm-ptx
-        - accelerate-bignum < 0 # tried accelerate-bignum-0.3.0.0, but its *library* requires the disabled package: llvm-hs-pure
-        - accelerate-blas < 0 # tried accelerate-blas-0.3.0.0, but its *library* requires the disabled package: cublas
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: accelerate-fft
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: lens-accelerate
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: linear-accelerate
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: repa
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *executable* requires the disabled package: repa-io
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-native
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: accelerate-llvm-ptx
-        - accelerate-examples < 0 # tried accelerate-examples-1.3.0.0, but its *library* requires the disabled package: fclabels
-        - accelerate-fft < 0 # tried accelerate-fft-1.3.0.0, but its *library* requires the disabled package: cufft
-        - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
-        - accelerate-fftw < 0 # tried accelerate-fftw-1.0.0.1, but its *library* requires accelerate-io >=1.0 && < 1.1 and the snapshot contains accelerate-io-1.3.0.0
-        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
-        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - accelerate-fourier < 0 # tried accelerate-fourier-1.0.0.5, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - accelerate-io < 0 # tried accelerate-io-1.3.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-io-bmp < 0 # tried accelerate-io-bmp-0.1.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-io-bytestring < 0 # tried accelerate-io-bytestring-0.1.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-io-repa < 0 # tried accelerate-io-repa-0.1.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-io-repa < 0 # tried accelerate-io-repa-0.1.0.0, but its *library* requires the disabled package: repa
-        - accelerate-io-vector < 0 # tried accelerate-io-vector-0.1.0.0, but its *library* requires the disabled package: accelerate
-        - accelerate-llvm < 0 # tried accelerate-llvm-1.3.0.0, but its *library* requires the disabled package: llvm-hs
-        - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires libffi >=0.1 && < 0.2 and the snapshot contains libffi-0.2.1
-        - accelerate-llvm-native < 0 # tried accelerate-llvm-native-1.3.0.0, but its *library* requires the disabled package: llvm-hs
-        - accelerate-llvm-ptx < 0 # tried accelerate-llvm-ptx-1.3.0.0, but its *library* requires the disabled package: llvm-hs
-        - accelerate-utility < 0 # tried accelerate-utility-1.0.0.1, but its *library* requires accelerate >=1.0 && < 1.2 and the snapshot contains accelerate-1.3.0.0
         - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires aeson >=0.7 && < 1.6 || >=2.0 && < 2.1 and the snapshot contains aeson-2.2.3.0
         - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires aeson >=1.4 && < 2.2 and the snapshot contains aeson-2.2.3.0
@@ -6299,9 +6022,6 @@ packages:
         - airship < 0 # tried airship-0.9.5, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
         - al < 0 # tried al-0.1.4.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - alerts < 0 # tried alerts-0.1.2.0, but its *library* requires text >=0.11 && < 2.0 and the snapshot contains text-2.1.1
-        - alg < 0 # tried alg-0.2.13.1, but its *library* requires base >=4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: dual
-        - alg < 0 # tried alg-0.2.13.1, but its *library* requires the disabled package: util
         - amazonka-apigatewaymanagementapi < 0 # tried amazonka-apigatewaymanagementapi-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.19.1.0
         - amazonka-appconfigdata < 0 # tried amazonka-appconfigdata-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.19.1.0
         - amazonka-backupstorage < 0 # tried amazonka-backupstorage-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.19.1.0
@@ -6332,8 +6052,6 @@ packages:
         - amqp-utils < 0 # tried amqp-utils-0.6.4.0, but its *executable* requires the disabled package: filepath-bytestring
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires ansi-terminal >=0.6 && < 0.9 and the snapshot contains ansi-terminal-1.1.1
-        - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.19.1.0
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: amazonka-dynamodb
         - antiope-dynamodb < 0 # tried antiope-dynamodb-7.5.3, but its *library* requires the disabled package: antiope-core
@@ -6402,7 +6120,6 @@ packages:
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *library* requires cookie ^>=0.4.5 and the snapshot contains cookie-0.5.0
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *library* requires lens ^>=5.0.1 || ^>=5.1 || ^>=5.2 and the snapshot contains lens-5.3.2
         - aws-cloudfront-signed-cookies < 0 # tried aws-cloudfront-signed-cookies-0.2.0.12, but its *library* requires text ^>=1.2.4 || ^>=2.0 and the snapshot contains text-2.1.1
-        - axel < 0 # tried axel-0.0.12, but its *library* requires base >=4.12 && < 4.13 and the snapshot contains base-4.19.1.0
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient
         - b9 < 0 # tried b9-3.2.3, but its *library* requires aeson >=1.4 && < 1.5 and the snapshot contains aeson-2.2.3.0
         - b9 < 0 # tried b9-3.2.3, but its *library* requires hspec >=2.7 && < 2.8 and the snapshot contains hspec-2.11.9
@@ -6437,14 +6154,7 @@ packages:
         - bench < 0 # tried bench-1.0.13, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
         - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart
         - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart-diagrams
-        - binary-bits < 0 # tried binary-bits-0.5, but its *library* requires base >=4 && < 4.13 and the snapshot contains base-4.19.1.0
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - bioace < 0 # tried bioace-0.0.1, but its *library* requires the disabled package: biocore
-        - bioalign < 0 # tried bioalign-0.0.5, but its *library* requires the disabled package: biocore
-        - biocore < 0 # tried biocore-0.3.1, but its *library* requires base >=3 && < 4.11 and the snapshot contains base-4.19.1.0
-        - biofasta < 0 # tried biofasta-0.0.3, but its *library* requires the disabled package: biocore
-        - biofastq < 0 # tried biofastq-0.1, but its *library* requires the disabled package: biocore
-        - biopsl < 0 # tried biopsl-0.4, but its *library* requires the disabled package: biocore
         - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: bitcoin-script
         - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: hexstring
         - bitcoin-api-extra < 0 # tried bitcoin-api-extra-0.9.1, but its *library* requires the disabled package: bitcoin-api
@@ -6456,12 +6166,8 @@ packages:
         - bitcoin-types < 0 # tried bitcoin-types-0.9.2, but its *library* requires the disabled package: hexstring
         - blake2 < 0 # tried blake2-0.3.0.1, but its *library* requires base ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
         - blake2 < 0 # tried blake2-0.3.0.1, but its *library* requires bytestring ^>=0.10.12 || ^>=0.11 and the snapshot contains bytestring-0.12.1.0
-        - blastxml < 0 # tried blastxml-0.3.2, but its *library* requires the disabled package: biocore
         - blaze-colonnade < 0 # tried blaze-colonnade-1.2.3.0, but its *library* requires the disabled package: colonnade
         - bookkeeping < 0 # tried bookkeeping-0.4.0.1, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
-        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires base >=4.6 && < 4.14 and the snapshot contains base-4.19.1.0
-        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires cond >=0.4.1 && < 0.5 and the snapshot contains cond-0.5.1
-        - boolean-normal-forms < 0 # tried boolean-normal-forms-0.0.1.1, but its *library* requires deepseq >=1.1.0.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - boots < 0 # tried boots-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - both < 0 # tried both-0.1.1.2, but its *library* requires the disabled package: zero
         - bower-json < 0 # tried bower-json-1.1.0.0, but its *library* requires the disabled package: aeson-better-errors
@@ -6520,10 +6226,6 @@ packages:
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
         - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
-        - category < 0 # tried category-0.2.5.0, but its *library* requires base >=4.10 && < 4.15 and the snapshot contains base-4.19.1.0
-        - category < 0 # tried category-0.2.5.0, but its *library* requires the disabled package: dual
-        - category < 0 # tried category-0.2.5.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - cereal-time < 0 # tried cereal-time-0.1.0.0, but its *library* requires time >=1.5 && < 1.8.1 and the snapshot contains time-1.12.2
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.2.3.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson-casing >=0.1.0.5 && < 0.2 and the snapshot contains aeson-casing-0.2.0.0
         - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -6537,9 +6239,6 @@ packages:
         - cheapskate-highlight < 0 # tried cheapskate-highlight-0.1.0.0, but its *library* requires the disabled package: highlighting-kate
         - cheapskate-lucid < 0 # tried cheapskate-lucid-0.1.0.0, but its *library* requires the disabled package: cheapskate
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.4.7.0
-        - clang-compilation-database < 0 # tried clang-compilation-database-0.1.0.1, but its *library* requires base >=4.8 && < 4.12 and the snapshot contains base-4.19.1.0
-        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.19.1.0
-        - classyplate < 0 # tried classyplate-0.3.2.0, but its *library* requires template-haskell >=2.12 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
         - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires primitive >=0.6.4 && < 0.9 and the snapshot contains primitive-0.9.0.0
         - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires th-abstraction >=0.2 && < 0.6 and the snapshot contains th-abstraction-0.7.0.0
         - cleff-plugin < 0 # tried cleff-plugin-0.1.0.0, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.19.1.0
@@ -6548,9 +6247,7 @@ packages:
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires cmark >=0.5 && < 0.6 and the snapshot contains cmark-0.6.1
         - cmark-highlight < 0 # tried cmark-highlight-0.2.0.0, but its *library* requires the disabled package: highlighting-kate
         - co-log-concurrent < 0 # tried co-log-concurrent-0.5.1.0, but its *library* requires base >=4.10.1.0 && < 4.19 and the snapshot contains base-4.19.1.0
-        - codec < 0 # tried codec-0.2.1, but its *library* requires the disabled package: binary-bits
         - colonnade < 0 # tried colonnade-1.2.0.2, but its *library* requires text >=1.0 && < 2.1 and the snapshot contains text-2.1.1
-        - colour-accelerate < 0 # tried colour-accelerate-0.4.0.0, but its *library* requires the disabled package: accelerate
         - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires semigroupoids >=4 && < 6 and the snapshot contains semigroupoids-6.0.1
         - comonad-extras < 0 # tried comonad-extras-4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - composite-aeson < 0 # tried composite-aeson-0.8.2.2, but its *library* requires aeson >=1.1.2.0 && < 2.1 and the snapshot contains aeson-2.2.3.0
@@ -6601,7 +6298,6 @@ packages:
         - connection < 0 # tried connection-0.3.1, but its *library* requires the disabled package: x509-validation
         - connection < 0 # tried connection-0.3.1, but its *library* requires tls >=1.4 && < 1.7 and the snapshot contains tls-2.0.6
         - console-style < 0 # tried console-style-0.0.2.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - constraint < 0 # tried constraint-0.1.4.0, but its *library* requires the disabled package: category
         - containers-unicode-symbols < 0 # tried containers-unicode-symbols-0.3.1.3, but its *library* requires containers >=0.5 && < 0.6.5 and the snapshot contains containers-0.6.8
         - country < 0 # tried country-0.2.4.2, but its *library* requires the disabled package: bytehash
         - cprng-aes < 0 # tried cprng-aes-0.6.1, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -6642,8 +6338,6 @@ packages:
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.19.1.0
-        - deepseq-instances < 0 # tried deepseq-instances-0.1.0.1, but its *library* requires deepseq >=1.4.0.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - dhall < 0 # tried dhall-1.42.1, but its *library* requires Diff >=0.2 && < 0.5 and the snapshot contains Diff-0.5
         - dhall < 0 # tried dhall-1.42.1, but its *library* requires ansi-terminal >=0.6.3.1 && < 1.1 and the snapshot contains ansi-terminal-1.1.1
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -6678,16 +6372,6 @@ packages:
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.19.1.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.1.1
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *executable* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.3.0
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires attoparsec >=0.10.4.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires base >=4.8.2 && < 4.11 and the snapshot contains base-4.19.1.0
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires containers >=0.5.6.2 && < 0.6 and the snapshot contains containers-0.6.8
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires exceptions >=0.8.3 && < 0.9 and the snapshot contains exceptions-0.10.7
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires time >=1.5.0.1 && < 1.9 and the snapshot contains time-1.12.2
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - dictionaries < 0 # tried dictionaries-0.2.0.4, but its *library* requires zlib >=0.6.1.2 && < 0.7 and the snapshot contains zlib-0.7.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.2.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
@@ -6705,12 +6389,7 @@ packages:
         - docker-build-cacher < 0 # tried docker-build-cacher-2.1.1, but its *library* requires language-docker >=6.0.4 && < 7.0 and the snapshot contains language-docker-13.0.0
         - dom-parser < 0 # tried dom-parser-3.2.0, but its *library* requires the disabled package: xml-lens
         - dunai < 0 # tried dunai-0.13.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - earcut < 0 # tried earcut-0.1.0.4, but its *library* requires base >=4.5 && < 4.15 and the snapshot contains base-4.19.1.0
         - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.4
-        - edit < 0 # tried edit-1.0.1.0, but its *library* requires QuickCheck >=2.10 && < 2.13 and the snapshot contains QuickCheck-2.14.3
-        - edit < 0 # tried edit-1.0.1.0, but its *library* requires base >=4.9 && < 4.12 and the snapshot contains base-4.19.1.0
-        - edit < 0 # tried edit-1.0.1.0, but its *library* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - edit < 0 # tried edit-1.0.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - effect-handlers < 0 # tried effect-handlers-0.1.0.8, but its *library* requires free >=4.9 && < 5 and the snapshot contains free-5.2
         - egison < 0 # tried egison-4.1.3, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.1.1
         - egison < 0 # tried egison-4.1.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
@@ -6759,8 +6438,6 @@ packages:
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires base >=4.9.0 && < 4.17 and the snapshot contains base-4.19.1.0
         - fold-debounce-conduit < 0 # tried fold-debounce-conduit-0.2.0.7, but its *library* requires transformers >=0.5.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires the disabled package: util
-        - foldable1 < 0 # tried foldable1-0.1.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - fortran-src < 0 # tried fortran-src-0.15.1, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - fortran-src < 0 # tried fortran-src-0.15.1, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - fortran-src < 0 # tried fortran-src-0.15.1, but its *library* requires singletons-base >=3.0 && < 3.2 and the snapshot contains singletons-base-3.3
@@ -6772,8 +6449,6 @@ packages:
         - fortran-src-extras < 0 # tried fortran-src-extras-0.5.0, but its *library* requires text >=1.2 && < 2.1 and the snapshot contains text-2.1.1
         - friday < 0 # tried friday-0.2.3.2, but its *library* requires primitive >=0.5.2.1 && < 0.9 and the snapshot contains primitive-0.9.0.0
         - friday-juicypixels < 0 # tried friday-juicypixels-0.1.2.4, but its *library* requires the disabled package: friday
-        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
-        - fswatch < 0 # tried fswatch-0.1.0.6, but its *library* requires haskeline >=0.7 && < 0.8 and the snapshot contains haskeline-0.8.2.1
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires MonadRandom >=0.5.1 && < 0.6 and the snapshot contains MonadRandom-0.6
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires mod >=0.1.0 && < 0.2 and the snapshot contains mod-0.2.0.1
         - galois-field < 0 # tried galois-field-1.0.2, but its *library* requires poly >=0.3.2 && < 0.5 and the snapshot contains poly-0.5.1.0
@@ -6785,8 +6460,6 @@ packages:
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.19.1.0
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.19.1.0
-        - generic-xmlpickler < 0 # tried generic-xmlpickler-0.1.0.6, but its *library* requires generic-deriving >=1.6 && < 1.14 and the snapshot contains generic-deriving-1.14.5
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires deepseq >=1.4.2.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.42.1
@@ -6802,8 +6475,6 @@ packages:
         - ginger < 0 # tried ginger-0.10.5.2, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - ginger < 0 # tried ginger-0.10.5.2, but its *library* requires text >=1.2.3.1 && < 2.1 and the snapshot contains text-2.1.1
         - git-annex < 0 # tried git-annex-10.20240831, but its *executable* requires the disabled package: filepath-bytestring
-        - github-webhook-handler < 0 # tried github-webhook-handler-0.0.8, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.19.1.0
-        - github-webhook-handler-snap < 0 # tried github-webhook-handler-snap-0.0.7, but its *library* requires base >=4 && < 4.11 and the snapshot contains base-4.19.1.0
         - glaze < 0 # tried glaze-0.3.0.1, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.3.2
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react < 0 # tried glazier-react-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
@@ -6811,12 +6482,9 @@ packages:
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: data-diverse-lens
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - glazier-react-widget < 0 # tried glazier-react-widget-1.0.0.0, but its *library* requires the disabled package: glazier
-        - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
-        - gloss-accelerate < 0 # tried gloss-accelerate-2.1.0.0, but its *library* requires the disabled package: linear-accelerate
         - gloss-examples < 0 # tried gloss-examples-1.13.0.4, but its *executable* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - gloss-examples < 0 # tried gloss-examples-1.13.0.4, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
         - gloss-raster < 0 # tried gloss-raster-1.13.1.2, but its *library* requires the disabled package: repa
-        - gloss-raster-accelerate < 0 # tried gloss-raster-accelerate-2.1.0.0, but its *library* requires the disabled package: accelerate
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: x509
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: x509-store
@@ -6915,7 +6583,6 @@ packages:
         - gogol-youtube < 0 # tried gogol-youtube-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-analytics < 0 # tried gogol-youtube-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
         - gogol-youtube-reporting < 0 # tried gogol-youtube-reporting-0.5.0, but its *library* requires the disabled package: gogol-core
-        - google-cloud < 0 # tried google-cloud-0.0.4, but its *library* requires base >=4.4 && < 4.11 and the snapshot contains base-4.19.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.6.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.17
@@ -6975,84 +6642,11 @@ packages:
         - hasbolt < 0 # tried hasbolt-0.1.7.0, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - hasbolt < 0 # tried hasbolt-0.1.7.0, but its *library* requires network >=2.6.3.1 && < 3.2 and the snapshot contains network-3.2.2.0
         - hasbolt < 0 # tried hasbolt-0.1.7.0, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
-        - hashable-time < 0 # tried hashable-time-0.3, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.19.1.0
         - hashing < 0 # tried hashing-0.1.1.0, but its *library* requires bytestring >=0.10.6.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-ast < 0 # tried haskell-tools-ast-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires ghc-boot-th >=8.4 && < 8.7 and the snapshot contains ghc-boot-th-9.8.2
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-backend-ghc < 0 # tried haskell-tools-backend-ghc-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-builtin-refactorings < 0 # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *executable* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5.1
-        - haskell-tools-cli < 0 # tried haskell-tools-cli-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires Diff >=0.3 && < 0.4 and the snapshot contains Diff-0.5
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires network >=2.6 && < 2.9 and the snapshot contains network-3.2.2.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires optparse-applicative >=0.14 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires strict >=0.3 && < 0.4 and the snapshot contains strict-0.5.1
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-daemon < 0 # tried haskell-tools-daemon-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-debug < 0 # tried haskell-tools-debug-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires warp >=3.2 && < 3.3 and the snapshot contains warp-3.4.1
-        - haskell-tools-demo < 0 # tried haskell-tools-demo-1.1.1.0, but its *library* requires websockets >=0.12 && < 0.13 and the snapshot contains websockets-0.13.0.0
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - haskell-tools-prettyprint < 0 # tried haskell-tools-prettyprint-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires Cabal >=2.0 && < 2.5 and the snapshot contains Cabal-3.10.2.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires template-haskell >=2.13 && < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires the disabled package: references
-        - haskell-tools-refactor < 0 # tried haskell-tools-refactor-1.1.1.0, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires ghc >=8.4 && < 8.7 and the snapshot contains ghc-9.8.2
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-tools-rewrite < 0 # tried haskell-tools-rewrite-1.1.1.0, but its *library* requires the disabled package: references
         - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires unix >=2.7.1.0 && < 2.8 and the snapshot contains unix-2.8.4.0
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
         - haskoin-store < 0 # tried haskoin-store-1.5.12, but its *library* requires the disabled package: statsd-rupp
@@ -7083,16 +6677,8 @@ packages:
         - hetzner < 0 # tried hetzner-0.6.0.0, but its *library* requires base >=4.16 && < 4.19 and the snapshot contains base-4.19.1.0
         - hgeometry < 0 # tried hgeometry-0.14, but its *library* requires the disabled package: vector-circular
         - hgeometry-combinatorial < 0 # tried hgeometry-combinatorial-0.14, but its *library* requires the disabled package: vector-circular
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.19.1.0
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - hgrev < 0 # tried hgrev-0.2.6, but its *library* requires template-haskell >=2.10 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - hid < 0 # tried hid-0.2.2, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - hidden-char < 0 # tried hidden-char-0.1.0.2, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.1.0
-        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires base >=4.7 && < 4.12 and the snapshot contains base-4.19.1.0
-        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - hierarchy < 0 # tried hierarchy-1.0.2, but its *library* requires transformers-compat >=0.3 && < 0.7 and the snapshot contains transformers-compat-0.7.2
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires resourcet >=1.2.3 && < =1.3 and the snapshot contains resourcet-1.3.0
@@ -7150,11 +6736,6 @@ packages:
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires time >=1.9.0.0 && < 1.10.0.0 and the snapshot contains time-1.12.2
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector >=0.11.0.0 && < 0.13.0.0 and the snapshot contains vector-0.13.1.0
         - hquantlib < 0 # tried hquantlib-0.0.5.1, but its *library* requires vector-algorithms >=0.8.0.0 && < 0.9.0.0 and the snapshot contains vector-algorithms-0.9.0.2
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires Cabal >=1.24.0.0 && < 3.7 and the snapshot contains Cabal-3.10.2.0
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires base >=4.9.0.0 && < 4.16 and the snapshot contains base-4.19.1.0
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires ghc >=8.0.2 && < 9.1 and the snapshot contains ghc-9.8.2
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - hs-tags < 0 # tried hs-tags-0.1.5.3, but its *executable* requires strict >=0.3.2 && < 0.5 and the snapshot contains strict-0.5.1
         - hsb2hs < 0 # tried hsb2hs-0.3.1, but its *executable* requires the disabled package: preprocessor-tools
         - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
@@ -7183,8 +6764,6 @@ packages:
         - hsexif < 0 # tried hsexif-0.6.1.10, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires base >=4.6.0.0 && < 4.17 and the snapshot contains base-4.19.1.0
         - hspec-need-env < 0 # tried hspec-need-env-0.1.0.10, but its *library* requires hspec-core >=2.2.4 && < 2.11 and the snapshot contains hspec-core-2.11.9
-        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.19.1.0
-        - hspec-tables < 0 # tried hspec-tables-0.0.1, but its *library* requires hspec-core >=2.7 && < 2.8 and the snapshot contains hspec-core-2.11.9
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires the disabled package: hsp
@@ -7238,8 +6817,6 @@ packages:
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: log-warper
         - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: text-format
-        - indentation-core < 0 # tried indentation-core-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.19.1.0
-        - indentation-parsec < 0 # tried indentation-parsec-0.0.0.2, but its *library* requires base >=4.6 && < 4.13 and the snapshot contains base-4.19.1.0
         - inflections < 0 # tried inflections-0.4.0.7, but its *library* requires text >=0.2 && < 2.1 and the snapshot contains text-2.1.1
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.8.2
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires the disabled package: jni
@@ -7306,28 +6883,7 @@ packages:
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires smallcheck >=1.0 && < 1.2 and the snapshot contains smallcheck-1.2.1.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires text >=1.1 && < 1.4 and the snapshot contains text-2.1.1
         - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires aeson >=0.7 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires base >=4.3.1 && < 4.13 and the snapshot contains base-4.19.1.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires text >=0.11.2 && < 1.3 and the snapshot contains text-2.1.1
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - json-rpc-client < 0 # tried json-rpc-client-0.2.5.0, but its *library* requires vector-algorithms >=0.5.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.2
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.19.1.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.1.1
-        - json-rpc-server < 0 # tried json-rpc-server-0.2.6.0, but its *library* requires vector >=0.7.1 && < 0.13 and the snapshot contains vector-0.13.1.0
         - json-spec-elm-servant < 0 # tried json-spec-elm-servant-0.4.1.2, but its *library* requires filepath >=1.4.300.2 && < 1.6 and the snapshot contains filepath-1.4.200.1
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.17
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - jsonrpc-tinyclient < 0 # tried jsonrpc-tinyclient-1.0.0.0, but its *library* requires websockets >0.10 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
@@ -7345,7 +6901,6 @@ packages:
         - kind-generics-th < 0 # tried kind-generics-th-0.2.3.3, but its *library* requires th-abstraction >=0.4 && < 0.7 and the snapshot contains th-abstraction-0.7.0.0
         - kleene < 0 # tried kleene-0.1, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.2.3.0
-        - kraken < 0 # tried kraken-0.1.0, but its *library* requires base >=4.5 && < 4.14 and the snapshot contains base-4.19.1.0
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires aeson >=1.4.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.1.1
@@ -7364,29 +6919,12 @@ packages:
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
         - large-hashable < 0 # tried large-hashable-0.1.0.4, but its *library* requires template-haskell < 2.15 and the snapshot contains template-haskell-2.21.0.0
-        - lens-accelerate < 0 # tried lens-accelerate-0.3.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.3.2
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.3.2
         - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.3.2
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family >=1.2 && < 1.3 and the snapshot contains lens-family-2.1.3
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family-core >=1.2 && < 1.3 and the snapshot contains lens-family-core-2.1.3
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires the disabled package: hs-functors
-        - lenz < 0 # tried lenz-0.4.2.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - libgraph < 0 # tried libgraph-1.14, but its *library* requires the disabled package: union-find
-        - libinfluxdb < 0 # tried libinfluxdb-0.0.4, but its *library* requires base >=4.8 && < 4.11 and the snapshot contains base-4.19.1.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires base >=4.13.0.0 && < 4.15 and the snapshot contains base-4.19.1.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires bytestring ^>=0.10.10.0 and the snapshot contains bytestring-0.12.1.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires exceptions ==0.10.4 and the snapshot contains exceptions-0.10.7
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires monad-time >=0.3 && < 0.4 and the snapshot contains monad-time-0.4.0.0
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires text >=1.2.3.2 && < 1.2.5 and the snapshot contains text-2.1.1
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires time >=1.9 && < 1.10 and the snapshot contains time-1.12.2
-        - libjwt-typed < 0 # tried libjwt-typed-0.2, but its *library* requires transformers ^>=0.5.6.2 and the snapshot contains transformers-0.6.1.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires Cabal >=3.0.1 && < 3.3 and the snapshot contains Cabal-3.10.2.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires base >=4.13.0 && < 4.15 and the snapshot contains base-4.19.1.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires tar >=0.5.1 && < 0.6 and the snapshot contains tar-0.6.3.0
-        - licensor < 0 # tried licensor-0.5.0, but its *library* requires zlib >=0.6.2 && < 0.7 and the snapshot contains zlib-0.7.1.0
-        - linear-accelerate < 0 # tried linear-accelerate-0.7.0.0, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.3.2
-        - linked-list-with-iterator < 0 # tried linked-list-with-iterator-0.1.1.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires megaparsec >=7.0.0 && < 9 and the snapshot contains megaparsec-9.6.1
         - liquid-fixpoint < 0 # tried liquid-fixpoint-8.10.7, but its *library* requires rest-rewrite >=0.1.1 && < 0.2 and the snapshot contains rest-rewrite-0.4.4
         - llvm-hs-pure < 0 # tried llvm-hs-pure-9.0.0, but its *library* requires bytestring >=0.10 && < 0.11.3 and the snapshot contains bytestring-0.12.1.0
@@ -7454,12 +6992,6 @@ packages:
         - medea < 0 # tried medea-1.2.0, but its *library* requires text ^>=1.2.3.1 and the snapshot contains text-2.1.1
         - medea < 0 # tried medea-1.2.0, but its *library* requires vector ^>=0.12.0.3 and the snapshot contains vector-0.13.1.0
         - memfd < 0 # tried memfd-1.0.1.3, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
-        - memory-hexstring < 0 # tried memory-hexstring-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires regex-tdfa >=1.2.3.1 && < 1.3 and the snapshot contains regex-tdfa-1.3.2.2
         - menshen < 0 # tried menshen-0.0.3, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - mercury-api < 0 # tried mercury-api-0.1.0.2, but its *executable* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
@@ -7469,15 +7001,6 @@ packages:
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - messagepack-rpc < 0 # tried messagepack-rpc-0.5.1, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
         - microlens-process < 0 # tried microlens-process-0.2.0.2, but its *library* requires microlens >=0.3 && < 0.4.13 and the snapshot contains microlens-0.4.13.1
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-api-data >=0.3 && < 0.5 and the snapshot contains http-api-data-0.6.1
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.2
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires servant-client >=0.13 && < 0.16 and the snapshot contains servant-client-0.20.2
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - microsoft-translator < 0 # tried microsoft-translator-0.1.2, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires lens >=4.4 && < 4.20 and the snapshot contains lens-5.3.2
         - milena < 0 # tried milena-0.5.4.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7493,7 +7016,6 @@ packages:
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *executable* requires the disabled package: pipes-text
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
         - moffy-samples-gtk4 < 0 # tried moffy-samples-gtk4-0.1.0.1, but its *executable* requires the disabled package: moffy-samples-gtk4-run
-        - mole < 0 # tried mole-0.0.7, but its *executable* requires base >=4.11 && < 4.15 and the snapshot contains base-4.19.1.0
         - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - monad-journal < 0 # tried monad-journal-0.8.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - monad-logger-prefix < 0 # tried monad-logger-prefix-0.1.12, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7510,25 +7032,12 @@ packages:
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires msgpack >=0.7 && < 0.8 and the snapshot contains msgpack-1.0.1.0
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires shakespeare-text >=1.0 && < 1.1 and the snapshot contains shakespeare-text-1.1.0
         - msgpack-idl < 0 # tried msgpack-idl-0.2.1, but its *library* requires template-haskell >=2.5 && < 2.9 and the snapshot contains template-haskell-2.21.0.0
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.19.1.0
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires binary-conduit >=1.2.3 && < 1.3 and the snapshot contains binary-conduit-1.3.1
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires bytestring >=0.10.4 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit >=1.2.3.1 && < 1.3 and the snapshot contains conduit-1.3.6
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires conduit-extra >=1.1.3.4 && < 1.3 and the snapshot contains conduit-extra-1.3.6
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires network >=2.6 && < 2.9 || >=3.0 && < 3.1 and the snapshot contains network-3.2.2.0
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.2
-        - msgpack-rpc < 0 # tried msgpack-rpc-1.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - mstate < 0 # tried mstate-0.2.10, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - mwc-random-accelerate < 0 # tried mwc-random-accelerate-0.2.0.0, but its *library* requires the disabled package: accelerate
         - mwc-random-monad < 0 # tried mwc-random-monad-0.7.3.1, but its *library* requires the disabled package: monad-primitive
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires mysql-haskell >=0.8.3 && < 0.8.5 and the snapshot contains mysql-haskell-1.1.5
         - mysql-haskell-openssl < 0 # tried mysql-haskell-openssl-0.8.3.1, but its *library* requires the disabled package: tcp-streams
         - n2o-web < 0 # tried n2o-web-0.11.2, but its *library* requires the disabled package: n2o-protocols
         - nakadi-client < 0 # tried nakadi-client-0.7.0.0, but its *library* requires resourcet >=1.2.0 && < 1.3 and the snapshot contains resourcet-1.3.0
-        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires base >=4.10 && < 4.13 and the snapshot contains base-4.19.1.0
-        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - naqsha < 0 # tried naqsha-0.3.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
         - net-mqtt < 0 # tried net-mqtt-0.8.6.1, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - net-mqtt < 0 # tried net-mqtt-0.8.6.1, but its *library* requires deepseq >=1.4.3.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - net-mqtt < 0 # tried net-mqtt-0.8.6.1, but its *library* requires text >=1.2.3 && < 2.1.0 and the snapshot contains text-2.1.1
@@ -7587,7 +7096,6 @@ packages:
         - numhask-prelude < 0 # tried numhask-prelude-0.5.0, but its *library* requires numhask >=0.3 && < 0.6 and the snapshot contains numhask-0.12.0.3
         - ochintin-daicho < 0 # tried ochintin-daicho-0.3.4.2, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - oeis < 0 # tried oeis-0.3.10, but its *library* requires HTTP >=4000.2 && < 4000.4 and the snapshot contains HTTP-4000.4.1
-        - oset < 0 # tried oset-0.4.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *executable* requires optparse-applicative >=0.14 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires Cabal >=3.2 && < 3.3 and the snapshot contains Cabal-3.10.2.0
         - packdeps < 0 # tried packdeps-0.6.0.0, but its *library* requires tar >=0.4 && < 0.6 and the snapshot contains tar-0.6.3.0
@@ -7637,26 +7145,6 @@ packages:
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires hmatrix >=0.17.0.2 && < 0.19 and the snapshot contains hmatrix-0.20.2
         - picedit < 0 # tried picedit-0.2.3.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.1.0
         - picosat < 0 # tried picosat-0.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.2.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires aeson >=1.3 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires base >=4.11 && < 4.12 and the snapshot contains base-4.19.1.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires binary-orphans >=0.1 && < 0.2 and the snapshot contains binary-orphans-1.0.5
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.7.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires shake >=0.16 && < 0.17 and the snapshot contains shake-0.19.8
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - pier < 0 # tried pier-0.3.0.0, but its *executable* requires yaml >=0.8 && < 0.11 and the snapshot contains yaml-0.11.11.2
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires Cabal >=2.2 && < 2.3 and the snapshot contains Cabal-3.10.2.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base >=4.11 && < 4.12 and the snapshot contains base-4.19.1.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires base64-bytestring >=1.0 && < 1.1 and the snapshot contains base64-bytestring-1.2.1.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.6.8
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.4.7.0
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires shake >=0.16.4 && < 0.17 and the snapshot contains shake-0.19.8
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - pier-core < 0 # tried pier-core-0.3.0.0, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.1.1
         - pinboard < 0 # tried pinboard-0.10.3.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.1.0
@@ -7667,21 +7155,12 @@ packages:
         - pipes-text < 0 # tried pipes-text-1.0.1, but its *library* requires bytestring >=0.9.2.1 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - pipes-text < 0 # tried pipes-text-1.0.1, but its *library* requires text >=0.11.2 && < 2.1 and the snapshot contains text-2.1.1
         - pixelated-avatar-generator < 0 # tried pixelated-avatar-generator-0.1.3, but its *executable* requires the disabled package: cli
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires base >=4.7 && < 4.13 || ^>=4.13 and the snapshot contains base-4.19.1.0
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires haskell-src-exts-simple >=1.18 && < 1.21 || ^>=1.21 and the snapshot contains haskell-src-exts-simple-1.23.0.0
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires mtl >=2 && < 2.2 || ^>=2.2 and the snapshot contains mtl-2.3.1
-        - pointful < 0 # tried pointful-1.1.0.0, but its *library* requires transformers >=0.2 && < 0.5 || ^>=0.5 and the snapshot contains transformers-0.6.1.0
         - polysemy-extra < 0 # tried polysemy-extra-0.2.1.0, but its *library* requires polysemy >=1.4 && < 1.8 and the snapshot contains polysemy-1.9.2.0
         - polysemy-fskvstore < 0 # tried polysemy-fskvstore-0.1.2.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - polysemy-fskvstore < 0 # tried polysemy-fskvstore-0.1.2.0, but its *library* requires polysemy >=1.4.0.0 && < 1.8 and the snapshot contains polysemy-1.9.2.0
         - polysemy-kvstore < 0 # tried polysemy-kvstore-0.1.3.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.2.0
-        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires aeson >=1.0 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.19.1.0
-        - polysemy-kvstore-jsonfile < 0 # tried polysemy-kvstore-jsonfile-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.2.0
         - polysemy-methodology < 0 # tried polysemy-methodology-0.2.2.0, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.19.1.0
         - polysemy-methodology < 0 # tried polysemy-methodology-0.2.2.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.2.0
-        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires base >=4.7 && < 4.16 and the snapshot contains base-4.19.1.0
-        - polysemy-path < 0 # tried polysemy-path-0.2.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.7 and the snapshot contains polysemy-1.9.2.0
         - polysemy-several < 0 # tried polysemy-several-0.1.1.0, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.19.1.0
         - polysemy-several < 0 # tried polysemy-several-0.1.1.0, but its *library* requires polysemy >=1.3.0.0 && < 1.8 and the snapshot contains polysemy-1.9.2.0
         - polysemy-socket < 0 # tried polysemy-socket-0.0.2.0, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -7697,32 +7176,7 @@ packages:
         - polysemy-zoo < 0 # tried polysemy-zoo-0.8.2.0, but its *library* requires constraints >=0.10.1 && < 0.14 and the snapshot contains constraints-0.14.2
         - polysemy-zoo < 0 # tried polysemy-zoo-0.8.2.0, but its *library* requires ghc-prim >=0.5.2 && < 0.10 and the snapshot contains ghc-prim-0.11.0
         - polysemy-zoo < 0 # tried polysemy-zoo-0.8.2.0, but its *library* requires text >=1.1.0 && < 2.1 and the snapshot contains text-2.1.1
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires base >=4.6.0.0 && < 4.15 and the snapshot contains base-4.19.1.0
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires containers >=0.5.9.2 && < =0.6.4.1 and the snapshot contains containers-0.6.8
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - pomaps < 0 # tried pomaps-0.2.0.1, but its *library* requires ghc-prim >=0.4 && < 0.7 and the snapshot contains ghc-prim-0.11.0
         - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: inflections
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires HTTP >=4000.3.7 && < 4000.4 and the snapshot contains HTTP-4000.4.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires aeson >=1.4.7 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires auto-update >=0.1.4 && < 0.2 and the snapshot contains auto-update-0.2.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires base >=4.9 && < 4.16 and the snapshot contains base-4.19.1.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires cookie >=0.4.2 && < 0.5 and the snapshot contains cookie-0.5.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql >=1.4 && < 1.5 and the snapshot contains hasql-1.8.0.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-dynamic-statements ==0.3.1 and the snapshot contains hasql-dynamic-statements-0.3.1.7
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-pool >=0.5 && < 0.6 and the snapshot contains hasql-pool-1.2.0.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires hasql-transaction >=1.0.1 && < 1.1 and the snapshot contains hasql-transaction-1.1.1.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires jose >=0.8.1 && < 0.9 and the snapshot contains jose-0.11
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens >=4.14 && < 5.1 and the snapshot contains lens-5.3.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires lens-aeson >=1.0.1 && < 1.2 and the snapshot contains lens-aeson-1.2.3
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires network >=2.6 && < 3.2 and the snapshot contains network-3.2.2.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires swagger2 >=2.4 && < 2.7 and the snapshot contains swagger2-2.8.9
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.1.1
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires time >=1.6 && < 1.11 and the snapshot contains time-1.12.2
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - postgrest < 0 # tried postgrest-9.0.1, but its *library* requires warp >=3.3.19 && < 3.4 and the snapshot contains warp-3.4.1
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires Diff >=0.3 && < 0.5 and the snapshot contains Diff-0.5
         - pretty-diff < 0 # tried pretty-diff-0.4.0.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
@@ -7737,8 +7191,6 @@ packages:
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires prometheus ^>=2.2 and the snapshot contains prometheus-2.3.0
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.1
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
-        - publicsuffix < 0 # tried publicsuffix-0.20200526, but its *library* requires base >=4 && < 4.15 and the snapshot contains base-4.19.1.0
-        - pure-io < 0 # tried pure-io-0.2.1, but its *library* requires base >=4.5 && < 4.11 and the snapshot contains base-4.19.1.0
         - purview < 0 # tried purview-0.2.0.2, but its *library* requires template-haskell >=2.15.0 && < 2.21 and the snapshot contains template-haskell-2.21.0.0
         - purview < 0 # tried purview-0.2.0.2, but its *library* requires warp >=3.3.0 && < 3.4 and the snapshot contains warp-3.4.1
         - purview < 0 # tried purview-0.2.0.2, but its *library* requires websockets >=0.12 && < 0.13 and the snapshot contains websockets-0.13.0.0
@@ -7772,8 +7224,6 @@ packages:
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.3.2
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.3
         - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
-        - random-source < 0 # tried random-source-0.3.0.13, but its *library* requires base >=4 && < 4.16 and the snapshot contains base-4.19.1.0
-        - random-source < 0 # tried random-source-0.3.0.13, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.2.3.0
         - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires the disabled package: reanimate-svg
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.19.1.0
@@ -7809,13 +7259,8 @@ packages:
         - repa-algorithms < 0 # tried repa-algorithms-3.4.1.5, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
         - repa-io < 0 # tried repa-io-3.4.1.2, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - repa-io < 0 # tried repa-io-3.4.1.2, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *executable* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
-        - req-url-extra < 0 # tried req-url-extra-0.1.1.0, but its *library* requires req >=2.0.0 && < 2.1.0 and the snapshot contains req-3.13.3
         - require < 0 # tried require-0.4.11, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - require < 0 # tried require-0.4.11, but its *library* requires text >=1.2.3.0 && < 2 and the snapshot contains text-2.1.1
-        - rethinkdb-client-driver < 0 # tried rethinkdb-client-driver-0.0.25, but its *library* requires base < 4.15 and the snapshot contains base-4.19.1.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires aeson >=0.8 && < 1.5.7 and the snapshot contains aeson-2.2.3.0
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires attoparsec >=0.12.1.6 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - riak < 0 # tried riak-1.2.0.0, but its *library* requires network >=3.0 && < 3.1 and the snapshot contains network-3.2.2.0
@@ -7846,16 +7291,8 @@ packages:
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires bytestring >=0.10.8 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
         - saltine < 0 # tried saltine-0.2.1.0, but its *library* requires text ^>=1.2 || ^>=2.0 and the snapshot contains text-2.1.1
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - scale < 0 # tried scale-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires containers >=0.5.7.1 && < 0.6 and the snapshot contains containers-0.6.8
         - scalendar < 0 # tried scalendar-1.2.0, but its *library* requires text >=1.2.0.0 && < 2 and the snapshot contains text-2.1.1
-        - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires aeson >=1 && < 1.4.3.0 and the snapshot contains aeson-2.2.3.0
-        - schematic < 0 # tried schematic-0.5.1.0, but its *library* requires the disabled package: validationt
         - sdl2 < 0 # tried sdl2-2.5.5.0, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - sdl2 < 0 # tried sdl2-2.5.5.0, but its *library* requires linear >=1.10.1.2 && < 1.23 and the snapshot contains linear-1.23
         - sdl2-gfx < 0 # tried sdl2-gfx-0.3.0.0, but its *library* requires the disabled package: sdl2
@@ -7878,31 +7315,7 @@ packages:
         - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
         - selda-sqlite < 0 # tried selda-sqlite-0.1.7.2, but its *library* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - semigroupoid-extras < 0 # tried semigroupoid-extras-5, but its *library* requires semigroupoids >=5 && < 6 and the snapshot contains semigroupoids-6.0.1
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires base >=4.11 && < 4.14 and the snapshot contains base-4.19.1.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires http-client >=0.5.6 && < 0.7 and the snapshot contains http-client-0.7.17
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires lens >=4.15 && < 4.20 and the snapshot contains lens-5.3.2
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires network >=2.2.3 && < 3.2 and the snapshot contains network-3.2.2.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires optparse-applicative >=0.12 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires text >=1.2.2 && < 1.3 and the snapshot contains text-2.1.1
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires time >=1.5.0.1 && < 1.10 and the snapshot contains time-1.12.2
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix < 2.8 and the snapshot contains unix-2.8.4.0
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires unix-compat < 0.6 and the snapshot contains unix-compat-0.7.2
-        - sensu-run < 0 # tried sensu-run-0.7.0.5, but its *executable* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - seqloc < 0 # tried seqloc-0.6.1.1, but its *library* requires the disabled package: biocore
         - serf < 0 # tried serf-0.1.1.0, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.1
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires blaze-builder >=0.4 && < 0.4.1 and the snapshot contains blaze-builder-0.4.2.3
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cookie >=0.4.1 && < 0.5 and the snapshot contains cookie-0.5.0
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires cryptonite >=0.14 && < 0.25 and the snapshot contains cryptonite-0.30
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires exceptions >=0.8 && < 0.9 and the snapshot contains exceptions-0.10.7
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-api-data >=0.3 && < 0.4 and the snapshot contains http-api-data-0.6.1
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires http-types >=0.9 && < 0.12 and the snapshot contains http-types-0.12.4
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires memory >=0.11 && < 0.15 and the snapshot contains memory-0.18.0
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant >=0.5 && < 0.13 and the snapshot contains servant-0.20.2
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires servant-server >=0.5 && < 0.13 and the snapshot contains servant-server-0.20.2
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires time >=1.6 && < 1.8.1 and the snapshot contains time-1.12.2
-        - servant-auth-cookie < 0 # tried servant-auth-cookie-0.6.0.3, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires servant-server >=0.14 && < 0.20 and the snapshot contains servant-server-0.20.2
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: wordpress-auth
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.13.1
@@ -7912,8 +7325,6 @@ packages:
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.20.2
         - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
         - servant-elm < 0 # tried servant-elm-0.7.3, but its *library* requires the disabled package: elm-bridge
-        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires aeson >=1.3 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - servant-errors < 0 # tried servant-errors-0.1.7.0, but its *library* requires base >=4.10.0.0 && < 4.15 and the snapshot contains base-4.19.1.0
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
         - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires lens >=4.17 && < 5.3 and the snapshot contains lens-5.3.2
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.6.8
@@ -7923,13 +7334,6 @@ packages:
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires QuickCheck >=2.12.6.1 && < 2.14 and the snapshot contains QuickCheck-2.14.3
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.19.1.0
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant >=0.17 && < 0.19 and the snapshot contains servant-0.20.2
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires servant-server >=0.17 && < 0.19 and the snapshot contains servant-server-0.20.2
-        - servant-mock < 0 # tried servant-mock-0.8.7, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires lens >=4.9 && < 5 and the snapshot contains lens-5.3.2
@@ -7938,30 +7342,14 @@ packages:
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16.1
         - servant-ruby < 0 # tried servant-ruby-0.9.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.1.0
-        - servant-streaming < 0 # tried servant-streaming-0.3.0.0, but its *library* requires servant >=0.13 && < 0.16 and the snapshot contains servant-0.20.2
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.1.0
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant >=0.14 && < 0.15 and the snapshot contains servant-0.20.2
-        - servant-streaming-client < 0 # tried servant-streaming-client-0.3.0.0, but its *library* requires servant-client-core >=0.14 && < 0.15 and the snapshot contains servant-client-core-0.20.2
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires base >=4.7 && < 4.13 and the snapshot contains base-4.19.1.0
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires http-media >=0.6 && < 0.8 and the snapshot contains http-media-0.8.1.1
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires resourcet >=1.1 && < 1.3 and the snapshot contains resourcet-1.3.0
-        - servant-streaming-server < 0 # tried servant-streaming-server-0.3.0.0, but its *library* requires servant-server >=0.13 && < 0.15 and the snapshot contains servant-server-0.20.2
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires base >=4.7 && < 4.19 and the snapshot contains base-4.19.1.0
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires file-embed-lzma >=0 && < 0.1 and the snapshot contains file-embed-lzma-0.1
         - servant-swagger-ui-redoc < 0 # tried servant-swagger-ui-redoc-0.3.4.1.22.3, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1.1
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires base >=4.9 && < 4.14 and the snapshot contains base-4.19.1.0
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - servant-yaml < 0 # tried servant-yaml-0.1.0.1, but its *library* requires servant >=0.15 && < 0.18 and the snapshot contains servant-0.20.2
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires exceptions >=0.8.3 && < 0.10.0 and the snapshot contains exceptions-0.10.7
         - sessiontypes-distributed < 0 # tried sessiontypes-distributed-0.1.1, but its *library* requires the disabled package: sessiontypes
         - sets < 0 # tried sets-0.0.6.2, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
-        - sexpr-parser < 0 # tried sexpr-parser-0.2.2.0, but its *executable* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - sexpr-parser < 0 # tried sexpr-parser-0.2.2.0, but its *library* requires megaparsec >=6.5 && < 9.3 and the snapshot contains megaparsec-9.6.1
         - shake-language-c < 0 # tried shake-language-c-0.12.0, but its *library* requires the disabled package: fclabels
         - shake-plus-extended < 0 # tried shake-plus-extended-0.4.1.0, but its *library* requires the disabled package: ixset-typed
         - shellmet < 0 # tried shellmet-0.0.4.1, but its *library* requires text >=1.2.3 && < 2.1 and the snapshot contains text-2.1.1
@@ -7980,13 +7368,6 @@ packages:
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.21.0.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.1
         - siphash < 0 # tried siphash-1.0.3, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires base >=4.9 && < 4.13 and the snapshot contains base-4.19.1.0
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires constraints >=0.9 && < 0.11 and the snapshot contains constraints-0.14.2
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires lens >=4.15 && < 5 and the snapshot contains lens-5.3.2
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.2
-        - sized-grid < 0 # tried sized-grid-0.2.0.1, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires aeson >=2.0 && < 2.2 and the snapshot contains aeson-2.2.3.0
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires base >=4.11 && < 4.18 and the snapshot contains base-4.19.1.0
@@ -7995,7 +7376,6 @@ packages:
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires servant-client >=0.16 && < 0.20 and the snapshot contains servant-client-0.20.2
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires servant-client-core >=0.16 && < 0.20 and the snapshot contains servant-client-core-0.20.2
         - slack-web < 0 # tried slack-web-1.6.1.0, but its *library* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
-        - smallcheck-series < 0 # tried smallcheck-series-0.7.1.0, but its *library* requires base >=4.6 && < 4.15 and the snapshot contains base-4.19.1.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.19.1.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.2
         - smash < 0 # tried smash-0.1.3, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
@@ -8047,8 +7427,6 @@ packages:
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
         - srt-formatting < 0 # tried srt-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
-        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires base >=4.12.0.0 && < 4.16 and the snapshot contains base-4.19.1.0
-        - stackcollapse-ghc < 0 # tried stackcollapse-ghc-0.0.1.4, but its *executable* requires transformers >=0.5.6 && < 0.5.7 and the snapshot contains transformers-0.6.1.0
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires base >=4.5 && < 4.19 and the snapshot contains base-4.19.1.0
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires text >=0.11 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
         - stb-image-redux < 0 # tried stb-image-redux-0.2.1.2, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
@@ -8059,7 +7437,6 @@ packages:
         - streamly-examples < 0 # tried streamly-examples-0.2.0, but its *executable* requires streamly ==0.10.0 and the snapshot contains streamly-0.10.1
         - streamly-examples < 0 # tried streamly-examples-0.2.0, but its *executable* requires streamly-core ==0.2.0 and the snapshot contains streamly-core-0.2.2
         - streamly-examples < 0 # tried streamly-examples-0.2.0, but its *executable* requires tasty-bench >=0.3 && < 0.4 and the snapshot contains tasty-bench-0.4
-        - streamproc < 0 # tried streamproc-1.6.2, but its *library* requires base >=3 && < 4.13 and the snapshot contains base-4.19.1.0
         - streamt < 0 # tried streamt-0.5.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
         - strict-tuple-lens < 0 # tried strict-tuple-lens-0.2, but its *library* requires lens ^>=5 and the snapshot contains lens-5.3.2
         - string-random < 0 # tried string-random-0.1.4.3, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
@@ -8100,28 +7477,6 @@ packages:
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires haskell-src-exts >=1.18 && < 1.20 and the snapshot contains haskell-src-exts-1.23.1
         - structured-haskell-mode < 0 # tried structured-haskell-mode-1.1.0, but its *executable* requires the disabled package: descriptive
         - superbuffer < 0 # tried superbuffer-0.3.1.2, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.19.1.0
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.2
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.1
-        - sv < 0 # tried sv-1.4.0.1, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sv-cassava < 0 # tried sv-cassava-0.3, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires attoparsec >=0.12.1.4 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires base >=4.9 && < 4.15 and the snapshot contains base-4.19.1.0
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires bifunctors >=5.1 && < 5.6 and the snapshot contains bifunctors-5.6.2
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires lens >=4 && < 4.20 and the snapshot contains lens-5.3.2
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires mtl >=2.0.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires profunctors >=5.2.1 && < 5.6 and the snapshot contains profunctors-5.6.2
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroupoids >=5 && < 5.4 and the snapshot contains semigroupoids-6.0.1
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - sv-core < 0 # tried sv-core-0.5, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires aeson >=1.0 && < 2.0 and the snapshot contains aeson-2.2.3.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires containers >=0.5.0.0 && < 0.6 and the snapshot contains containers-0.6.8
@@ -8187,9 +7542,6 @@ packages:
         - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
         - transformers-bifunctors < 0 # tried transformers-bifunctors-0.1, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - transformers-fix < 0 # tried transformers-fix-1.0, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires base >=4.8 && < 4.13 and the snapshot contains base-4.19.1.0
-        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - transformers-lift < 0 # tried transformers-lift-0.2.0.2, but its *library* requires writer-cps-transformers ==0.1.1.4 and the snapshot contains writer-cps-transformers-0.5.6.1
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires network >=2.8.0.0 && < 3.0.0.0 and the snapshot contains network-3.2.2.0
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: TCache
         - transient-universe < 0 # tried transient-universe-0.6.0.1, but its *library* requires the disabled package: transient
@@ -8200,28 +7552,7 @@ packages:
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
         - ttl-hashtables < 0 # tried ttl-hashtables-1.4.1.0, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - type-combinators-singletons < 0 # tried type-combinators-singletons-0.2.1.0, but its *library* requires the disabled package: type-combinators
-        - type-errors-pretty < 0 # tried type-errors-pretty-0.0.1.2, but its *library* requires base >=4.10.1.0 && < 4.16 and the snapshot contains base-4.19.1.0
         - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.19.1.0
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires attoparsec >=0.13.2.2 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.19.1.0
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires cryptonite >=0.25 && < 0.27 and the snapshot contains cryptonite-0.30
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires http-api-data >=0.3.8.1 && < 0.5 and the snapshot contains http-api-data-0.6.1
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires parser-combinators >=1.0.0 && < 1.3 and the snapshot contains parser-combinators-1.3.0
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires the disabled package: x509
-        - ucam-webauth < 0 # tried ucam-webauth-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires aeson >=1.2 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base >=4.11.0.0 && < 4.13 and the snapshot contains base-4.19.1.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires base64-bytestring >=1.0.0.1 && < 1.1 and the snapshot contains base64-bytestring-1.2.1.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires deepseq >=1.4.3.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires text >=0.11 && < 1.2.3.0 || >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires time >=1.8.0.2 && < 1.10 and the snapshot contains time-1.12.2
-        - ucam-webauth-types < 0 # tried ucam-webauth-types-0.1.0.0, but its *library* requires timerep >=2.0.0.2 && < 2.1 and the snapshot contains timerep-2.1.0.0
         - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable
         - unfork < 0 # tried unfork-1.0.0.1, but its *library* requires base ^>=4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.19.1.0
@@ -8241,19 +7572,12 @@ packages:
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: dhall
         - variable-media-field-dhall < 0 # tried variable-media-field-dhall-0.1.0.0, but its *library* requires the disabled package: variable-media-field
         - variable-media-field-optics < 0 # tried variable-media-field-optics-0.1.0.0, but its *library* requires the disabled package: variable-media-field
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires base >=4.0.0.0 && < 4.11 and the snapshot contains base-4.19.1.0
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires containers >=0.5.5.1 && < 0.6 and the snapshot contains containers-0.6.8
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires mtl >=2.0.1.0 && < 2.3 and the snapshot contains mtl-2.3.1
-        - vcswrapper < 0 # tried vcswrapper-0.1.6, but its *library* requires text >=0.11.1.5 && < 1.3 and the snapshot contains text-2.1.1
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.19.1.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.9.0.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires semigroupoids >=5.3 && < 5.4 and the snapshot contains semigroupoids-6.0.1
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires template-haskell >=2.12 && < 2.19 and the snapshot contains template-haskell-2.21.0.0
         - vector-circular < 0 # tried vector-circular-0.1.4, but its *library* requires vector >=0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires base >=4.3 && < 4.15 and the snapshot contains base-4.19.1.0
-        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires primitive >=0.6 && < 0.8 and the snapshot contains primitive-0.9.0.0
-        - vector-fftw < 0 # tried vector-fftw-0.1.4.0, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.1.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.0.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.1
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires the disabled package: protocol-buffers
@@ -8262,13 +7586,6 @@ packages:
         - verbosity < 0 # tried verbosity-0.4.0.0, but its *library* requires the disabled package: dhall
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires aeson >=1.2 && < 2.0 and the snapshot contains aeson-2.2.3.0
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires text >=1.2 && < 2.0 and the snapshot contains text-2.1.1
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires base >=4.9 && < 4.15 and the snapshot contains base-4.19.1.0
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires brick >0.26.1 && < 0.54 and the snapshot contains brick-2.3.2
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.3.2
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires text >=1.2.2.0 && < 1.3 and the snapshot contains text-2.1.1
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vector-algorithms >=0.6.0.4 && < 0.9 and the snapshot contains vector-algorithms-0.9.0.2
-        - viewprof < 0 # tried viewprof-0.0.0.33, but its *executable* requires vty >=5.13 && < 5.29 and the snapshot contains vty-6.2
         - wai-control < 0 # tried wai-control-0.2.0.0, but its *library* requires websockets >=0.12.5.3 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.2.3.0
@@ -8293,48 +7610,6 @@ packages:
         - web-routes-hsp < 0 # tried web-routes-hsp-0.24.6.2, but its *library* requires the disabled package: hsp
         - web-routes-wai < 0 # tried web-routes-wai-0.24.3.2, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - web-routes-wai < 0 # tried web-routes-wai-0.24.3.2, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
-        - web3 < 0 # tried web3-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-bignum < 0 # tried web3-bignum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - web3-crypto < 0 # tried web3-crypto-1.0.0.0, but its *library* requires vector >0.12 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.2
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires microlens-aeson >2.2 && < 2.4 and the snapshot contains microlens-aeson-2.5.2
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - web3-ethereum < 0 # tried web3-ethereum-1.0.0.0, but its *library* requires vinyl >0.5 && < 0.14 and the snapshot contains vinyl-0.14.3
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires cryptonite >0.22 && < 0.30 and the snapshot contains cryptonite-0.30
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - web3-polkadot < 0 # tried web3-polkadot-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires http-client >0.5 && < 0.7 and the snapshot contains http-client-0.7.17
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires mtl >2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires network >2.5 && < 3.2 and the snapshot contains network-3.2.2.0
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires transformers >0.5 && < 0.6 and the snapshot contains transformers-0.6.1.0
-        - web3-provider < 0 # tried web3-provider-1.0.0.0, but its *library* requires websockets >0.10 && < 0.13 and the snapshot contains websockets-0.13.0.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires OneTuple >0.2 && < 0.3 and the snapshot contains OneTuple-0.4.2
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires aeson >1.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires base >4.11 && < 4.15 and the snapshot contains base-4.19.1.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires bytestring >0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires memory >0.14 && < 0.16 and the snapshot contains memory-0.18.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires template-haskell >2.11 && < 2.17 and the snapshot contains template-haskell-2.21.0.0
-        - web3-solidity < 0 # tried web3-solidity-1.0.0.0, but its *library* requires text >1.2 && < 1.3 and the snapshot contains text-2.1.1
         - webby < 0 # tried webby-1.1.1, but its *library* requires aeson >=1.4 && < 2.2 and the snapshot contains aeson-2.2.3.0
         - webby < 0 # tried webby-1.1.1, but its *library* requires formatting >=6.3.7 && < 7.2 and the snapshot contains formatting-7.2.0
         - webby < 0 # tried webby-1.1.1, but its *library* requires http-api-data >=0.4 && < 0.6 and the snapshot contains http-api-data-0.6.1
@@ -8421,9 +7696,6 @@ packages:
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires time >=1.5 && < 1.12 and the snapshot contains time-1.12.2
         - ztail < 0 # tried ztail-1.2.0.3, but its *executable* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.4.0
         - zxcvbn-hs < 0 # tried zxcvbn-hs-0.3.6, but its *library* requires zlib ^>=0.6 and the snapshot contains zlib-0.7.1.0
-        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires base >=4.7 && < 4.15 and the snapshot contains base-4.19.1.0
-        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - zydiskell < 0 # tried zydiskell-0.2.0.0, but its *library* requires storable-record >=0.0.5 && < 0.0.6 and the snapshot contains storable-record-0.0.7
     # End of Library and exe bounds failures
 
     "Stackage upper bounds":
@@ -8658,7 +7930,6 @@ skipped-tests:
     # These tests sometimes take too long and hit the stackage build
     # servers time limit so these shouldn't be removed from
     # skipped-tests unless we know a fix has been released.
-    - accelerate-fourier
     - binary-search # Never finishes https://github.com/nushio3/binary-search/issues/2
     - blank-canvas # Never finishes https://github.com/ku-fpg/blank-canvas/issues/73
     - cabal-helper
@@ -8794,14 +8065,12 @@ skipped-tests:
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
     # Test bounds issues
-    - BiobaseNewick # tried BiobaseNewick-0.0.0.2, but its *test-suite* requires the disabled package: test-framework-th
     - ENIG # tried ENIG-0.0.1.0, but its *test-suite* requires the disabled package: test-framework-th
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires doctest >=0.16.2 && < 0.20 and the snapshot contains doctest-0.22.6
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires hedgehog >=1.0.2 && < 1.2 and the snapshot contains hedgehog-1.4
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty >=1.2.3 && < 1.5 and the snapshot contains tasty-1.5
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-discover >=4.2.1 && < 4.3 and the snapshot contains tasty-discover-5.0.0
     - JuicyPixels-blurhash # tried JuicyPixels-blurhash-0.1.0.3, but its *test-suite* requires tasty-hedgehog >=1.0.0.2 && < 1.2 and the snapshot contains tasty-hedgehog-1.4.0.2
-    - TotalMap # tried TotalMap-0.1.1.1, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - airship # tried airship-0.9.5, but its *test-suite* requires bytestring >=0.9.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
     - airship # tried airship-0.9.5, but its *test-suite* requires tasty >=0.10.1 && < 1.3 and the snapshot contains tasty-1.5
     - airship # tried airship-0.9.5, but its *test-suite* requires tasty-quickcheck >=0.8.3 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
@@ -8831,7 +8100,6 @@ skipped-tests:
     - blake2 # tried blake2-0.3.0.1, but its *test-suite* requires tasty-quickcheck ^>=0.10.2 and the snapshot contains tasty-quickcheck-0.11
     - blas-hs # tried blas-hs-0.1.1.0, but its *test-suite* requires base < 4.13 and the snapshot contains base-4.19.1.0
     - bloodhound # tried bloodhound-0.22.0.0, but its *test-suite* requires the disabled package: quickcheck-properties
-    - boolean-normal-forms # tried boolean-normal-forms-0.0.1.1, but its *test-suite* requires QuickCheck >=2.10 && < 2.14 and the snapshot contains QuickCheck-2.14.3
     - brittany # tried brittany-0.14.0.2, but its *test-suite* requires hspec ^>=2.8.3 and the snapshot contains hspec-2.11.9
     - bugzilla-redhat # tried bugzilla-redhat-1.0.1.1, but its *test-suite* requires aeson >=0.7 && < 2.2 and the snapshot contains aeson-2.2.3.0
     - buttplug-hs-core # tried buttplug-hs-core-0.1.0.1, but its *test-suite* requires hspec >=2.7.8 && < 2.9 and the snapshot contains hspec-2.11.9
@@ -8910,7 +8178,6 @@ skipped-tests:
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires integer-gmp >=1.0.2 && < 1.1 and the snapshot contains integer-gmp-1.1
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires tasty >=1.2 && < 1.3 and the snapshot contains tasty-1.5
     - galois-field # tried galois-field-1.0.2, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - generic-xmlpickler # tried generic-xmlpickler-0.1.0.6, but its *test-suite* requires tasty >=0.10 && < 1.3 and the snapshot contains tasty-1.5
     - geojson # tried geojson-4.1.1, but its *test-suite* requires bytestring >=0.10.8.1 && < 0.12 and the snapshot contains bytestring-0.12.1.0
     - geojson # tried geojson-4.1.1, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.9
     - geojson # tried geojson-4.1.1, but its *test-suite* requires tasty >=0.8 && < 0.13 || >=1.0 && < 1.5 and the snapshot contains tasty-1.5
@@ -8923,20 +8190,6 @@ skipped-tests:
     - hasbolt # tried hasbolt-0.1.7.0, but its *test-suite* requires hspec >=2.4.1 && < 2.11 and the snapshot contains hspec-2.11.9
     - hashable # tried hashable-1.4.7.0, but its *test-suite* requires tasty-quickcheck ^>=0.10.3 and the snapshot contains tasty-quickcheck-0.11
     - haskell-names # tried haskell-names-0.9.9, but its *test-suite* requires tasty >=0.12 && < 1.3 and the snapshot contains tasty-1.5
-    - haskell-tools-builtin-refactorings # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskell-tools-builtin-refactorings # tried haskell-tools-builtin-refactorings-1.1.1.0, but its *test-suite* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires knob >=0.1 && < 0.2 and the snapshot contains knob-0.2.2
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires Glob >=0.9 && < 0.10 and the snapshot contains Glob-0.10.2
-    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-    - haskell-tools-daemon # tried haskell-tools-daemon-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskell-tools-demo # tried haskell-tools-demo-1.1.1.0, but its *test-suite* requires network >=2.6 && < 2.9 and the snapshot contains network-3.2.2.0
-    - haskell-tools-demo # tried haskell-tools-demo-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires polyparse >=1.12 && < 1.13 and the snapshot contains polyparse-1.13
-    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
-    - haskell-tools-refactor # tried haskell-tools-refactor-1.1.1.0, but its *test-suite* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
-    - haskell-tools-rewrite # tried haskell-tools-rewrite-1.1.1.0, but its *test-suite* requires tasty >=0.11 && < 1.2 and the snapshot contains tasty-1.5
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires lens >=4.12 && < 5 and the snapshot contains lens-5.3.2
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
     - haskoin-core # tried haskoin-core-1.1.0, but its *test-suite* requires base64 >=0.4 && < 0.5 and the snapshot contains base64-1.0
@@ -8944,7 +8197,6 @@ skipped-tests:
     - heap # tried heap-1.0.4, but its *test-suite* requires QuickCheck >=2.10 && < 2.12 and the snapshot contains QuickCheck-2.14.3
     - hegg # tried hegg-0.5.0.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5
     - hegg # tried hegg-0.5.0.0, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - hidden-char # tried hidden-char-0.1.0.2, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.9
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires QuickCheck < 2.12 and the snapshot contains QuickCheck-2.14.3
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires base < 4.12 and the snapshot contains base-4.19.1.0
     - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires hspec >=2.2 && < 2.6 and the snapshot contains hspec-2.11.9
@@ -8952,7 +8204,6 @@ skipped-tests:
     - hsdev # tried hsdev-0.3.4.0, but its *test-suite* requires lens-aeson >=1.0 && < 1.2 and the snapshot contains lens-aeson-1.2.3
     - hspec-expectations-pretty-diff # tried hspec-expectations-pretty-diff-0.7.2.6, but its *test-suite* requires aeson < 2 and the snapshot contains aeson-2.2.3.0
     - hspec-need-env # tried hspec-need-env-0.1.0.10, but its *test-suite* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
-    - hspec-tables # tried hspec-tables-0.0.1, but its *test-suite* requires hspec >=2.7 && < 2.8 and the snapshot contains hspec-2.11.9
     - http-conduit # tried http-conduit-2.3.9, but its *test-suite* requires warp >=3.0.0.2 && < 3.4 and the snapshot contains warp-3.4.1
     - http-media # tried http-media-0.8.1.1, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - hw-conduit # tried hw-conduit-0.2.1.1, but its *test-suite* requires doctest >=0.16.2 && < 0.21 and the snapshot contains doctest-0.22.6
@@ -8979,13 +8230,8 @@ skipped-tests:
     - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty-hspec >=1.1.2 && < 1.2 and the snapshot contains tasty-hspec-1.2.0.4
     - irc-dcc # tried irc-dcc-2.0.1, but its *test-suite* requires tasty-quickcheck >=0.8.4 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - isomorphism-class # tried isomorphism-class-0.1.0.12, but its *test-suite* requires tasty-quickcheck >=0.10.1 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - json-rpc-client # tried json-rpc-client-0.2.5.0, but its *test-suite* requires QuickCheck >=2.4.2 && < 2.14 and the snapshot contains QuickCheck-2.14.3
     - json-spec-elm-servant # tried json-spec-elm-servant-0.4.0.2, but its *test-suite* requires cookie >=0.4.6 && < 0.5 and the snapshot contains cookie-0.5.0
     - lattices # tried lattices-2.2.1, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec >=2.7 && < 2.8 and the snapshot contains hspec-2.11.9
-    - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires hspec-core >=2.7 && < 2.8 and the snapshot contains hspec-core-2.11.9
-    - libjwt-typed # tried libjwt-typed-0.2, but its *test-suite* requires the disabled package: jwt
-    - linear-accelerate # tried linear-accelerate-0.7.0.0, but its *test-suite* requires doctest >=0.11.1 && < 0.17 and the snapshot contains doctest-0.22.6
     - loc # tried loc-0.2.0.0, but its *test-suite* requires hedgehog ^>=1.0.5 || ^>=1.1 || ^>=1.2 and the snapshot contains hedgehog-1.4
     - loc # tried loc-0.2.0.0, but its *test-suite* requires hspec-hedgehog ^>=0.0.1 and the snapshot contains hspec-hedgehog-0.1.1.0
     - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.3
@@ -9014,8 +8260,6 @@ skipped-tests:
     - opaleye # tried opaleye-0.10.3.1, but its *test-suite* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
     - optics-operators # tried optics-operators-0.1.0.1, but its *test-suite* requires tasty-quickcheck >=0.10.2 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - options # tried options-1.2.1.2, but its *test-suite* requires the disabled package: patience
-    - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.9
-    - oset # tried oset-0.4.0.1, but its *test-suite* requires hspec-discover >=2.2 && < 2.8 and the snapshot contains hspec-discover-2.11.9
     - parameterized-utils # tried parameterized-utils-2.1.8.0, but its *test-suite* requires the disabled package: hedgehog-classes
     - partial-semigroup # tried partial-semigroup-0.6.0.2, but its *test-suite* requires hedgehog ^>=1.1.2 || ^>=1.2 and the snapshot contains hedgehog-1.4
     - pasta-curves # tried pasta-curves-0.0.1.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5
@@ -9027,7 +8271,6 @@ skipped-tests:
     - pipes-extras # tried pipes-extras-1.0.15, but its *test-suite* requires transformers >=0.2.0.0 && < 0.6 and the snapshot contains transformers-0.6.1.0
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
     - postgresql-libpq-notify # tried postgresql-libpq-notify-0.2.0.0, but its *test-suite* requires the disabled package: tmp-postgres
-    - postgrest # tried postgrest-9.0.1, but its *test-suite* requires hspec >=2.3 && < 2.9 and the snapshot contains hspec-2.11.9
     - pretty-diff # tried pretty-diff-0.4.0.3, but its *test-suite* requires tasty >=1.1 && < 1.5 and the snapshot contains tasty-1.5
     - pretty-sop # tried pretty-sop-0.2.0.3, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - prettyprinter # tried prettyprinter-1.7.1, but its *test-suite* requires the disabled package: pgp-wordlist
@@ -9051,15 +8294,10 @@ skipped-tests:
     - registry # tried registry-0.6.1.0, but its *test-suite* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
     - registry # tried registry-0.6.1.0, but its *test-suite* requires tasty < 1.5 and the snapshot contains tasty-1.5
     - rel8 # tried rel8-1.5.0.0, but its *test-suite* requires the disabled package: tmp-postgres
-    - req-url-extra # tried req-url-extra-0.1.1.0, but its *test-suite* requires hspec >=2.2 && < 2.8 and the snapshot contains hspec-2.11.9
     - rhine # tried rhine-1.4.0.1, but its *test-suite* requires tasty-quickcheck ^>=0.10 and the snapshot contains tasty-quickcheck-0.11
     - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.14.3
-    - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - scale # tried scale-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
     - scalendar # tried scalendar-1.2.0, but its *test-suite* requires the disabled package: SCalendar
-    - schematic # tried schematic-0.5.1.0, but its *test-suite* requires base >=4.11 && < 4.13 and the snapshot contains base-4.19.1.0
     - serialise # tried serialise-0.2.6.1, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - servant-auth-cookie # tried servant-auth-cookie-0.6.0.3, but its *test-suite* requires deepseq >=1.3 && < 1.5 and the snapshot contains deepseq-1.5.0.0
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.20 and the snapshot contains servant-server-0.20.2
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires warp >=3.0.13.1 && < 3.4 and the snapshot contains warp-3.4.1
     - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.11.9
@@ -9068,22 +8306,9 @@ skipped-tests:
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.9
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires http-api-data >=0.3.7 && < 0.4.2 and the snapshot contains http-api-data-0.6.1
-    - servant-mock # tried servant-mock-0.8.7, but its *test-suite* requires hspec-wai >=0.9.0 && < 0.11 and the snapshot contains hspec-wai-0.11.1
-    - servant-streaming # tried servant-streaming-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.13 and the snapshot contains QuickCheck-2.14.3
-    - servant-streaming-client # tried servant-streaming-client-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
-    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires QuickCheck >=2.8 && < 2.12 and the snapshot contains QuickCheck-2.14.3
-    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires streaming-bytestring >=0.1 && < 0.2 and the snapshot contains streaming-bytestring-0.3.2
-    - servant-streaming-server # tried servant-streaming-server-0.3.0.0, but its *test-suite* requires warp >=3.2.4 && < 3.3 and the snapshot contains warp-3.4.1
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires base-compat >=0.10.5 && < 0.12 and the snapshot contains base-compat-0.13.1
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires servant-server >=0.15 && < 0.18 and the snapshot contains servant-server-0.20.2
-    - servant-yaml # tried servant-yaml-0.1.0.1, but its *test-suite* requires warp >=3.2.25 && < 3.4 and the snapshot contains warp-3.4.1
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.9
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.4
-    - sexpr-parser # tried sexpr-parser-0.2.2.0, but its *test-suite* requires hspec >=2.5 && < 2.10 and the snapshot contains hspec-2.11.9
     - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.11.9
-    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires ansi-terminal >=0.8.0.2 && < 0.10 and the snapshot contains ansi-terminal-1.1.1
-    - sized-grid # tried sized-grid-0.2.0.1, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - slack-web # tried slack-web-1.6.1.0, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.11 and the snapshot contains hspec-discover-2.11.9
     - sparse-tensor # tried sparse-tensor-0.2.1.5, but its *test-suite* requires tasty >=0.11 && < 1.5 and the snapshot contains tasty-1.5
     - sparse-tensor # tried sparse-tensor-0.2.1.5, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
@@ -9099,16 +8324,6 @@ skipped-tests:
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty-discover >=4.2 && < 4.3 and the snapshot contains tasty-discover-5.0.0
     - strong-path # tried strong-path-1.1.4.0, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires hedgehog >=0.5 && < 1.1 and the snapshot contains hedgehog-1.4
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires lens >=4 && < 4.20 and the snapshot contains lens-5.3.2
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires semigroups >=0.18 && < 0.20 and the snapshot contains semigroups-0.20
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.5
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires tasty-hedgehog >=0.1 && < 1.1 and the snapshot contains tasty-hedgehog-1.4.0.2
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-    - sv # tried sv-1.4.0.1, but its *test-suite* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-    - sv-cassava # tried sv-cassava-0.3, but its *test-suite* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-    - sv-core # tried sv-core-0.5, but its *test-suite* requires tasty >=0.11 && < 1.3 and the snapshot contains tasty-1.5
-    - sv-core # tried sv-core-0.5, but its *test-suite* requires tasty-quickcheck >=0.9 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - swagger2 # tried swagger2-2.8.9, but its *test-suite* requires hspec-discover >=2.5.5 && < 2.9 and the snapshot contains hspec-discover-2.11.9
     - system-fileio # tried system-fileio-0.3.16.4, but its *test-suite* requires the disabled package: chell
     - system-filepath # tried system-filepath-0.4.14, but its *test-suite* requires the disabled package: chell
@@ -9123,13 +8338,7 @@ skipped-tests:
     - text-builder-dev # tried text-builder-dev-0.3.4.4, but its *test-suite* requires tasty-quickcheck >=0.10.1 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - text-iso8601 # tried text-iso8601-0.1.1, but its *test-suite* requires tasty-quickcheck >=0.10.2 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - type-errors # tried type-errors-0.2.0.2, but its *test-suite* requires doctest >=0.16.0.1 && < 0.22 and the snapshot contains doctest-0.22.6
-    - type-errors-pretty # tried type-errors-pretty-0.0.1.2, but its *test-suite* requires doctest >=0.16 && < 0.19 and the snapshot contains doctest-0.22.6
     - tztime # tried tztime-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hunit-compat
-    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires QuickCheck >=2.11.3 && < 2.14 and the snapshot contains QuickCheck-2.14.3
-    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires generic-random >=1.2.0.0 && < 1.3 and the snapshot contains generic-random-1.5.0.1
-    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires hspec >=2.0.0 && < 2.8 and the snapshot contains hspec-2.11.9
-    - ucam-webauth # tried ucam-webauth-0.1.0.0, but its *test-suite* requires the disabled package: time-qq
-    - ucam-webauth-types # tried ucam-webauth-types-0.1.0.0, but its *test-suite* requires hspec >=2.0.0 && < 2.8 and the snapshot contains hspec-2.11.9
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires QuickCheck >=2.9 && < 2.14 and the snapshot contains QuickCheck-2.14.3
     - uniprot-kb # tried uniprot-kb-0.1.2.0, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.9
     - utf8-conversions # tried utf8-conversions-0.1.0.4, but its *test-suite* requires the disabled package: charsetdetect-ae
@@ -9139,16 +8348,6 @@ skipped-tests:
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires tasty-discover >=4.2 && < 5.0 and the snapshot contains tasty-discover-5.0.0
     - wakame # tried wakame-0.1.0.0, but its *test-suite* requires text >=1.2 && < 2.0 and the snapshot contains text-2.1.1
     - wave # tried wave-0.2.1, but its *test-suite* requires bytestring >=0.2 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-    - web3-bignum # tried web3-bignum-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - web3-bignum # tried web3-bignum-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
-    - web3-crypto # tried web3-crypto-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - web3-crypto # tried web3-crypto-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
-    - web3-ethereum # tried web3-ethereum-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - web3-ethereum # tried web3-ethereum-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
-    - web3-polkadot # tried web3-polkadot-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - web3-polkadot # tried web3-polkadot-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
-    - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec >=2.4.4 && < 2.8 and the snapshot contains hspec-2.11.9
-    - web3-solidity # tried web3-solidity-1.0.0.0, but its *test-suite* requires hspec-discover >=2.4.4 && < 2.8 and the snapshot contains hspec-discover-2.11.9
     - wild-bind-x11 # tried wild-bind-x11-0.2.0.15, but its *test-suite* requires time >=1.5.0 && < 1.12 and the snapshot contains time-1.12.2
     - xml-parser # tried xml-parser-0.1.1.1, but its *test-suite* requires tasty-quickcheck >=0.9 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - yesod-core # tried yesod-core-1.6.26.0, but its *test-suite* requires cookie >=0.4.1 && < 0.5 and the snapshot contains cookie-0.5.0
@@ -9288,7 +8487,6 @@ expected-test-failures:
     - HTF # Requires shell script and are incompatible with sandboxed package databases
     - HaRe # Needs ~/.ghc-mod/cabal-helper https://github.com/fpco/stackage/pull/906
     - IPv6DB
-    - accelerate-bignum # CUDA GPU
     - aeson-typescript # needs either yarn or npm; one of them is needed to install a TypeScript compiler.
     - alex
     - amqp
@@ -9311,7 +8509,6 @@ expected-test-failures:
     - drifter-postgresql # PostgreSQL
     - egison # executable not found https://github.com/egison/egison/issues/250
     - esqueleto # mysql and postgresql
-    - etcd # etcd https://github.com/fpco/stackage/issues/811
     - eventful-dynamodb
     - eventful-postgresql
     - eventsource-geteventstore-store
@@ -9326,8 +8523,6 @@ expected-test-failures:
     - gitson # https://github.com/myfreeweb/gitson/issues/1
     - happy # Needs mtl in the user package DB
     - haskell-neo4j-client # neo4j with auth disabled
-    - haskell-tools-cli # https://github.com/haskell-tools/haskell-tools/issues/230
-    - haskell-tools-refactor # https://github.com/haskell-tools/haskell-tools/issues/231
     - hasql # PostgreSQL
     - hasql-dynamic-statements # PostgreSQL
     - hasql-notifications # PostgreSQL
@@ -9380,7 +8575,6 @@ expected-test-failures:
     - postgresql-simple-queue
     - postgresql-syntax # hedgehog-test executable not found https://github.com/commercialhaskell/stackage/pull/6102
     - postgresql-typed # PostgreSQL
-    - postgrest # PostgreSQL
     - purescript # git 128 https://github.com/purescript/purescript/issues/2292
     - rattle # needs fsatrace
     - redis-io
@@ -9388,7 +8582,6 @@ expected-test-failures:
     - req-conduit # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
     - rest-rewrite # posix_spawnp
     - rethinkdb
-    - rethinkdb-client-driver
     - riak # needs riak server on localhost:8098
     - sdl2 # "Failed to connect to the Mir Server"
     - sendgrid-v3 # Requires sendgrid API key in env #5951/closed
@@ -9412,7 +8605,6 @@ expected-test-failures:
     - wai-rate-limit-redis # Redis
     - wai-session-postgresql # PostgreSQL
     - wai-session-redis # https://github.com/commercialhaskell/stackage/pull/5980
-    - web3 # requires running server
     - webdriver-angular # webdriver server
     - websockets
     - what4 # Missing cvc4 and cvc5 - cvc5 is not available for ubuntu 22.04 https://github.com/GaloisInc/what4/issues/262
@@ -9540,7 +8732,6 @@ expected-test-failures:
     # these if we want them fixed
     - domain-optics # `demo`: executable not found
     - ghci-hexcalc # https://github.com/takenobu-hs/ghci-hexcalc/issues/2
-    - haskell-tools-daemon # openFile: permission denied https://github.com/fpco/stackage/issues/2502
     - isocline # segfault https://github.com/daanx/isocline/issues/1
     - rounded # segfault
     - shake-language-c # Cannot reproduce locally, looks like it may be a bug in Stack or curator
@@ -9587,7 +8778,6 @@ expected-test-failures:
     - pg-transact # https://github.com/jfischoff/pg-transact/issues/2
     - poly
     - postgresql-simple-queue # same issue as before, see also https://github.com/fpco/stackage/issues/2592 as that will fix both
-    - raaz # https://github.com/commercialhaskell/stackage/issues/4784
     - rattletrap # OOM? https://github.com/fpco/stackage/issues/2232
     - relude # doctest fails due to GHC bugs, will be fixed in the next `relude` release
     - sbv
@@ -9659,7 +8849,6 @@ expected-benchmark-failures:
     - lz4 # https://github.com/fpco/stackage/issues/3510
     - memcache # 0.3.0.2
     - product-profunctors # 0.11.1.1
-    - raaz # https://github.com/commercialhaskell/stackage/issues/4766
     - stateWriter # 0.4.0 https://github.com/bartavelle/stateWriter/issues/5
     - ua-parser # 0.7.7.0 compile fail against aeson 2
     - universum
@@ -9743,11 +8932,8 @@ skipped-benchmarks:
     #
     # Benchmark bounds issues
     - IntervalMap # tried IntervalMap-0.6.2.1, but its *benchmarks* requires the disabled package: SegmentTree
-    - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires accelerate-llvm-native >=1.1 && < 1.2 and the snapshot contains accelerate-llvm-native-1.3.0.0
-    - accelerate-fourier # tried accelerate-fourier-1.0.0.5, but its *benchmarks* requires criterion >=1.0 && < 1.5 and the snapshot contains criterion-1.6.3.0
     - apply-merge # tried apply-merge-0.1.1.0, but its *benchmarks* requires tasty-bench >=0.3 && < 0.4 and the snapshot contains tasty-bench-0.4
     - arithmoi # tried arithmoi-0.13.0.0, but its *benchmarks* requires tasty-bench < 0.4 and the snapshot contains tasty-bench-0.4
-    - avers # tried avers-0.0.17.1, but its *benchmarks* requires criterion >=1.1.4.0 && < 1.6 and the snapshot contains criterion-1.6.3.0
     - base32 # tried base32-0.4, but its *benchmarks* requires bytestring ^>=0.11 and the snapshot contains bytestring-0.12.1.0
     - binary-parsers # tried binary-parsers-0.2.4.0, but its *benchmarks* requires criterion >=1.1 && < 1.2 and the snapshot contains criterion-1.6.3.0
     - bitvec # tried bitvec-1.1.5.0, but its *benchmarks* requires tasty-bench >=0.3.2 && < 0.4 and the snapshot contains tasty-bench-0.4
@@ -9767,9 +8953,6 @@ skipped-benchmarks:
     - fused-effects # tried fused-effects-1.1.2.3, but its *benchmarks* requires tasty-bench >=0.3 && < 0.4 and the snapshot contains tasty-bench-0.4
     - galois-field # tried galois-field-1.0.2, but its *benchmarks* requires criterion >=1.5 && < 1.6 and the snapshot contains criterion-1.6.3.0
     - ghc-trace-events # tried ghc-trace-events-0.1.2.9, but its *benchmarks* requires tasty-bench < 0.4 and the snapshot contains tasty-bench-0.4
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires criterion >=1.1 && < 1.6 and the snapshot contains criterion-1.6.3.0
-    - haskell-tools-cli # tried haskell-tools-cli-1.1.1.0, but its *benchmarks* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
     - hasmin # tried hasmin-1.0.3, but its *benchmarks* requires criterion >=0.11 && < 1.6 and the snapshot contains criterion-1.6.3.0
     - hegg # tried hegg-0.5.0.0, but its *benchmarks* requires tasty-bench >=0.2 && < 0.4 and the snapshot contains tasty-bench-0.4
     - hip # tried hip-1.5.6.0, but its *benchmarks* requires the disabled package: repa-algorithms
@@ -9787,14 +8970,11 @@ skipped-benchmarks:
     - pred-trie # tried pred-trie-0.6.1, but its *benchmarks* requires the disabled package: sets
     - primecount # tried primecount-0.1.0.1, but its *benchmarks* requires tasty-bench >=0.3 && < 0.4 and the snapshot contains tasty-bench-0.4
     - regex-applicative # tried regex-applicative-0.3.4, but its *benchmarks* requires the disabled package: parsers-megaparsec
-    - servant-auth-cookie # tried servant-auth-cookie-0.6.0.3, but its *benchmarks* requires criterion >=0.6.2.1 && < 1.4 and the snapshot contains criterion-1.6.3.0
     - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *benchmarks* requires shelly >=1.6.8 && < 1.10 and the snapshot contains shelly-1.12.1
     - spdx # tried spdx-1.1, but its *benchmarks* requires QuickCheck ^>=2.15.0.1 and the snapshot contains QuickCheck-2.14.3
     - streamly-process # tried streamly-process-0.3.1, but its *benchmarks* requires tasty-bench >=0.2.5 && < 0.4 and the snapshot contains tasty-bench-0.4
     - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires criterion < 1.3 and the snapshot contains criterion-1.6.3.0
     - superbuffer # tried superbuffer-0.3.1.2, but its *benchmarks* requires the disabled package: buffer-builder
-    - sv # tried sv-1.4.0.1, but its *benchmarks* requires criterion >=1.3 && < 1.6 and the snapshot contains criterion-1.6.3.0
-    - sv # tried sv-1.4.0.1, but its *benchmarks* requires deepseq >=1.1 && < 1.5 and the snapshot contains deepseq-1.5.0.0
     - tar # tried tar-0.6.3.0, but its *benchmarks* requires tasty-bench < 0.4 and the snapshot contains tasty-bench-0.4
     - text-iso8601 # tried text-iso8601-0.1.1, but its *benchmarks* requires tasty-bench >=0.3.4 && < 0.4 and the snapshot contains tasty-bench-0.4
     - ttrie # tried ttrie-0.1.2.2, but its *benchmarks* requires the disabled package: criterion-plus
@@ -9971,11 +9151,9 @@ hide:
 - gtk3 # conflicts with many modules in gtk
 - hashmap # conflicts with Data.HashSet in unordered-containers
 - hledger-web # conflicts with Foundation in foundation
-- hs-functors # conflicts with profunctors, see #3609/closed
 - hxt-unicode # conflicts with Data.String.UTF8 in utf8-string
 - kawhi # conflicts with Control.Monad.Http in monad-http
 - language-c # conflicts with modules in language-c-quote
-- lenz # conflicts with lens, see https://github.com/fpco/stackage/issues/3600
 - log # conflicts with modules in its dependencies
 - matrices # conflicts with matrix
 - monad-extras # conflicts with Control.Monad.Extra in extra

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6000,7 +6000,6 @@ packages:
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: TCache
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: Workflow
         - MFlow < 0 # tried MFlow-0.4.6.0, but its *library* requires the disabled package: monadloc
-        - MapWith < 0 # tried MapWith-0.2.0.0, but its *library* requires base >=4.9.1 && < 4.15 and the snapshot contains base-4.19.1.0
         - Network-NineP < 0 # tried Network-NineP-0.4.7.4, but its *library* requires network >=3.0 && < 3.2 and the snapshot contains network-3.2.2.0
         - SpatialMath < 0 # tried SpatialMath-0.2.7.1, but its *library* requires lens >=5.2.3 && < 5.3 and the snapshot contains lens-5.3.2
         - Spock < 0 # tried Spock-0.14.0.0, but its *library* requires the disabled package: Spock-core


### PR DESCRIPTION
This removes packages that were disabled with the upgrade to GHC 9.2, and
haven't been enabled since.

I removed the checklist since it talking about adding packages, not removing
them.
