### PR TITLE
update juhp packages 2024-09

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1802,8 +1802,10 @@ packages:
         - cached-json-file
         - copr-api
         - dl-fedora
-        - fedora-dists
-        - fedora-haskell-tools
+        - fbrnch
+        - fedora-haskell-tools < 0 # not yet updated to fedora-releases
+        - fedora-releases
+        - fedora-repoquery
         - HaXml
         - hkgr
         - http-directory
@@ -1813,11 +1815,11 @@ packages:
         - koji-tool
         - pagure
         - pagure-cli
-        - pdc
         - pkgtreediff
         - rhbzquery < 0 # 0.4.4 https://github.com/juhp/rhbzquery/issues/1
         - rpm-nvr
         - rpmbuild-order
+        - select-rpms
         - simple-cabal
         - simple-cmd
         - simple-cmd-args


### PR DESCRIPTION
- add fbrnch fedora-releases fedora-repoquery select-rpms
- drop fedora-haskell-tools, fedora-dists and pdc

It is possible a one or two testsuites might need to be disabled