### PR TITLE
Re-enable tz

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8373,8 +8373,6 @@ packages:
         - type-level-show < 0 # tried type-level-show-0.3.0, but its *library* requires the disabled package: defun-core
         - type-natural < 0 # tried type-natural-1.3.0.1, but its *library* requires the disabled package: ghc-typelits-presburger
         - type-operators < 0 # tried type-operators-0.2.0.0, but its *library* requires base >=4.7 && < 4.17 and the snapshot contains base-4.20.0.0
-        - tz < 0 # tried tz-0.1.3.6, but its *library* requires template-haskell >=2.6 && < 2.22 and the snapshot contains template-haskell-2.22.0.0
-        - tztime < 0 # tried tztime-0.1.1.0, but its *library* requires the disabled package: tz
         - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
         - unfoldable < 0 # tried unfoldable-1.0.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - unfoldable-restricted < 0 # tried unfoldable-restricted-0.0.3, but its *library* requires the disabled package: unfoldable


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
