### PR TITLE
Adopt cabal-doctest

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -152,7 +152,6 @@ packages:
         - regex-pcre-builtin
         - test-framework
         - c2hs
-        - cabal-doctest
         - hackage-security
         - haskell-lexer
         - lifted-async
@@ -5246,6 +5245,9 @@ packages:
     "Sebastian Graf <sgraf1337@gmail.com> @sgraf812":
         - happy-lib
         - happy
+
+    "Max Ulidtko <ulidtko@gmail.com> @ulidtko":
+        - cabal-doctest
 
     "Grandfathered dependencies":
         - BiobaseNewick


### PR DESCRIPTION
Following hand-over of `cabal-doctest` from @andreasabel, adding myself onto maintainers list, to receive bounds-breakage notifications. 

Resolves https://github.com/ulidtko/cabal-doctest/issues/84

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
   ```
   Outdated dependencies:
   Cabal >=1.10 && <3.14 (latest: 3.14.0.0)
   ```