### PR TITLE
reenable typecheck-plugin-nat-simple and ranged-list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3418,7 +3418,7 @@ packages:
         - warp-tls-uid < 0 # 0.2.0.6 https://github.com/YoshikuniJujo/warp-tls-uid/issues/1
         - nowdoc
         - typecheck-plugin-nat-simple
-        - ranged-list < 0 # https://github.com/YoshikuniJujo/ranged-list/issues/1
+        - ranged-list
         - c-enum
         - c-struct
         - union-angle
@@ -9386,7 +9386,6 @@ expected-test-failures:
     - tmp-proc # 0.7.1.0 https://github.com/adetokunbo/tmp-proc/issues/112
     - twitter-types # 0.11.0 compile fail against aeson 2
     - type-of-html-static # 0.1.0.2 https://github.com/commercialhaskell/stackage/issues/5728
-    - typecheck-plugin-nat-simple # 0.1.0.9 https://github.com/YoshikuniJujo/typecheck-plugin-nat-simple/issues/2
     - tztime # 0.1.1.0
     - ua-parser # 0.7.7.0 compile fail against aeson 2
     - ua-parser # 0.7.7.0 https://github.com/commercialhaskell/stackage/issues/6440


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
