### PR TITLE
sandwich-hedgehog: re-enable at 0.1.3.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -432,7 +432,7 @@ packages:
         - fsnotify
         - myers-diff
         - sandwich
-        - sandwich-hedgehog < 0 # 0.1.3.0 https://github.com/codedownio/sandwich/issues/97
+        - sandwich-hedgehog
         - sandwich-quickcheck
         - sandwich-slack
         - sandwich-webdriver


### PR DESCRIPTION
Closes https://github.com/codedownio/sandwich/issues/97. CC @alaendle.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
