### PR TITLE
Remove `graph-wrapper`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1946,7 +1946,6 @@ packages:
     "Sönke Hahn <soenkehahn@gmail.com> @soenkehahn":
         - generics-eot
         - getopt-generics
-        - graph-wrapper
         - string-conversions
         - hspec-checkers
         - FindBin


### PR DESCRIPTION
I don't wish to actively maintain the package anymore (see also [here](https://github.com/soenkehahn/graph-wrapper/commit/b49f4424e51ff1f5f41c1acae6bac5c640b21028)) and I was pinged in https://github.com/commercialhaskell/stackage/issues/7549 about it. Is removing it from the file the best choice here, since it doesn't build with `ghc-9.10`? Or should it be moved to the `Grandfathered dependencies` instead?

Thanks!
