### PR TITLE
Remove packages not compatible with aeson-2 or transformers-0.6

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -427,7 +427,6 @@ packages:
     "Travis Athougies <travis@athougies.net> @tathougies":
         - beam-core
         - beam-migrate
-        - beam-mysql
         - beam-postgres
         - beam-sqlite
 
@@ -525,11 +524,6 @@ packages:
 
     "Walter Schulze <awalterschulze@gmail.com> @awalterschulze":
         - katydid
-
-    "Nobutada Matsubara <t12307043@gunma-u.ac.jp> @matsubara0507":
-        - chatwork
-        - rakuten
-        - servant-kotlin
 
     "Pavol Klacansky <pavol@klacansky.com> @pavolzetor":
         - openexr-write
@@ -846,10 +840,6 @@ packages:
         - google-translate
         - hackernews
         - ses-html
-        - stripe-haskell
-        - stripe-http-client
-        - stripe-core
-        - stripe-tests
 
     "Piotr Mlodawski @pmlodawski":
         - error-util < 0 # 0.0.1.2 MonadFail
@@ -893,7 +883,6 @@ packages:
         - binary-conduit
         - lzma-conduit
         - mutable-containers
-        - hpc-coveralls
         - monad-unlift
         - monad-unlift-ref
         - yaml
@@ -1004,7 +993,6 @@ packages:
 
     "Jon Schoning <jonschoning@gmail.com> @jonschoning":
         - pinboard
-        - swagger-petstore
 
     "Jasper Van der Jeugt @jaspervdj":
         - blaze-html
@@ -1418,21 +1406,12 @@ packages:
         - messagepack
         - messagepack-rpc
 
-    "Boris Lykah <lykahb@gmail.com> @lykahb":
-        - groundhog
-        - groundhog-inspector
-        - groundhog-mysql
-        - groundhog-postgresql
-        - groundhog-sqlite
-        - groundhog-th
-
     "Janne Hellsten <jjhellst@gmail.com> @nurpax":
         - sqlite-simple
 
     "Michal J. Gajda <maintainer@migamake.com> @mgajda":
         - iterable
         - FenwickTree
-        - json-autotype
 
     "Dom De Re <domdere@domdere.com> @domdere":
         - cassava-conduit
@@ -1563,7 +1542,6 @@ packages:
         - event
         - hid
         - monad-journal
-        - smoothie
         - wavefront
         - zero
 
@@ -1785,10 +1763,6 @@ packages:
 
     "Alexandr Ruchkin <voidex@live.com> @mvoidex":
         - hformat
-        - simple-log
-        - text-region
-        - haskell-names
-        - hsdev
 
     "Aleksey Kliger <aleksey@lambdageek.org> @lambdageek":
         - unbound-generics
@@ -1800,7 +1774,6 @@ packages:
 
     "Andraz Bajt <andraz@bajt.me> @edofic":
         - effect-handlers
-        - koofr-client
         - snowflake
 
     "Leza M. Lutonda <lemol-c@hotmail.com> @lemol":
@@ -1844,7 +1817,6 @@ packages:
         - stack-clean-old
 
         - darcs
-        - idris
         - libffi
         - cairo
         - glib
@@ -2267,102 +2239,6 @@ packages:
         - amazonka-workspaces-web
         - amazonka-xray
         - gogol
-        - gogol-core
-        - gogol-adexchange-buyer
-        - gogol-adexchange-seller
-        - gogol-admin-datatransfer
-        - gogol-admin-directory
-        - gogol-admin-emailmigration
-        - gogol-admin-reports
-        - gogol-adsense
-        - gogol-adsense-host
-        - gogol-affiliates
-        - gogol-analytics
-        - gogol-android-enterprise
-        - gogol-android-publisher
-        - gogol-appengine
-        - gogol-apps-activity
-        - gogol-apps-calendar
-        - gogol-apps-licensing
-        - gogol-apps-reseller
-        - gogol-apps-tasks
-        - gogol-appstate
-        - gogol-autoscaler
-        - gogol-bigquery
-        - gogol-billing
-        - gogol-blogger
-        - gogol-books
-        - gogol-civicinfo
-        - gogol-classroom
-        - gogol-cloudmonitoring
-        - gogol-cloudtrace
-        - gogol-compute
-        - gogol-container
-        - gogol-customsearch
-        - gogol-dataflow
-        - gogol-dataproc
-        - gogol-datastore
-        - gogol-debugger
-        - gogol-deploymentmanager
-        - gogol-dfareporting
-        - gogol-discovery
-        - gogol-dns
-        - gogol-doubleclick-bids
-        - gogol-doubleclick-search
-        - gogol-drive
-        - gogol-firebase-rules
-        - gogol-fitness
-        - gogol-fonts
-        - gogol-freebasesearch
-        - gogol-fusiontables
-        - gogol-games
-        - gogol-games-configuration
-        - gogol-games-management
-        - gogol-genomics
-        - gogol-gmail
-        - gogol-groups-migration
-        - gogol-groups-settings
-        - gogol-identity-toolkit
-        - gogol-kgsearch
-        - gogol-latencytest
-        - gogol-logging
-        - gogol-maps-coordinate
-        - gogol-maps-engine
-        - gogol-mirror
-        - gogol-monitoring
-        - gogol-oauth2
-        - gogol-pagespeed
-        - gogol-partners
-        - gogol-people
-        - gogol-play-moviespartner
-        - gogol-plus
-        - gogol-plus-domains
-        - gogol-prediction
-        - gogol-proximitybeacon
-        - gogol-pubsub
-        - gogol-qpxexpress
-        - gogol-replicapool
-        - gogol-replicapool-updater
-        - gogol-resourcemanager
-        - gogol-resourceviews
-        - gogol-script
-        - gogol-sheets
-        - gogol-shopping-content
-        - gogol-siteverification
-        - gogol-spectrum
-        - gogol-sqladmin
-        - gogol-storage
-        - gogol-storage-transfer
-        - gogol-tagmanager
-        - gogol-taskqueue
-        - gogol-translate
-        - gogol-urlshortener
-        - gogol-useraccounts
-        - gogol-vision
-        - gogol-webmaster-tools
-        - gogol-youtube
-        - gogol-youtube-analytics
-        - gogol-youtube-reporting
         - ede
         - pagerduty < 0 # 0.0.8 compile fail with GHC 8.4 https://github.com/brendanhay/pagerduty/issues/10
         - semver
@@ -2727,7 +2603,6 @@ packages:
         - webdriver-angular
 
     "Sven Heyll <svh@posteo.de> @sheyll":
-        - b9
         - type-spec
         - pretty-types < 0 # 0.4.0.0 # fails to compile https://github.com/sheyll/pretty-types/issues/2
         - function-builder
@@ -3298,8 +3173,6 @@ packages:
         - extensible-effects < 0 # https://github.com/suhailshergill/extensible-effects/issues/135
 
     "Justus Adam <dev@justus.science> @JustusAdam":
-        - marvin
-        - marvin-interpolate
         - mustache
         - exit-codes
 
@@ -3544,9 +3417,6 @@ packages:
         - greskell-websocket
         - hspec-need-env
 
-    "Cies Breijs <cies@kde.nl> @cies":
-        - htoml
-
     "Martijn Rijkeboer <mrr@sru-systems.com> @mrijkeboer":
         - protobuf-simple
 
@@ -3621,7 +3491,6 @@ packages:
         - haskey-btree
         - haskey-mtl
         - intset-imperative
-        - lxd-client
         - lxd-client-config
         - xxhash-ffi
         - zeromq4-patterns
@@ -4018,15 +3887,8 @@ packages:
         - optparse-enum
         - fmt
 
-    "Elliot Cameron <eacameron@gmail.com> @3noch":
-        - ziptastic-client
-        - ziptastic-core
-
     "Hardy Jones <jones3.hardy@gmail.com> @joneshf":
-        - katip-rollbar
-        - rollbar-hs
         - servant-ruby
-        - wai-middleware-rollbar
 
     "Andrey Mokhov <andrey.mokhov@gmail.com> @snowleopard":
         - algebraic-graphs
@@ -4088,7 +3950,6 @@ packages:
 
     "Simon Hafner <hafnersimon@gmail.com> @reactormonk":
         - uri-bytestring-aeson
-        - katip-scalyr-scribe
 
     "Sebastian Witte <woozletoff@gmail.com> @saep":
         - nvim-hs
@@ -4141,7 +4002,6 @@ packages:
         - listsafe
 
     "Serokell <libraries@serokell.io> @serokell":
-        - importify
         - log-warper
         - o-clock
         - tasty-hunit-compat
@@ -4152,9 +4012,6 @@ packages:
 
     "Holmusk <tech@holmusk.com> @arbus":
         - elm-street
-
-    "Noel Kwan <noelkwan1998@gmail.com> @kwannoel":
-        - servant-docs-simple
 
     "Lorenz Moesenlechner <moesenle@gmail.com> @moesenle":
         - servant-websockets
@@ -4282,7 +4139,6 @@ packages:
         - time-locale-vietnamese
 
     "Tim McGilchrist <timmcgil@gmail.com>  @tmcgilchrist":
-        - riak
         - riak-protobuf
         - airship
         - hedgehog-corpus
@@ -4747,8 +4603,6 @@ packages:
 
     "David Himmelstrup <lemmih@gmail.com> @lemmih":
         - chiphunk
-        - reanimate-svg > 0.13.0.1 # https://github.com/reanimate/reanimate-svg/issues/41
-        - reanimate
         - vector-circular
         - hgeometry
         - hgeometry-combinatorial
@@ -4861,7 +4715,6 @@ packages:
         - pretty-diff
 
     "Jorah Gao <jorah@version.cloud> @gqk007":
-        - aeson-default
         - vformat
         - vformat-time
         - vformat-aeson
@@ -4869,9 +4722,6 @@ packages:
 
     "Shintaro Sakata <shintaro.sakata.tokyo@gmail.com> @chemirea":
         - utf8-conversions
-
-    "Alessandro Marrella <amarrella@earnestresearch.com> @amarrella":
-        - kubernetes-webhook-haskell
 
     "8c6794b6 <8c6794b6@gmail.com> @8c6794b6":
         - hpc-codecov
@@ -5124,8 +4974,6 @@ packages:
 
     "Edward Yang <qwbarch@gmail.com> @qwbarch":
         - captcha-core
-        - captcha-2captcha
-        - captcha-capmonster
         - data-default-extra
         - data-default-instances-base
         - data-default-instances-bytestring
@@ -5513,8 +5361,6 @@ packages:
         - heap
         - here
         - hex
-        - hjsonpointer
-        - hjsonschema
         - hlibgit2
         - hmatrix
         - hmatrix-gsl
@@ -5561,7 +5407,6 @@ packages:
         - ixset-typed
         - jsaddle-dom
         - json
-        - json-alt
         - kansas-comet
         - kleene
         - knob
@@ -5960,7 +5805,6 @@ packages:
         - ghcjs-base-stub < 0 # 0.3.0.2 compile fail aeson 2.0
         - giphy-api < 0 # 0.7.0.0 https://github.com/passy/giphy-api/pull/19
         - gluturtle < 0 # 0.0.58.1
-        - groundhog < 0 # 0.12.0
         - haskell-awk < 0 # 1.2.0.1
         - haskell-import-graph < 0 # 1.0.4
         - haskell-spacegoo < 0 # 0.2.0.1
@@ -5980,7 +5824,6 @@ packages:
         - llvm-hs-pretty < 0 # 0.9.0.0
         - machines-binary < 0 # 7.0.0.0
         - machines-io < 0 # 7.0.0.0
-        - marvin-interpolate < 0 # 1.1.2
         - mltool < 0 # 0.2.0.1
         - moesocks < 0 # 1.0.1.0
         - monad-recorder < 0 # 0.1.1
@@ -6012,7 +5855,6 @@ packages:
         - sum-type-boilerplate < 0 # 0.1.1
         - swagger < 0 # 0.3.0 compile fail aeson 2.0
         - template-toolkit < 0 # 0.1.1.0 compile fail aeson 2.0
-        - text-region < 0 # 0.3.1.0
         - throttle-io-stream < 0 # 0.2.0.1
         - throwable-exceptions < 0 # 0.1.0.9
         - timemap < 0 # 0.0.7 https://github.com/athanclark/timemap/issues/1
@@ -6097,7 +5939,6 @@ packages:
         - aeson-better-errors < 0 # tried aeson-better-errors-0.9.1.1, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires aeson >=1.4 && < 2.2 and the snapshot contains aeson-2.2.3.0
         - aeson-commit < 0 # tried aeson-commit-1.6.0, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
-        - aeson-default < 0 # tried aeson-default-0.9.1.0, but its *library* requires aeson >=1.2 && < 2 and the snapshot contains aeson-2.2.3.0
         - aeson-extra < 0 # tried aeson-extra-0.5.1.3, but its *library* requires base >=4.7 && < 4.20 and the snapshot contains base-4.20.0.0
         - aeson-extra < 0 # tried aeson-extra-0.5.1.3, but its *library* requires base-compat-batteries >=0.11.2 && < 0.14 and the snapshot contains base-compat-batteries-0.14.1
         - aeson-extra < 0 # tried aeson-extra-0.5.1.3, but its *library* requires template-haskell >=2.8 && < 2.22 and the snapshot contains template-haskell-2.22.0.0
@@ -6485,12 +6326,6 @@ packages:
         - aws-lambda-haskell-runtime < 0 # tried aws-lambda-haskell-runtime-4.3.2, but its *library* requires the disabled package: path
         - aws-lambda-haskell-runtime-wai < 0 # tried aws-lambda-haskell-runtime-wai-2.0.2, but its *library* requires the disabled package: aws-lambda-haskell-runtime
         - axiom < 0 # tried axiom-0.4.7, but its *library* requires the disabled package: transient
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires aeson >=1.4 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires filepath >=1.4 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires hspec >=2.7 && < 2.8 and the snapshot contains hspec-2.11.10
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.3.2
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - b9 < 0 # tried b9-3.2.3, but its *library* requires the disabled package: extensible-effects
         - barrier < 0 # tried barrier-0.1.1, but its *library* requires text >=1.1 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
         - base-noprelude < 0 # tried base-noprelude-4.13.0.0, but its *library* requires base ==4.13.0.0 and the snapshot contains base-4.20.0.0
         - base16-lens < 0 # tried base16-lens-0.1.3.2, but its *library* requires base16 ^>=0.3 and the snapshot contains base16-1.0
@@ -6509,15 +6344,6 @@ packages:
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.3.2
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.1
         - battleship-combinatorics < 0 # tried battleship-combinatorics-0.0.1, but its *library* requires containers >=0.4.2 && < 0.7 and the snapshot contains containers-0.7
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires aeson >=0.11 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires beam-core >=0.8 && < 0.9 and the snapshot contains beam-core-0.10.3.0
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires free >=4.12 && < 5.2 and the snapshot contains free-5.2
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires hashable >=1.1 && < 1.3 and the snapshot contains hashable-1.5.0.0
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires mysql >=0.1 && < 0.2 and the snapshot contains mysql-0.2.1
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - beam-mysql < 0 # tried beam-mysql-0.2.0.0, but its *library* requires time >=1.6 && < 1.10 and the snapshot contains time-1.12.2
         - bech32 < 0 # tried bech32-1.1.7, but its *library* requires extra >=1.7.14 && < 1.8 and the snapshot contains extra-1.8
         - bech32-th < 0 # tried bech32-th-1.1.7, but its *library* requires the disabled package: bech32
         - bench < 0 # tried bench-1.0.13, but its *executable* requires text < 2.1 and the snapshot contains text-2.1.1
@@ -6592,38 +6418,6 @@ packages:
         - cabal-install-parsers < 0 # tried cabal-install-parsers-0.6.2, but its *library* requires the disabled package: binary-instances
         - cabal-install-solver < 0 # tried cabal-install-solver-3.12.1.0, but its *library* requires Cabal ^>=3.12.1.0 and the snapshot contains Cabal-3.12.0.0
         - cabal-install-solver < 0 # tried cabal-install-solver-3.12.1.0, but its *library* requires Cabal-syntax ^>=3.12.1.0 and the snapshot contains Cabal-syntax-3.12.0.0
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires extra >=1.7.9 && < 1.8 and the snapshot contains extra-1.8
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.3.2
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.3
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
-        - captcha-2captcha < 0 # tried captcha-2captcha-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires extra >=1.7.9 && < 1.8 and the snapshot contains extra-1.8
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.3.2
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires lens-aeson >=1.1.3 && < 1.2 and the snapshot contains lens-aeson-1.2.3
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
-        - captcha-capmonster < 0 # tried captcha-capmonster-0.1.0.0, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires aeson >=1.5.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires bytestring >=0.10.12.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires cookie >=0.4.5 && < 0.5 and the snapshot contains cookie-0.5.0
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires lens >=4.19.2 && < 5.1 and the snapshot contains lens-5.3.2
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires mtl >=2.2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires o-clock >=1.2.1 && < 1.3 and the snapshot contains o-clock-1.4.0
-        - captcha-core < 0 # tried captcha-core-0.1.0.1, but its *library* requires text >=1.2.4.1 && < 1.3 and the snapshot contains text-2.1.1
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires aeson-casing >=0.1.0.5 && < 0.2 and the snapshot contains aeson-casing-0.2.0.0
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires data-default-class >=0.1.2.0 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.6.1
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.17
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires req >=1.0.0 && < 1.3.0 and the snapshot contains req-3.13.4
-        - chatwork < 0 # tried chatwork-0.1.3.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires containers >=0.4 && < 0.7 and the snapshot contains containers-0.7
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires data-default >=0.5 && < 0.8 and the snapshot contains data-default-0.8.0.0
         - cheapskate < 0 # tried cheapskate-0.1.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -6811,11 +6605,6 @@ packages:
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires data-default-class >=0.0.1 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires lens >=4.0 && < 5.3 and the snapshot contains lens-5.3.2
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires text >=1.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires base >=4.12.0.0 && < 4.15.0.0 and the snapshot contains base-4.20.0.0
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires containers >=0.6.0 && < 0.7 and the snapshot contains containers-0.7
-        - dialogflow-fulfillment < 0 # tried dialogflow-fulfillment-0.1.1.4, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.1.1
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.12.0.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
         - directory-ospath-streaming < 0 # tried directory-ospath-streaming-0.2, but its *library* requires filepath >=1.4.100 && < 1.5 and the snapshot contains filepath-1.5.2.0
@@ -6983,102 +6772,6 @@ packages:
         - gloss-raster < 0 # tried gloss-raster-1.13.1.2, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: x509
         - gogol < 0 # tried gogol-0.5.0, but its *library* requires the disabled package: x509-store
-        - gogol-adexchange-buyer < 0 # tried gogol-adexchange-buyer-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-adexchange-seller < 0 # tried gogol-adexchange-seller-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-admin-datatransfer < 0 # tried gogol-admin-datatransfer-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-admin-directory < 0 # tried gogol-admin-directory-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-admin-emailmigration < 0 # tried gogol-admin-emailmigration-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-admin-reports < 0 # tried gogol-admin-reports-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-adsense < 0 # tried gogol-adsense-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-adsense-host < 0 # tried gogol-adsense-host-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-affiliates < 0 # tried gogol-affiliates-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-analytics < 0 # tried gogol-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-android-enterprise < 0 # tried gogol-android-enterprise-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-android-publisher < 0 # tried gogol-android-publisher-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-appengine < 0 # tried gogol-appengine-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-apps-activity < 0 # tried gogol-apps-activity-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-apps-calendar < 0 # tried gogol-apps-calendar-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-apps-licensing < 0 # tried gogol-apps-licensing-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-apps-reseller < 0 # tried gogol-apps-reseller-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-apps-tasks < 0 # tried gogol-apps-tasks-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-appstate < 0 # tried gogol-appstate-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-autoscaler < 0 # tried gogol-autoscaler-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-bigquery < 0 # tried gogol-bigquery-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-billing < 0 # tried gogol-billing-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-blogger < 0 # tried gogol-blogger-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-books < 0 # tried gogol-books-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-civicinfo < 0 # tried gogol-civicinfo-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-classroom < 0 # tried gogol-classroom-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-cloudmonitoring < 0 # tried gogol-cloudmonitoring-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-cloudtrace < 0 # tried gogol-cloudtrace-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-compute < 0 # tried gogol-compute-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-container < 0 # tried gogol-container-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-core < 0 # tried gogol-core-0.5.0, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - gogol-customsearch < 0 # tried gogol-customsearch-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-dataflow < 0 # tried gogol-dataflow-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-dataproc < 0 # tried gogol-dataproc-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-datastore < 0 # tried gogol-datastore-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-debugger < 0 # tried gogol-debugger-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-deploymentmanager < 0 # tried gogol-deploymentmanager-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-dfareporting < 0 # tried gogol-dfareporting-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-discovery < 0 # tried gogol-discovery-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-dns < 0 # tried gogol-dns-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-doubleclick-bids < 0 # tried gogol-doubleclick-bids-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-doubleclick-search < 0 # tried gogol-doubleclick-search-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-drive < 0 # tried gogol-drive-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-firebase-rules < 0 # tried gogol-firebase-rules-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-fitness < 0 # tried gogol-fitness-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-fonts < 0 # tried gogol-fonts-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-freebasesearch < 0 # tried gogol-freebasesearch-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-fusiontables < 0 # tried gogol-fusiontables-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-games < 0 # tried gogol-games-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-games-configuration < 0 # tried gogol-games-configuration-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-games-management < 0 # tried gogol-games-management-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-genomics < 0 # tried gogol-genomics-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-gmail < 0 # tried gogol-gmail-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-groups-migration < 0 # tried gogol-groups-migration-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-groups-settings < 0 # tried gogol-groups-settings-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-identity-toolkit < 0 # tried gogol-identity-toolkit-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-kgsearch < 0 # tried gogol-kgsearch-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-latencytest < 0 # tried gogol-latencytest-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-logging < 0 # tried gogol-logging-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-maps-coordinate < 0 # tried gogol-maps-coordinate-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-maps-engine < 0 # tried gogol-maps-engine-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-mirror < 0 # tried gogol-mirror-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-monitoring < 0 # tried gogol-monitoring-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-oauth2 < 0 # tried gogol-oauth2-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-pagespeed < 0 # tried gogol-pagespeed-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-partners < 0 # tried gogol-partners-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-people < 0 # tried gogol-people-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-play-moviespartner < 0 # tried gogol-play-moviespartner-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-plus < 0 # tried gogol-plus-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-plus-domains < 0 # tried gogol-plus-domains-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-prediction < 0 # tried gogol-prediction-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-proximitybeacon < 0 # tried gogol-proximitybeacon-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-pubsub < 0 # tried gogol-pubsub-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-qpxexpress < 0 # tried gogol-qpxexpress-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-replicapool < 0 # tried gogol-replicapool-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-replicapool-updater < 0 # tried gogol-replicapool-updater-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-resourcemanager < 0 # tried gogol-resourcemanager-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-resourceviews < 0 # tried gogol-resourceviews-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-script < 0 # tried gogol-script-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-sheets < 0 # tried gogol-sheets-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-shopping-content < 0 # tried gogol-shopping-content-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-siteverification < 0 # tried gogol-siteverification-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-spectrum < 0 # tried gogol-spectrum-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-sqladmin < 0 # tried gogol-sqladmin-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-storage < 0 # tried gogol-storage-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-storage-transfer < 0 # tried gogol-storage-transfer-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-tagmanager < 0 # tried gogol-tagmanager-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-taskqueue < 0 # tried gogol-taskqueue-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-translate < 0 # tried gogol-translate-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-urlshortener < 0 # tried gogol-urlshortener-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-useraccounts < 0 # tried gogol-useraccounts-0.3.0, but its *library* requires gogol-core >=0.3.0 && < 0.3.1 and the snapshot contains gogol-core-0.5.0
-        - gogol-vision < 0 # tried gogol-vision-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-webmaster-tools < 0 # tried gogol-webmaster-tools-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-youtube < 0 # tried gogol-youtube-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-youtube-analytics < 0 # tried gogol-youtube-analytics-0.5.0, but its *library* requires the disabled package: gogol-core
-        - gogol-youtube-reporting < 0 # tried gogol-youtube-reporting-0.5.0, but its *library* requires the disabled package: gogol-core
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-api-data >=0.2 && < 0.4 and the snapshot contains http-api-data-0.6.1
         - google-translate < 0 # tried google-translate-0.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.17
@@ -7087,18 +6780,6 @@ packages:
         - gothic < 0 # tried gothic-0.1.8.2, but its *library* requires hashable >=1.4.3 && < 1.5 and the snapshot contains hashable-1.5.0.0
         - graphql-client < 0 # tried graphql-client-1.2.4, but its *executable* requires the disabled package: path
         - graphql-client < 0 # tried graphql-client-1.2.4, but its *library* requires the disabled package: aeson-schemas
-        - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires groundhog-th >=0.8 && < 0.12 and the snapshot contains groundhog-th-0.12
-        - groundhog-inspector < 0 # tried groundhog-inspector-0.11.0, but its *library* requires the disabled package: groundhog
-        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires mysql >=0.1.1.3 && < 0.2 and the snapshot contains mysql-0.2.1
-        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires the disabled package: groundhog
-        - groundhog-mysql < 0 # tried groundhog-mysql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires postgresql-simple >=0.3 && < 0.7 and the snapshot contains postgresql-simple-0.7.0.0
-        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires the disabled package: groundhog
-        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires transformers >=0.2.1 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - groundhog-postgresql < 0 # tried groundhog-postgresql-0.12, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
-        - groundhog-sqlite < 0 # tried groundhog-sqlite-0.12.0, but its *library* requires the disabled package: groundhog
-        - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires aeson >=0.7 && < 2 and the snapshot contains aeson-2.2.3.0
-        - groundhog-th < 0 # tried groundhog-th-0.12, but its *library* requires the disabled package: groundhog
         - grouped-list < 0 # tried grouped-list-0.2.3.0, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.20.0.0
         - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires gi-gdk >=3.0.25 && < 4 and the snapshot contains gi-gdk-4.0.9
         - gtk-sni-tray < 0 # tried gtk-sni-tray-0.1.8.1, but its *library* requires gi-gtk >=3.0.38 && < 4 and the snapshot contains gi-gtk-4.0.9
@@ -7140,12 +6821,6 @@ packages:
         - hasbolt < 0 # tried hasbolt-0.1.7.0, but its *library* requires network >=2.6.3.1 && < 3.2 and the snapshot contains network-3.2.7.0
         - hasbolt < 0 # tried hasbolt-0.1.7.0, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
         - hashing < 0 # tried hashing-0.1.1.0, but its *library* requires bytestring >=0.10.6.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires aeson >=0.8.0.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires bytestring >=0.10.4.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires containers >=0.2 && < 0.7 and the snapshot contains containers-0.7
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires filepath >=1.1 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - haskell-names < 0 # tried haskell-names-0.9.9, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - haskey < 0 # tried haskey-0.3.1.0, but its *library* requires unix >=2.7.1.0 && < 2.8 and the snapshot contains unix-2.8.5.1
         - haskey-mtl < 0 # tried haskey-mtl-0.3.1.0, but its *library* requires monad-control >=1.0.1.0 && < 1.0.2.4 and the snapshot contains monad-control-1.0.3.1
         - haskintex < 0 # tried haskintex-0.8.0.2, but its *library* requires filepath >=1.1.0 && < 1.5 and the snapshot contains filepath-1.5.2.0
@@ -7197,23 +6872,6 @@ packages:
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
         - hindent < 0 # tried hindent-6.2.1, but its *library* requires Cabal < 3.12 and the snapshot contains Cabal-3.12.0.0
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
-        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires aeson >=0.7 && < 1.4 and the snapshot contains aeson-2.2.3.0
-        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.5.0.0
-        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - hjsonpointer < 0 # tried hjsonpointer-1.5.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires QuickCheck >=2.8 && < 2.11 and the snapshot contains QuickCheck-2.15.0.1
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires aeson >=0.11 && < 1.4 and the snapshot contains aeson-2.2.3.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.7
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires filepath >=1.3 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hashable >=1.2 && < 1.3 and the snapshot contains hashable-1.5.0.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires hjsonpointer >=1.1 && < 1.4 and the snapshot contains hjsonpointer-1.5.0
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-client >=0.4.30 && < 0.6 and the snapshot contains http-client-0.7.17
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires http-types >=0.8 && < 0.10 and the snapshot contains http-types-0.12.4
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires profunctors >=5.0 && < 5.3 and the snapshot contains profunctors-5.6.2
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires protolude >=0.1.10 && < 0.3 and the snapshot contains protolude-0.3.4
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.1
-        - hjsonschema < 0 # tried hjsonschema-1.10.0, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
         - hledger-iadd < 0 # tried hledger-iadd-1.3.21, but its *library* requires brick >=2.1 && < 2.6 and the snapshot contains brick-2.6
         - hledger-iadd < 0 # tried hledger-iadd-1.3.21, but its *library* requires hledger-lib >=1.33 && < 1.41 and the snapshot contains hledger-lib-1.41
         - hledger-ui < 0 # tried hledger-ui-1.41, but its *library* requires the disabled package: microlens-platform
@@ -7231,12 +6889,6 @@ packages:
         - hopfli < 0 # tried hopfli-0.2.2.1, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - hopfli < 0 # tried hopfli-0.2.2.1, but its *library* requires zlib >=0.5.4 && < 0.7 and the snapshot contains zlib-0.7.1.0
         - hpack-dhall < 0 # tried hpack-dhall-0.5.7, but its *library* requires hpack >=0.35 && < 0.36 and the snapshot contains hpack-0.37.0
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires aeson >=0.7.1 && < 1.3 and the snapshot contains aeson-2.2.3.0
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires containers >=0.5 && < 0.6 and the snapshot contains containers-0.7
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires hpc >=0.6 && < 0.7 and the snapshot contains hpc-0.7.0.1
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires retry >=0.5 && < 0.8 and the snapshot contains retry-0.9.3.1
-        - hpc-coveralls < 0 # tried hpc-coveralls-1.0.10, but its *library* requires transformers >=0.4.1 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - hpc-lcov < 0 # tried hpc-lcov-1.1.2, but its *executable* requires the disabled package: path
         - hpio < 0 # tried hpio-0.9.0.7, but its *executable* requires optparse-applicative >=0.11.0 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
         - hpio < 0 # tried hpio-0.9.0.7, but its *library* requires QuickCheck >=2.7.6 && < 2.13 and the snapshot contains QuickCheck-2.15.0.1
@@ -7259,30 +6911,6 @@ packages:
         - hschema-aeson < 0 # tried hschema-aeson-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-prettyprinter < 0 # tried hschema-prettyprinter-0.0.1.1, but its *library* requires the disabled package: hschema
         - hschema-quickcheck < 0 # tried hschema-quickcheck-0.0.1.1, but its *library* requires the disabled package: hschema
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires aeson >=1.2.4.0 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires attoparsec >=0.13.1.0 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires containers >=0.5.7.1 && < 0.7 and the snapshot contains containers-0.7
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires data-default >=0.7.1.1 && < 0.8 and the snapshot contains data-default-0.8.0.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires deepseq >=1.4.2.0 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires filepath >=1.4.1.0 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires fsnotify >=0.2.1 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-boot >=8.0.1 && < 8.11 and the snapshot contains ghc-boot-9.10.1
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires ghc-lib-parser >=8.10 && < 8.11 and the snapshot contains ghc-lib-parser-9.10.1.20241103
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires hlint >=3.0.0 && < 3.3.0 and the snapshot contains hlint-3.8
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires http-client >=0.5 && < 0.7 and the snapshot contains http-client-0.7.17
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires lens >=4.14 && < 4.20 and the snapshot contains lens-5.3.2
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mmorph >=1.0.9 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires mtl >=2.2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires network >=2.8 && < 3.2 and the snapshot contains network-3.2.7.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires optparse-applicative >=0.12.1.0 && < 0.16 and the snapshot contains optparse-applicative-0.18.1.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires template-haskell >=2.11.0 && < 2.17 and the snapshot contains template-haskell-2.22.0.0
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires text >=1.2.2.2 && < 1.3 and the snapshot contains text-2.1.1
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires the disabled package: text-region
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires time >=1.6.0.1 && < 1.10 and the snapshot contains time-1.12.2
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires transformers >=0.5.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires unix >=2.7.2.0 && < 2.8 and the snapshot contains unix-2.8.5.1
-        - hsdev < 0 # tried hsdev-0.3.4.0, but its *library* requires vector >=0.11.0.0 && < 0.13 and the snapshot contains vector-0.13.2.0
         - hsexif < 0 # tried hsexif-0.6.1.10, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - hsexif < 0 # tried hsexif-0.6.1.10, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
         - hsx-jmacro < 0 # tried hsx-jmacro-7.3.8.2, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -7295,8 +6923,6 @@ packages:
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
         - hsyslog-udp < 0 # tried hsyslog-udp-0.2.5, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.5.1
         - html-parse < 0 # tried html-parse-0.2.1.0, but its *library* requires base >=4.7 && < 4.20 and the snapshot contains base-4.20.0.0
-        - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.2.3.0
-        - htoml < 0 # tried htoml-1.0.0.3, but its *library* requires text >=1.0 && < 2 and the snapshot contains text-2.1.1
         - http-api-data-qq < 0 # tried http-api-data-qq-0.1.0.0, but its *library* requires template-haskell >=2.14 && < 2.22 and the snapshot contains template-haskell-2.22.0.0
         - http-download < 0 # tried http-download-0.2.1.0, but its *library* requires the disabled package: path
         - hw-balancedparens < 0 # tried hw-balancedparens-0.4.1.3, but its *library* requires the disabled package: hw-fingertree
@@ -7326,31 +6952,9 @@ packages:
         - hw-xml < 0 # tried hw-xml-0.5.1.2, but its *library* requires the disabled package: hw-balancedparens
         - hw-xml < 0 # tried hw-xml-0.5.1.2, but its *library* requires the disabled package: hw-rankselect
         - hyper < 0 # tried hyper-0.2.1.1, but its *library* requires base >=4.5 && < 4.20 and the snapshot contains base-4.20.0.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires Cabal >=2.4 && < =3.4 and the snapshot contains Cabal-3.12.0.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires aeson >=0.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-terminal < 0.12 and the snapshot contains ansi-terminal-1.1.2
-        - idris < 0 # tried idris-1.3.4, but its *library* requires ansi-wl-pprint < 0.7 and the snapshot contains ansi-wl-pprint-1.0.2
-        - idris < 0 # tried idris-1.3.4, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
-        - idris < 0 # tried idris-1.3.4, but its *library* requires deepseq < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires filepath < 1.5 and the snapshot contains filepath-1.5.2.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires fsnotify >=0.2 && < 0.4 and the snapshot contains fsnotify-0.4.1.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires libffi < 0.2 and the snapshot contains libffi-0.2.1
-        - idris < 0 # tried idris-1.3.4, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - idris < 0 # tried idris-1.3.4, but its *library* requires network >=2.7 && < 3.1.2 and the snapshot contains network-3.2.7.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires optparse-applicative >=0.13 && < 0.17 and the snapshot contains optparse-applicative-0.18.1.0
-        - idris < 0 # tried idris-1.3.4, but its *library* requires text >=1.2.1.0 && < 1.4 and the snapshot contains text-2.1.1
-        - idris < 0 # tried idris-1.3.4, but its *library* requires transformers >=0.5 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - idris < 0 # tried idris-1.3.4, but its *library* requires unix < 2.8 and the snapshot contains unix-2.8.5.1
-        - idris < 0 # tried idris-1.3.4, but its *library* requires vector < 0.13 and the snapshot contains vector-0.13.2.0
         - ihaskell < 0 # tried ihaskell-0.12.0.0, but its *library* requires the disabled package: hlint
         - ihaskell-hvega < 0 # tried ihaskell-hvega-0.5.0.5, but its *library* requires ihaskell >=0.10 && < 0.12 and the snapshot contains ihaskell-0.12.0.0
         - ilist < 0 # tried ilist-0.4.0.1, but its *library* requires base >=4.10 && < 4.20 and the snapshot contains base-4.20.0.0
-        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: haskell-names
-        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: log-warper
-        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: microlens-platform
-        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: path
-        - importify < 0 # tried importify-1.0.1, but its *library* requires the disabled package: text-format
         - incremental-parser < 0 # tried incremental-parser-0.5.1, but its *library* requires the disabled package: rank2classes
         - inflections < 0 # tried inflections-0.4.0.7, but its *library* requires text >=0.2 && < 2.1 and the snapshot contains text-2.1.1
         - inline-java < 0 # tried inline-java-0.10.0, but its *library* requires ghc >=8.10.1 && < =8.11 and the snapshot contains ghc-9.10.1
@@ -7416,33 +7020,12 @@ packages:
         - jmacro-rpc-happstack < 0 # tried jmacro-rpc-happstack-0.3.2, but its *library* requires the disabled package: jmacro-rpc
         - jmacro-rpc-snap < 0 # tried jmacro-rpc-snap-0.3, but its *library* requires the disabled package: jmacro-rpc
         - journalctl-stream < 0 # tried journalctl-stream-0.6.0.6, but its *library* requires base < 4.20 and the snapshot contains base-4.20.0.0
-        - json-alt < 0 # tried json-alt-1.0.0, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *executable* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires aeson >=1.2.1 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires containers >=0.3 && < 0.7 and the snapshot contains containers-0.7
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires data-default >=0.7 && < 0.8 and the snapshot contains data-default-0.8.0.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires filepath >=1.3 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires hashable >=1.2 && < 1.4 and the snapshot contains hashable-1.5.0.0
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires lens >=4.1 && < 4.20 and the snapshot contains lens-5.3.2
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires smallcheck >=1.0 && < 1.2 and the snapshot contains smallcheck-1.2.1.1
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires text >=1.1 && < 1.4 and the snapshot contains text-2.1.1
-        - json-autotype < 0 # tried json-autotype-3.1.2, but its *library* requires vector >=0.9 && < 0.13 and the snapshot contains vector-0.13.2.0
         - json-spec-openapi < 0 # tried json-spec-openapi-1.0.0.0, but its *library* requires the disabled package: insert-ordered-containers
         - json-spec-openapi < 0 # tried json-spec-openapi-1.0.0.0, but its *library* requires the disabled package: openapi3
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
         - kanji < 0 # tried kanji-3.5.0, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.2.3.0
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires aeson >=1.2 && < 1.3 and the snapshot contains aeson-2.2.3.0
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires async >=2.1 && < 2.2 and the snapshot contains async-2.2.5
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.8.2
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires rollbar-hs >=0.2 && < 0.3 and the snapshot contains rollbar-hs-0.3.1.0
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - katip-rollbar < 0 # tried katip-rollbar-0.3.0.1, but its *library* requires time >=1.8 && < 1.9 and the snapshot contains time-1.12.2
-        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.2.3.0
-        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires katip >=0.5 && < 0.6 and the snapshot contains katip-0.8.8.2
-        - katip-scalyr-scribe < 0 # tried katip-scalyr-scribe-0.1.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
         - keyed-vals < 0 # tried keyed-vals-0.2.3.1, but its *library* requires the disabled package: redis-glob
         - keyed-vals-hspec-tests < 0 # tried keyed-vals-hspec-tests-0.2.3.1, but its *library* requires the disabled package: keyed-vals
         - keyed-vals-mem < 0 # tried keyed-vals-mem-0.2.3.1, but its *library* requires the disabled package: keyed-vals
@@ -7450,10 +7033,6 @@ packages:
         - kind-generics-th < 0 # tried kind-generics-th-0.2.3.3, but its *library* requires template-haskell >=2.14 && < 2.21 and the snapshot contains template-haskell-2.22.0.0
         - kind-generics-th < 0 # tried kind-generics-th-0.2.3.3, but its *library* requires th-abstraction >=0.4 && < 0.7 and the snapshot contains th-abstraction-0.7.1.0
         - kleene < 0 # tried kleene-0.1, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - koofr-client < 0 # tried koofr-client-1.0.0.3, but its *library* requires aeson >=0.8 && < 2 and the snapshot contains aeson-2.2.3.0
-        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires aeson >=1.4.6 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires bytestring >=0.10.8 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - kubernetes-webhook-haskell < 0 # tried kubernetes-webhook-haskell-0.2.0.3, but its *library* requires text >=1.2.3 && < 1.3 and the snapshot contains text-2.1.1
         - l10n < 0 # tried l10n-0.1.0.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.1
         - lambdabot-core < 0 # tried lambdabot-core-5.3.1.2, but its *library* requires dependent-sum-template >=0.1.0.2 && < 0.2 and the snapshot contains dependent-sum-template-0.2.0.1
         - lambdabot-irc-plugins < 0 # tried lambdabot-irc-plugins-5.3.1.2, but its *library* requires the disabled package: lambdabot-core
@@ -7524,16 +7103,6 @@ packages:
         - lsp-types < 0 # tried lsp-types-2.3.0.0, but its *library* requires data-default ^>=0.7 and the snapshot contains data-default-0.8.0.0
         - lsp-types < 0 # tried lsp-types-2.3.0.0, but its *library* requires hashable ^>=1.4 and the snapshot contains hashable-1.5.0.0
         - lsql-csv < 0 # tried lsql-csv-0.1.0.6, but its *library* requires base >=4.9 && < 4.20 and the snapshot contains base-4.20.0.0
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires aeson >=1.0.2.1 && < 2 and the snapshot contains aeson-2.2.3.0
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires network >=2.6.3.2 && < 3 and the snapshot contains network-3.2.7.0
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant >=0.11 && < 0.14 and the snapshot contains servant-0.20.2
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires servant-client >=0.11 && < 0.14 and the snapshot contains servant-client-0.20.2
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires text >=1.2.2.2 && < 2 and the snapshot contains text-2.1.1
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires the disabled package: x509
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires the disabled package: x509-store
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires the disabled package: x509-validation
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires tls >=1.3.9 && < 2 and the snapshot contains tls-2.1.5
-        - lxd-client < 0 # tried lxd-client-0.1.0.6, but its *library* requires websockets >=0.10.0.0 && < 0.11 || >=0.12.2.0 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - lxd-client-config < 0 # tried lxd-client-config-0.1.0.1, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
         - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires bytestring >=0.9.1 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - lzma-conduit < 0 # tried lzma-conduit-1.2.3, but its *library* requires resourcet >=1.1.0 && < 1.3 and the snapshot contains resourcet-1.3.0
@@ -7549,11 +7118,6 @@ packages:
         - makefile < 0 # tried makefile-1.1.0.0, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.1
         - mallard < 0 # tried mallard-0.6.1.1, but its *library* requires megaparsec >=6 && < 7 and the snapshot contains megaparsec-9.7.0
         - mandrill < 0 # tried mandrill-0.5.7.0, but its *library* requires text >=1.0.0.0 && < 2.1 and the snapshot contains text-2.1.1
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires aeson >=0.11 && < 1.3 and the snapshot contains aeson-2.2.3.0
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires http-client >=0.4 && < 0.6 and the snapshot contains http-client-0.7.17
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires lens >=4 && < 5 and the snapshot contains lens-5.3.2
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires text-icu >=0.6 && < 0.8 and the snapshot contains text-icu-0.8.0.5
-        - marvin < 0 # tried marvin-0.2.5, but its *library* requires the disabled package: marvin-interpolate
         - mason < 0 # tried mason-0.2.6, but its *library* requires network >=2.7 && < 3.2 and the snapshot contains network-3.2.7.0
         - massiv-persist < 0 # tried massiv-persist-1.0.0.3, but its *library* requires the disabled package: persist
         - mbox < 0 # tried mbox-0.3.4, but its *library* requires time < 1.10 and the snapshot contains time-1.12.2
@@ -7885,25 +7449,12 @@ packages:
         - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.22.0.0
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.6, but its *library* requires the disabled package: unfoldable-restricted
         - quickcheck-special < 0 # tried quickcheck-special-0.1.0.6, but its *library* requires the disabled package: special-values
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires aeson >=1.0.2.1 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires bytestring >=0.10.8.1 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires connection >=0.2.7 && < 0.3 and the snapshot contains connection-0.3.1
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires constraints >=0.9.1 && < 0.11 and the snapshot contains constraints-0.14.2
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires data-default-class >=0.1.2.0 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires extensible >=0.4.7.2 && < 0.4.11 and the snapshot contains extensible-0.9.2
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-api-data >=0.3.5 && < 0.3.9 and the snapshot contains http-api-data-0.6.1
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires http-client >=0.5.5.0 && < 0.6 and the snapshot contains http-client-0.7.17
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires lens >=4.15.3 && < 5.0 and the snapshot contains lens-5.3.2
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires req >=0.3.0 && < 1.3.0 and the snapshot contains req-3.13.4
-        - rakuten < 0 # tried rakuten-0.1.1.5, but its *library* requires text >=1.2.2.1 && < 1.3 and the snapshot contains text-2.1.1
         - rank2classes < 0 # tried rank2classes-1.5.3.1, but its *library* requires the disabled package: data-functor-logistic
         - reactive-balsa < 0 # tried reactive-balsa-0.4.0.1, but its *library* requires the disabled package: reactive-banana-bunch
         - reactive-banana < 0 # tried reactive-banana-1.3.2.0, but its *library* requires hashable >=1.1 && < 1.5 and the snapshot contains hashable-1.5.0.0
         - reactive-banana-bunch < 0 # tried reactive-banana-bunch-1.0.0.1, but its *library* requires the disabled package: reactive-banana
         - reactive-jack < 0 # tried reactive-jack-0.4.1.2, but its *library* requires the disabled package: reactive-banana-bunch
         - reactive-midyim < 0 # tried reactive-midyim-0.4.1.1, but its *library* requires the disabled package: reactive-banana-bunch
-        - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires aeson >=1.3.0.0 && < 2 and the snapshot contains aeson-2.2.3.0
-        - reanimate < 0 # tried reanimate-1.1.6.0, but its *library* requires the disabled package: reanimate-svg
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.20.0.0
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.9.0.0
         - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.17, but its *library* requires ghc >=8.6 && < 9.9 and the snapshot contains ghc-9.10.1
@@ -7949,23 +7500,9 @@ packages:
         - rhine-bayes < 0 # tried rhine-bayes-1.5, but its *library* requires the disabled package: monad-bayes
         - rhine-gloss < 0 # tried rhine-gloss-1.5, but its *library* requires the disabled package: monad-schedule
         - rhine-terminal < 0 # tried rhine-terminal-1.5, but its *library* requires the disabled package: monad-schedule
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires aeson >=0.8 && < 1.5.7 and the snapshot contains aeson-2.2.3.0
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires attoparsec >=0.12.1.6 && < 0.14 and the snapshot contains attoparsec-0.14.4
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires network >=3.0 && < 3.1 and the snapshot contains network-3.2.7.0
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires resource-pool >=0.2 && < 0.3 and the snapshot contains resource-pool-0.4.0.0
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires time >=1.4.2 && < 1.10 and the snapshot contains time-1.12.2
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - riak < 0 # tried riak-1.2.0.0, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.2.0
         - riak-protobuf < 0 # tried riak-protobuf-0.25.0.0, but its *library* requires the disabled package: proto-lens
         - riak-protobuf < 0 # tried riak-protobuf-0.25.0.0, but its *library* requires the disabled package: proto-lens-runtime
         - rio-prettyprint < 0 # tried rio-prettyprint-0.1.8.0, but its *library* requires the disabled package: path
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires network >=2.6 && < 2.8 and the snapshot contains network-3.2.7.0
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - rollbar-hs < 0 # tried rollbar-hs-0.3.1.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - run-haskell-module < 0 # tried run-haskell-module-0.0.2, but its *library* requires data-default >=0.7 && < 0.8 and the snapshot contains data-default-0.8.0.0
         - run-haskell-module < 0 # tried run-haskell-module-0.0.2, but its *library* requires filepath >=1.3 && < 1.5 and the snapshot contains filepath-1.5.2.0
         - rzk < 0 # tried rzk-0.7.5, but its *library* requires the disabled package: lsp
@@ -8024,21 +7561,6 @@ packages:
         - servant-auth-wordpress < 0 # tried servant-auth-wordpress-1.0.0.2, but its *library* requires the disabled package: wordpress-auth
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires base-compat >=0.9.1 && < 0.13 and the snapshot contains base-compat-0.14.1
         - servant-cassava < 0 # tried servant-cassava-0.10.2, but its *library* requires servant >=0.7 && < 0.20 and the snapshot contains servant-0.20.2
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires aeson >=1.4.2 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires bytestring >=0.10.8.2 && < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires servant >=0.15 && < 0.19 and the snapshot contains servant-0.20.2
-        - servant-docs-simple < 0 # tried servant-docs-simple-0.4.0.0, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.1
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *executable* requires aeson >=1.4.1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires base >=4.9 && < 4.20 and the snapshot contains base-4.20.0.0
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires base-compat >=0.10.5 && < 0.14 and the snapshot contains base-compat-0.14.1
-        - servant-js < 0 # tried servant-js-0.9.4.2, but its *library* requires lens >=4.17 && < 5.3 and the snapshot contains lens-5.3.2
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires containers >=0.5.7 && < 0.6.1 and the snapshot contains containers-0.7
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires formatting >=6.2 && < 6.4 and the snapshot contains formatting-7.2.0
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires lens >=4.15 && < 4.18 and the snapshot contains lens-5.3.2
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant >=0.9 && < 0.17 and the snapshot contains servant-0.20.2
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires servant-foreign >=0.9 && < 0.16 and the snapshot contains servant-foreign-0.16.1
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - servant-kotlin < 0 # tried servant-kotlin-0.1.1.9, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.6, but its *library* requires base >=4.9 && < 4.20 and the snapshot contains base-4.20.0.0
         - servant-openapi3 < 0 # tried servant-openapi3-2.0.1.6, but its *library* requires base-compat >=0.10.5 && < 0.14 and the snapshot contains base-compat-0.14.1
         - servant-pandoc < 0 # tried servant-pandoc-0.5.0.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -8070,15 +7592,6 @@ packages:
         - shikensu < 0 # tried shikensu-0.4.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.1
         - show-prettyprint < 0 # tried show-prettyprint-0.3.0.1, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.4
         - shower < 0 # tried shower-0.2.0.3, but its *library* requires base >=4.10 && < 4.18 and the snapshot contains base-4.20.0.0
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires data-default >=0.5 && < 0.8 and the snapshot contains data-default-0.8.0.0
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires deepseq >=1.4 && < 1.5 and the snapshot contains deepseq-1.5.0.0
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires filepath >=1.4 && < 1.5 and the snapshot contains filepath-1.5.2.0
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mmorph >=1.0 && < 1.2 and the snapshot contains mmorph-1.2.0
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires mtl >=2.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires text >=0.11.0 && < 2.0.0 and the snapshot contains text-2.1.1
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
-        - simple-log < 0 # tried simple-log-0.9.12, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - simple-media-timestamp-formatting < 0 # tried simple-media-timestamp-formatting-0.1.1.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires template-haskell >=2.12 && < 2.16 and the snapshot contains template-haskell-2.22.0.0
@@ -8103,10 +7616,6 @@ packages:
         - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.20.0.0
         - smash-lens < 0 # tried smash-lens-0.1.0.3, but its *library* requires lens >=4.0 && < 5.2 and the snapshot contains lens-5.3.2
         - smash-microlens < 0 # tried smash-microlens-0.1.0.2, but its *library* requires base >=4.11 && < 4.17 and the snapshot contains base-4.20.0.0
-        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires aeson >=0.8 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires linear >=1.16 && < 1.22 and the snapshot contains linear-1.23
-        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - smoothie < 0 # tried smoothie-0.4.2.11, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
         - soap < 0 # tried soap-0.2.3.6, but its *library* requires bytestring >=0.10.6 && < 0.12 and the snapshot contains bytestring-0.12.1.0
         - soap < 0 # tried soap-0.2.3.6, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
         - soap-openssl < 0 # tried soap-openssl-0.1.0.2, but its *library* requires text >=1.2.2.1 && < 2.1 and the snapshot contains text-2.1.1
@@ -8175,29 +7684,9 @@ packages:
         - stripe-concepts < 0 # tried stripe-concepts-1.0.3.3, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.20.0.0
         - stripe-concepts < 0 # tried stripe-concepts-1.0.3.3, but its *library* requires bytestring ^>=0.11 and the snapshot contains bytestring-0.12.1.0
         - stripe-concepts < 0 # tried stripe-concepts-1.0.3.3, but its *library* requires text ^>=1.2.5 || ^>=2.0 and the snapshot contains text-2.1.1
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
-        - stripe-core < 0 # tried stripe-core-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.1
-        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-core
-        - stripe-haskell < 0 # tried stripe-haskell-2.6.2, but its *library* requires the disabled package: stripe-http-client
-        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - stripe-http-client < 0 # tried stripe-http-client-2.6.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.1
         - stripe-signature < 0 # tried stripe-signature-1.0.0.16, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.20.0.0
         - stripe-signature < 0 # tried stripe-signature-1.0.0.16, but its *library* requires bytestring ^>=0.11 and the snapshot contains bytestring-0.12.1.0
         - stripe-signature < 0 # tried stripe-signature-1.0.0.16, but its *library* requires text ^>=1.2.5 || ^>=2.0 and the snapshot contains text-2.1.1
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires aeson >=0.8 && < 0.10 || >=0.11 && < 1.6 and the snapshot contains aeson-2.2.3.0
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec >=2.1.0 && < 2.8 and the snapshot contains hspec-2.11.10
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires hspec-core >=2.1.0 && < 2.8 and the snapshot contains hspec-core-2.11.10
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires mtl >=2.1.2 && < 2.3 and the snapshot contains mtl-2.3.1
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires random >=1.1 && < 1.2 and the snapshot contains random-1.2.1.3
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.1
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires time >=1.4 && < 1.11 and the snapshot contains time-1.12.2
-        - stripe-tests < 0 # tried stripe-tests-2.6.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires aeson ^>=2.0.3 || ^>=2.1 and the snapshot contains aeson-2.2.3.0
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.20.0.0
         - stripe-wreq < 0 # tried stripe-wreq-1.0.1.16, but its *library* requires bytestring ^>=0.11 and the snapshot contains bytestring-0.12.1.0
@@ -8219,17 +7708,6 @@ packages:
         - stylish-haskell < 0 # tried stylish-haskell-0.14.6.0, but its *library* requires ghc-lib-parser >=9.8 && < 9.9 and the snapshot contains ghc-lib-parser-9.10.1.20241103
         - stylish-haskell < 0 # tried stylish-haskell-0.14.6.0, but its *library* requires ghc-lib-parser-ex >=9.8 && < 9.9 and the snapshot contains ghc-lib-parser-ex-9.10.0.0
         - superbuffer < 0 # tried superbuffer-0.3.1.2, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires aeson >=1.0 && < 2.0 and the snapshot contains aeson-2.2.3.0
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires bytestring >=0.10.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires containers >=0.5.0.0 && < 0.6 and the snapshot contains containers-0.7
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-api-data >=0.3.4 && < 0.4 and the snapshot contains http-api-data-0.6.1
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires http-media >=0.4 && < 0.8 and the snapshot contains http-media-0.8.1.1
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires katip >=0.4 && < 0.6 and the snapshot contains katip-0.8.8.2
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires network >=2.6.2 && < 2.8 and the snapshot contains network-3.2.7.0
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires text >=0.11 && < 1.3 and the snapshot contains text-2.1.1
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires time >=1.5 && < 1.10 and the snapshot contains time-1.12.2
-        - swagger-petstore < 0 # tried swagger-petstore-0.0.2.0, but its *library* requires vector >=0.10.9 && < 0.13 and the snapshot contains vector-0.13.2.0
         - swagger2 < 0 # tried swagger2-2.8.9, but its *library* requires the disabled package: insert-ordered-containers
         - sweet-egison < 0 # tried sweet-egison-0.1.1.3, but its *library* requires logict ^>=0.7.0 and the snapshot contains logict-0.8.2.0
         - syb-with-class < 0 # tried syb-with-class-0.6.1.14, but its *library* requires template-haskell >=2.4 && < 2.19 and the snapshot contains template-haskell-2.22.0.0
@@ -8393,11 +7871,6 @@ packages:
         - vformat-aeson < 0 # tried vformat-aeson-0.1.0.1, but its *library* requires text >=1.2 && < 2.0 and the snapshot contains text-2.1.1
         - wai-control < 0 # tried wai-control-0.2.0.0, but its *library* requires websockets >=0.12.5.3 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.18.1.0
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires aeson >=1.0 && < 1.4 and the snapshot contains aeson-2.2.3.0
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires http-client >=0.5 && < 0.6 and the snapshot contains http-client-0.7.17
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.1
-        - wai-middleware-rollbar < 0 # tried wai-middleware-rollbar-0.11.0, but its *library* requires time >=1.6 && < 1.9 and the snapshot contains time-1.12.2
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
         - wai-session-redis < 0 # tried wai-session-redis-0.1.0.5, but its *executable* requires warp < 3.4 and the snapshot contains warp-3.4.7
@@ -8506,14 +7979,6 @@ packages:
         - zio < 0 # tried zio-0.1.0.2, but its *library* requires transformers >=0.5.6 && < 0.6 and the snapshot contains transformers-0.6.1.1
         - zip < 0 # tried zip-2.1.0, but its *library* requires filepath >=1.2 && < 1.5 and the snapshot contains filepath-1.5.2.0
         - zipper-extra < 0 # tried zipper-extra-0.1.3.2, but its *library* requires the disabled package: comonad-extras
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires base-compat >=0.9 && < 0.10 and the snapshot contains base-compat-0.14.1
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.20.2
-        - ziptastic-client < 0 # tried ziptastic-client-0.3.0.3, but its *library* requires servant-client >=0.9 && < 0.12 and the snapshot contains servant-client-0.20.2
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires aeson >=0.7 && < 1.3 and the snapshot contains aeson-2.2.3.0
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires base-compat >=0.9 && < 0.10 and the snapshot contains base-compat-0.14.1
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires http-api-data >=0.3 && < 0.4 and the snapshot contains http-api-data-0.6.1
-        - ziptastic-core < 0 # tried ziptastic-core-0.2.0.3, but its *library* requires servant >=0.9 && < 0.12 and the snapshot contains servant-0.20.2
         - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires bytestring >=0.9.1.10 && < 0.11 and the snapshot contains bytestring-0.12.1.0
         - zlib-lens < 0 # tried zlib-lens-0.1.2.1, but its *library* requires zlib >=0.5.4 && < 0.7 and the snapshot contains zlib-0.7.1.0
         - zm < 0 # tried zm-0.3.2, but its *library* requires bytestring >=0.10.6.0 && < 0.11 and the snapshot contains bytestring-0.12.1.0
@@ -8571,9 +8036,6 @@ package-flags:
     hpio:
         test-hlint: false
 
-    idris:
-        ffi: true
-
     hxt:
         network-uri: true
     hxt-http:
@@ -8617,9 +8079,6 @@ package-flags:
 
     windns:
         allow-non-windows: true
-
-    hsdev:
-        docs: false
 
     bson:
         _old-network: false
@@ -8791,8 +8250,6 @@ skipped-tests:
     - sydtest-webdriver-yesod # runs chromium
 
     - captcha-core
-    - captcha-2captcha
-    - captcha-capmonster
 
     # @thielema
     - glpk-headers
@@ -8844,9 +8301,6 @@ skipped-tests:
 
     # TODO
     - rpmbuild-order
-
-    # Revision to package caused it to require bounds and break
-    - htoml  # https://github.com/commercialhaskell/stackage/issues/6239
 
     # See "Large scale enabling/disabling of packages" in CURATORS.md for how to manage this section.
     #
@@ -8907,9 +8361,6 @@ skipped-tests:
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires bytestring >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.1.0
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
     - cborg # tried cborg-0.2.10.0, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.11.10
-    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.20.2
-    - chatwork # tried chatwork-0.1.3.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.4.7
     - chimera # tried chimera-0.4.1.0, but its *test-suite* requires QuickCheck >=2.10 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - chimera # tried chimera-0.4.1.0, but its *test-suite* requires tasty-quickcheck < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - clash-prelude # tried clash-prelude-1.8.1, but its *test-suite* requires hedgehog >=1.0.3 && < 1.5 and the snapshot contains hedgehog-1.5
@@ -8995,7 +8446,6 @@ skipped-tests:
     - hasbolt # tried hasbolt-0.1.7.0, but its *test-suite* requires QuickCheck >=2.9 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - hasbolt # tried hasbolt-0.1.7.0, but its *test-suite* requires hspec >=2.4.1 && < 2.11 and the snapshot contains hspec-2.11.10
     - hashable # tried hashable-1.5.0.0, but its *test-suite* requires tasty-quickcheck ^>=0.10.3 and the snapshot contains tasty-quickcheck-0.11
-    - haskell-names # tried haskell-names-0.9.9, but its *test-suite* requires tasty >=0.12 && < 1.3 and the snapshot contains tasty-1.5.2
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires lens >=4.12 && < 5 and the snapshot contains lens-5.3.2
     - haskey-mtl # tried haskey-mtl-0.3.1.0, but its *test-suite* requires text >=1.2 && < 2 and the snapshot contains text-2.1.1
     - haskoin-core # tried haskoin-core-1.1.0, but its *test-suite* requires base64 >=0.4 && < 0.5 and the snapshot contains base64-1.0
@@ -9003,12 +8453,8 @@ skipped-tests:
     - heap # tried heap-1.0.4, but its *test-suite* requires QuickCheck >=2.10 && < 2.12 and the snapshot contains QuickCheck-2.15.0.1
     - hegg # tried hegg-0.5.0.0, but its *test-suite* requires tasty >=1.4 && < 1.5 and the snapshot contains tasty-1.5.2
     - hegg # tried hegg-0.5.0.0, but its *test-suite* requires tasty-quickcheck >=0.10 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
-    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires QuickCheck < 2.12 and the snapshot contains QuickCheck-2.15.0.1
-    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires base < 4.12 and the snapshot contains base-4.20.0.0
-    - hjsonpointer # tried hjsonpointer-1.5.0, but its *test-suite* requires hspec >=2.2 && < 2.6 and the snapshot contains hspec-2.11.10
     - hmatrix-backprop # tried hmatrix-backprop-0.1.3.0, but its *test-suite* requires the disabled package: microlens-platform
     - hourglass # tried hourglass-0.2.12, but its *test-suite* requires time < 1.10 and the snapshot contains time-1.12.2
-    - hsdev # tried hsdev-0.3.4.0, but its *test-suite* requires lens-aeson >=1.0 && < 1.2 and the snapshot contains lens-aeson-1.2.3
     - hspec-expectations-pretty-diff # tried hspec-expectations-pretty-diff-0.7.2.6, but its *test-suite* requires aeson < 2 and the snapshot contains aeson-2.2.3.0
     - http-conduit # tried http-conduit-2.3.9.1, but its *test-suite* requires warp >=3.0.0.2 && < 3.4 and the snapshot contains warp-3.4.7
     - http-media # tried http-media-0.8.1.1, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
@@ -9066,7 +8512,6 @@ skipped-tests:
     - loc # tried loc-0.2.0.0, but its *test-suite* requires hspec-hedgehog ^>=0.0.1 and the snapshot contains hspec-hedgehog-0.3.0.0
     - loopbreaker # tried loopbreaker-0.1.1.1, but its *test-suite* requires inspection-testing >=0.4.2.1 && < 0.5 and the snapshot contains inspection-testing-0.5.0.3
     - lrucaching # tried lrucaching-0.3.4, but its *test-suite* requires QuickCheck >=2.8 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
-    - lxd-client # tried lxd-client-0.1.0.6, but its *test-suite* requires turtle >=1.3.6 && < 1.6 and the snapshot contains turtle-1.6.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires Glob >=0.7 && < 0.9 and the snapshot contains Glob-0.10.2
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires QuickCheck >=2.9.2 && < 2.11 and the snapshot contains QuickCheck-2.15.0.1
     - makefile # tried makefile-1.1.0.0, but its *test-suite* requires base >=4.9.1.0 && < 4.10 and the snapshot contains base-4.20.0.0
@@ -9130,9 +8575,6 @@ skipped-tests:
     - quadratic-irrational # tried quadratic-irrational-0.1.1, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11
     - queue-sheet # tried queue-sheet-0.7.0.2, but its *test-suite* requires tasty >=1.0 && < 1.5 and the snapshot contains tasty-1.5.2
     - queues # tried queues-1.0.0, but its *test-suite* requires hedgehog ^>=1.4 and the snapshot contains hedgehog-1.5
-    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires hspec >=2.4.1 && < 2.6 and the snapshot contains hspec-2.11.10
-    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires servant-server >=0.9.1.1 && < 0.15 and the snapshot contains servant-server-0.20.2
-    - rakuten # tried rakuten-0.1.1.5, but its *test-suite* requires warp >=3.2.11 && < 3.3 and the snapshot contains warp-3.4.7
     - rank2classes # tried rank2classes-1.5.3.1, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - records-sop # tried records-sop-0.1.1.1, but its *test-suite* requires hspec >=2.2 && < 2.11 and the snapshot contains hspec-2.11.10
     - registry # tried registry-0.6.1.0, but its *test-suite* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -9155,18 +8597,12 @@ skipped-tests:
     - servant-auth-client # tried servant-auth-client-0.4.2.0, but its *test-suite* requires the disabled package: servant-auth-server
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.20 and the snapshot contains servant-server-0.20.2
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires warp >=3.0.13.1 && < 3.4 and the snapshot contains warp-3.4.7
-    - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec >=2.7.1 && < 2.9 and the snapshot contains hspec-2.11.10
-    - servant-docs-simple # tried servant-docs-simple-0.4.0.0, but its *test-suite* requires hspec-core >=2.7.1 && < 2.9 and the snapshot contains hspec-core-2.11.10
     - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
-    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires aeson >=1.0 && < 1.5 and the snapshot contains aeson-2.2.3.0
-    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires hspec >=2.4.1 && < 2.8 and the snapshot contains hspec-2.11.10
-    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *test-suite* requires http-api-data >=0.3.7 && < 0.4.2 and the snapshot contains http-api-data-0.6.1
     - servant-multipart # tried servant-multipart-0.12.1, but its *test-suite* requires the disabled package: tasty-wai
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.10
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.5
     - siggy-chardust # tried siggy-chardust-1.0.0, but its *test-suite* requires the disabled package: hlint
     - simple-affine-space # tried simple-affine-space-0.2.1, but its *test-suite* requires the disabled package: hlint
-    - simple-log # tried simple-log-0.9.12, but its *test-suite* requires hspec >=2.3 && < 2.8 and the snapshot contains hspec-2.11.10
     - slack-web # tried slack-web-1.6.1.0, but its *test-suite* requires hspec-discover >=2.6.0 && < 2.11 and the snapshot contains hspec-discover-2.11.10
     - sparse-tensor # tried sparse-tensor-0.2.1.5, but its *test-suite* requires QuickCheck >=2.8.2 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - sparse-tensor # tried sparse-tensor-0.2.1.5, but its *test-suite* requires tasty >=0.11 && < 1.5 and the snapshot contains tasty-1.5.2
@@ -9357,7 +8793,6 @@ expected-test-failures:
     - grisette # 0.8.0.0 spec failed
     - hastache
     - hedn
-    - idris # https://github.com/fpco/stackage/issues/1382
     - ihaskell # https://github.com/gibiansky/IHaskell/issues/551
     - kdt # 0.2.6 https://github.com/giogadi/kdt/issues/7
     - lapack
@@ -9431,11 +8866,9 @@ expected-test-failures:
     - http-directory # httpbin issues, https://github.com/juhp/http-directory/issues/1
     - http2 # executable not found https://github.com/kazu-yamamoto/http2/issues/22
     - influxdb
-    - json-autotype # Requires filesystem access
     - jvm
     - katip-elasticsearch # elasticsearch
     - log # ElasticSearch
-    - lxd-client # Needs LXD, not available on debian
     - lz4 # executable not found https://github.com/commercialhaskell/stackage/issues/6226
     - lsp-test # example: lsp-demo-reactor-server: createProcess: posix_spawnp: does not exist (No such file or directory)
     - mangopay # https://github.com/prowdsponsor/mangopay/issues/30
@@ -9474,7 +8907,6 @@ expected-test-failures:
     - req-conduit # Access to httpbin.org is unreliable (at the moment 504 Gateway Time-out).
     - rest-rewrite # posix_spawnp
     - rethinkdb
-    - riak # needs riak server on localhost:8098
     - sdl2 # "Failed to connect to the Mir Server"
     - sendgrid-v3 # Requires sendgrid API key in env #5951/closed
     - serialport # "The tests need two serial ports as command line arguments" https://github.com/jputcu/serialport/issues/30
@@ -9518,7 +8950,6 @@ expected-test-failures:
     - gitlab-haskell # https://github.com/commercialhaskell/stackage/issues/6088
     - hspec-junit-formatter # https://github.com/freckle/hspec-junit-formatter/issues/14
     - persistent # https://github.com/commercialhaskell/stackage/issues/6037
-    - reanimate-svg # https://github.com/commercialhaskell/stackage/issues/5688
     - rzk
     - sequence-formats # https://github.com/commercialhaskell/stackage/issues/7501
 
@@ -9616,10 +9047,6 @@ expected-test-failures:
     - yggdrasil-schema # https://github.com/commercialhaskell/stackage/issues/7518
     - genvalidity-network-uri # URI <<loop>>
     - haskoin-node # "reads arbitrary addresses" failed
-
-    # Assertion failures due to module name ambiguity.
-    # These _should_ be fixed by using the `hide` section of this file
-    - reanimate # https://github.com/commercialhaskell/stackage/issues/5626
 
     # Recursive deps https://github.com/fpco/stackage/issues/1818
     - options
@@ -9786,9 +9213,6 @@ skipped-benchmarks:
     # Misc dependency issues
     - heftia-effects # requires https://github.com/hasura/eff (?) -- not on hackage
 
-    # Timeouts
-    - gogol-youtube
-
     # Very resource intensive
     - OpenGLRaw
     - pandoc
@@ -9891,7 +9315,6 @@ skipped-benchmarks:
     - row-types # tried row-types-1.0.1.2, but its *benchmarks* requires the disabled package: gauge
     - say # tried say-0.1.0.1, but its *benchmarks* requires the disabled package: gauge
     - serialise # tried serialise-0.2.6.1, but its *benchmarks* requires the disabled package: store
-    - servant-kotlin # tried servant-kotlin-0.1.1.9, but its *benchmarks* requires shelly >=1.6.8 && < 1.10 and the snapshot contains shelly-1.12.1
     - squeal-postgresql # tried squeal-postgresql-0.9.1.3, but its *benchmarks* requires the disabled package: gauge
     - streaming-commons # tried streaming-commons-0.2.2.6, but its *benchmarks* requires the disabled package: gauge
     - streamly-bytestring # tried streamly-bytestring-0.2.2, but its *benchmarks* requires the disabled package: gauge
@@ -10123,8 +9546,5 @@ no-revisions:
 non-parallel-builds:
 - amazonka-ec2 # Around 6 GB memory consumption - so do not build in parallel to optimize overall performance. For more details see: https://gitlab.haskell.org/ghc/ghc/-/issues/19203, https://github.com/brendanhay/amazonka/issues/549 and related issues.
 - pandoc
-- gogol-dfareporting
-- gogol-compute
-- idris
 - massiv-persist
 - massiv-serialise

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1742,7 +1742,6 @@ packages:
         - servant-docs
         - servant-foreign
         - servant-http-streams
-        - servant-js
         - servant-lucid
         - servant-machines
         - servant-multipart
@@ -8597,7 +8596,6 @@ skipped-tests:
     - servant-auth-client # tried servant-auth-client-0.4.2.0, but its *test-suite* requires the disabled package: servant-auth-server
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires servant-server >=0.4.4.5 && < 0.20 and the snapshot contains servant-server-0.20.2
     - servant-cassava # tried servant-cassava-0.10.2, but its *test-suite* requires warp >=3.0.13.1 && < 3.4 and the snapshot contains warp-3.4.7
-    - servant-js # tried servant-js-0.9.4.2, but its *test-suite* requires the disabled package: language-ecmascript
     - servant-multipart # tried servant-multipart-0.12.1, but its *test-suite* requires the disabled package: tasty-wai
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires hspec >=2.4.4 && < 2.5 and the snapshot contains hspec-2.11.10
     - sessiontypes-distributed # tried sessiontypes-distributed-0.1.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.5

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -210,9 +210,6 @@ packages:
     "Jakob Schöttl <jakob.schoettl@intensovet.de> @schoettl":
         - bank-holiday-germany
 
-    "Mauricio Fierro <mauriciofierrom@gmail.com> @mauriciofierrom":
-        - dialogflow-fulfillment
-
     "Mihai Giurgeanu <mihai.giurgeanu@gmail.com> @mihaigiurgeanu":
         - sqlcli
         - sqlcli-odbc
@@ -4972,7 +4969,6 @@ packages:
         - LetsBeRational
 
     "Edward Yang <qwbarch@gmail.com> @qwbarch":
-        - captcha-core
         - data-default-extra
         - data-default-instances-base
         - data-default-instances-bytestring
@@ -8248,8 +8244,6 @@ skipped-tests:
     - sydtest-webdriver-screenshot # runs chromium
     - sydtest-webdriver-yesod # runs chromium
 
-    - captcha-core
-
     # @thielema
     - glpk-headers
     - utility-ht
@@ -8383,8 +8377,6 @@ skipped-tests:
     - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires hspec >=2.7 && < 2.11 and the snapshot contains hspec-2.11.10
     - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires lsp-test >=0.13.0.0 && < 0.15 and the snapshot contains lsp-test-0.17.1.0
     - dhall-lsp-server # tried dhall-lsp-server-1.1.3, but its *test-suite* requires lsp-types >=1.2.0.0 && < 1.5 and the snapshot contains lsp-types-2.3.0.0
-    - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec >=2.7.1 && < 2.9.0 and the snapshot contains hspec-2.11.10
-    - dialogflow-fulfillment # tried dialogflow-fulfillment-0.1.1.4, but its *test-suite* requires hspec-discover >=2.7.1 && < 2.9.0 and the snapshot contains hspec-discover-2.11.10
     - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires network-transport-tcp >=0.6 && < 0.7 and the snapshot contains network-transport-tcp-0.8.5
     - distributed-process-lifted # tried distributed-process-lifted-0.3.0.1, but its *test-suite* requires the disabled package: rematch
     - dlist-nonempty # tried dlist-nonempty-0.1.3, but its *test-suite* requires QuickCheck >=2.9 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1


### PR DESCRIPTION
aeson-2.0.0.0 was uploaded to Hackage on 2021-12-11, which is more than three years ago.
transformers-0.6.0.2 was uploaded to Hackage on 2021-07-09, which is also more than three years ago.

Let's remove the packages that haven't bothered to update, since they are cluttering the package list.

If they get updated again some time, we can add them back.
