### PR TITLE
PyF: add it back on nightly

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8698,7 +8698,6 @@ expected-test-failures:
 
     # Consistent test failures
     - Allure # 0.11.0.0
-    - PyF # 0.11.3.0 https://github.com/guibou/PyF/issues/142
     - SpatialMath # 0.2.7.1 https://github.com/ghorn/spatial-math/issues/10
     - ap-normalize # 0.1.0.1 ghc-9.6
     - astro # 0.4.3.0 https://github.com/aligusnet/astro/issues/8


### PR DESCRIPTION
See for the bug report https://github.com/guibou/PyF/issues/142

This is fixed in https://hackage.haskell.org/package/PyF-0.11.4.0

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
