### PR TITLE
add Yi packages to stackage

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5270,7 +5270,7 @@ packages:
         - heftia
         - heftia-effects
 
-    "Marcel Fourné" <email@marcelfourne.de> @mfourne:
+    "Marcel Fourné <email@marcelfourne.de> @mfourne":
         - dynamic-state
         - yi
         - yi-core

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5261,6 +5261,21 @@ packages:
         - heftia
         - heftia-effects
 
+    "Marcel Fourné" <email@marcelfourne.de> @mfourne:
+        - dynamic-state
+        - yi
+        - yi-core
+        - yi-rope
+        - yi-language
+        - yi-misc-modes
+        - yi-mode-haskell
+        - yi-mode-javascript
+        - yi-keymap-cua
+        - yi-keymap-emacs
+        - yi-keymap-vim
+        - yi-frontend-pango
+        - yi-frontend-vty
+
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean
@@ -5814,7 +5829,6 @@ packages:
         - coercible-utils # #6271
         - compiler-warnings # #6326/closed
         - curl
-        - dynamic-state # #6326/closed
         - first-class-patterns # #5965/closed
         - ghc-trace-events # #6326/closed
         - hashing # #6271
@@ -5840,7 +5854,6 @@ packages:
         - unordered-intmap # #6326/closed
         - word-trie # #6326/closed
         - xdg-basedir # #6326/closed
-        - yi-rope # #6326/closed
 
     # Packages without maintainers that cause issues,
     # this is to prevent us from including them by accident. They can


### PR DESCRIPTION
With this I am adding myself as maintainer for the base set of Yi (the Haskell editor) packages, which I am also maintaining on hackage and in Debian. There are some poeple interested in the packages and I am currently keeping them up to date and porting forward for newer dependencies. Adding them to stackage would make maintenance in Debian easier for the group, some of whom are not Yi upstream.