### PR TITLE
Re-enable dimensional, geodetics

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6630,7 +6630,6 @@ packages:
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.19.2.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.1.1
-        - dimensional < 0 # tried dimensional-1.6, but its *library* requires deepseq >=1.3 && < 1.5.1.0 and the snapshot contains deepseq-1.5.1.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.10.3.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.1.0
@@ -6713,7 +6712,6 @@ packages:
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.19.2.0
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires text >=0.11 && < 2.1 and the snapshot contains text-2.1.1
         - generic-aeson < 0 # tried generic-aeson-0.2.0.14, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.1.0
-        - geodetics < 0 # tried geodetics-0.1.2, but its *library* requires the disabled package: dimensional
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires deepseq >=1.4.2.0 && < 1.5 and the snapshot contains deepseq-1.5.1.0
         - geojson < 0 # tried geojson-4.1.1, but its *library* requires text >=1.2.3.0 && < 2.1 and the snapshot contains text-2.1.1
         - ghc-clippy-plugin < 0 # tried ghc-clippy-plugin-0.0.0.1, but its *library* requires dhall >=1.30.0 && < 1.34 and the snapshot contains dhall-1.42.1


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

These issues have been fixed:

* https://github.com/bjornbm/dimensional/issues/228
