### PR TITLE
Add ollama-haskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -276,6 +276,9 @@ packages:
         - strict-tuple
         - strict-tuple-lens
 
+    "Tushar Adhatrao <tusharadhatrao@gmail.com> @tusharad":
+        - ollama-haskell
+
     "Matthieu Monsch <mtth@apache.org> @mtth":
         - flags-applicative
         - more-containers


### PR DESCRIPTION
Eariler, due to my recent commit, the package was failing to build with nightly, it has been fixed since.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
