### PR TITLE
sandwich-webdriver, sandwich-contexts: enable at 0.3.0.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -430,10 +430,11 @@ packages:
         - fsnotify
         - myers-diff
         - sandwich
+        - sandwich-contexts
         - sandwich-hedgehog
         - sandwich-quickcheck
         - sandwich-slack
-        - sandwich-webdriver < 0 # 0.2.3.1 https://github.com/codedownio/sandwich/issues/100
+        - sandwich-webdriver
         - slack-progressbar < 0 # 0.1.0.1 https://github.com/codedownio/slack-progressbar/issues/1
         - system-linux-proc # @erikd
         - webdriver


### PR DESCRIPTION
Fixes https://github.com/codedownio/sandwich/issues/100. CC @alaendle 

Hopefully it's okay to add both `sandwich-webdriver` and its dependency `sandwich-contexts` together like this.

It's possible we'll need to skip the tests of `sandwich-contexts`, since they require Nix.

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please not mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] On your own machine, you have successfully run the following command (find verify-package in the root of this repo):

      ./verify-package $package # or $package-$version

(Verified `sandwich-contexts`.)