### PR TITLE
Re-enable tomland after revision

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8336,8 +8336,6 @@ packages:
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires the disabled package: x509-validation
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.1.5
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires ansi-wl-pprint < 1 and the snapshot contains ansi-wl-pprint-1.0.2
-        - tomland < 0 # tried tomland-1.3.3.3, but its *library* requires hashable >=1.3.1.0 && < 1.5 and the snapshot contains hashable-1.5.0.0
-        - tomland < 0 # tried tomland-1.3.3.3, but its *library* requires megaparsec >=7.0.5 && < 9.7 and the snapshot contains megaparsec-9.7.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires Cabal < 3.12 and the snapshot contains Cabal-3.12.0.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.20.0.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -9284,8 +9282,6 @@ skipped-tests:
     - test-framework # tried test-framework-0.8.2.0, but its *test-suite* requires the disabled package: libxml
     - text-builder-dev # tried text-builder-dev-0.3.9, but its *test-suite* requires tasty-quickcheck >=0.10.1 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - text-iso8601 # tried text-iso8601-0.1.1, but its *test-suite* requires tasty-quickcheck >=0.10.2 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - tomland # tried tomland-1.3.3.3, but its *test-suite* requires hedgehog >=1.0.1 && < 1.5 and the snapshot contains hedgehog-1.5
-    - tomland # tried tomland-1.3.3.3, but its *test-suite* requires hspec-hedgehog >=0.0.1.1 && < 0.2 and the snapshot contains hspec-hedgehog-0.3.0.0
     - true-name # tried true-name-0.2.0.0, but its *test-suite* requires containers ^>=0.5.6 || ^>=0.6.0 and the snapshot contains containers-0.7
     - type-errors # tried type-errors-0.2.0.2, but its *test-suite* requires doctest >=0.16.0.1 && < 0.22 and the snapshot contains doctest-0.23.0
     - tztime # tried tztime-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hunit-compat


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
