### PR TITLE
Add back lz4-frame-conduit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2761,6 +2761,7 @@ packages:
         - hidapi
         - iso8601-time
         - loop
+        - lz4-frame-conduit
         - netpbm
         - network-house < 0 # 0.1.0.2 compile failure MonadFail
         - reinterpret-cast


### PR DESCRIPTION
Fixes #7241.

https://hackage.haskell.org/package/lz4-frame-conduit-0.1.0.2/changelog

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
  - need to submit PR now so I don't forget, but `verify-package` below works so hopefully it's OK
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
  - Hopefully nothing has to be done here: https://github.com/commercialhaskell/stackage/pull/5636
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
