### PR TITLE
Add the rest of the distributed-haskell packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -15,13 +15,21 @@ packages:
         - real-dice
 
     "David Simmons-Duffin <dsd@caltech.edu> @davidsd":
-        - rank1dynamic
-        - distributed-static
-        - network-transport
-        - network-transport-tests
-        - network-transport-tcp
-        - network-transport-inmemory
+        - distributed-process-async
+        - distributed-process-client-server
+        - distributed-process-execution
+        - distributed-process-extras
+        - distributed-process-simplelocalnet
+        - distributed-process-supervisor
+        - distributed-process-systest
+        - distributed-process-tests
         - distributed-process
+        - distributed-static
+        - network-transport-inmemory
+        - network-transport-tcp
+        - network-transport-tests
+        - network-transport
+        - rank1dynamic
 
     "Julian Ospald <hasufell@posteo.de> @hasufell":
         - os-string >= 2.0.2

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2751,7 +2751,7 @@ packages:
         - monad-peel
         - NineP
         - Network-NineP
-        - pontarius-xmpp
+        - pontarius-xmpp < 0 # fails to build
         - stringprep
         - ranges
 


### PR DESCRIPTION
I have been able to manually build all the packages with the latest snapshot. However, verify-package doesn't work because the packages being added are interdependent.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
