### PR TITLE
Revert "Disabled `sequenceTools` (stschiff/sequenceTools#35)."

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -245,7 +245,7 @@ packages:
     "Stephan Schiffels <stephan_schiffels@mac.com> @stschiff":
         - sequence-formats
         - pipes-ordered-zip
-        - sequenceTools < 0 # 1.5.3.1 https://github.com/stschiff/sequenceTools/issues/35
+        - sequenceTools
 
     "YongJoon Joe <developer@quietjoon.net> @QuietJoon":
         - doldol


### PR DESCRIPTION
This reverts commit e28ff6f5d6d575e00f0b2433296c8c6185410da4.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
