### PR TITLE
Re-enable Chart, Chart-cairo, Chart-diagrams, and bench-show

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5978,9 +5978,6 @@ packages:
     # Recheck with: commenter clear && commenter add-loop
     "Library and exe bounds failures":
         - Allure < 0 # tried Allure-0.11.0.0, but its *library* requires the disabled package: LambdaHack
-        - Chart < 0 # tried Chart-1.9.5, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
-        - Chart-cairo < 0 # tried Chart-cairo-1.9.4.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
-        - Chart-diagrams < 0 # tried Chart-diagrams-1.9.5.1, but its *library* requires lens >=3.9 && < 5.3 and the snapshot contains lens-5.3.2
         - ConfigFile < 0 # tried ConfigFile-1.1.4, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires hashtables >=1.2 && < 1.3 and the snapshot contains hashtables-1.3.1
         - GPipe < 0 # tried GPipe-2.2.5, but its *library* requires linear >=1.18 && < 1.21 and the snapshot contains linear-1.23
@@ -6397,8 +6394,6 @@ packages:
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
         - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
         - bench < 0 # tried bench-1.0.13, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
-        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart
-        - bench-show < 0 # tried bench-show-0.3.2, but its *library* requires the disabled package: Chart-diagrams
         - binary-parsers < 0 # tried binary-parsers-0.2.4.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: bitcoin-script
         - bitcoin-api < 0 # tried bitcoin-api-0.12.1, but its *library* requires the disabled package: hexstring
@@ -6920,8 +6915,6 @@ packages:
         - higher-leveldb < 0 # tried higher-leveldb-0.6.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.0
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
-        - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart
-        - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: Chart-diagrams
         - hip < 0 # tried hip-1.5.6.0, but its *library* requires the disabled package: repa
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
         - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires aeson >=0.7 && < 1.4 and the snapshot contains aeson-2.2.3.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
