### PR TITLE
Move maintenance of `happy` and `happy-lib` to @sgraf812 (#7520)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -110,7 +110,6 @@ packages:
         - Sit
 
         - alex
-        - happy < 1.21.0 # Note, cannot use 1.21.0, and 2.0 blocked by https://github.com/commercialhaskell/stackage/issues/7520
         - haskell-src
         - ListLike
         - MissingH
@@ -5241,6 +5240,10 @@ packages:
     "Přemysl Šťastný <p-w@stty.cz> @stastnypremysl":
         - curly-expander
         - lsql-csv
+
+    "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
+        - happy-lib
+        - happy < 1.21 # Note, cannot use 1.21.0, and 2.0 blocked by https://github.com/commercialhaskell/stackage/issues/7520
 
     "Grandfathered dependencies":
         - BiobaseNewick


### PR DESCRIPTION
CC @andreasabel.

Fixes #7520

Checklist:
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
