### PR TITLE
Re-enable language-bash

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1478,7 +1478,7 @@ packages:
         - aura
         - bounded-queue
         - kanji
-        - language-bash < 0 # 0.10.0 https://github.com/knrafto/language-bash/issues/43
+        - language-bash
         - microlens-aeson
         - pipes-random
         - servant-xml


### PR DESCRIPTION
knrafto/language-bash#43 fixed in 0.11.0

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
