### PR TITLE
Reinstate directory-ospath-streaming

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6589,7 +6589,6 @@ packages:
         - diagrams-html5 < 0 # tried diagrams-html5-1.4.2, but its *library* requires text >=1.0 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.1
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires Cabal >=2.0 && < 2.2 and the snapshot contains Cabal-3.12.0.0
         - direct-rocksdb < 0 # tried direct-rocksdb-0.0.3, but its *library* requires the disabled package: cabal-toolkit
-        - directory-ospath-streaming < 0 # tried directory-ospath-streaming-0.2.1, but its *library* requires filepath >=1.4.100 && < 1.5 and the snapshot contains filepath-1.5.2.0
         - discrimination < 0 # tried discrimination-0.5, but its *library* requires hashable >=1.2.7.0 && < 1.5 and the snapshot contains hashable-1.5.0.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires deepseq >=1.2 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - distributed-process-lifted < 0 # tried distributed-process-lifted-0.3.0.1, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -8066,9 +8065,6 @@ package-flags:
       optparse-applicative_ge_0_18: true
     redact:
       optparse-applicative_ge_0_18: true
-
-    directory-ospath-streaming:
-      os-string: false
 
     # based on https://github.com/commercialhaskell/stackage/issues/7361
     xxhash-ffi:


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
