### PR TITLE
Adjust flags to re-enable file-io

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6662,7 +6662,6 @@ packages:
         - fgl-arbitrary < 0 # tried fgl-arbitrary-0.2.0.6, but its *library* requires QuickCheck >=2.3 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
         - fields-and-cases < 0 # tried fields-and-cases-0.2.0.0, but its *library* requires base >=4.17.2.0 && < 4.20 and the snapshot contains base-4.20.0.0
-        - file-io < 0 # tried file-io-0.1.5, but its *library* requires filepath >=1.4.100.0 && < 1.5.0.0 and the snapshot contains filepath-1.5.2.0
         - filepath-bytestring < 0 # tried filepath-bytestring-1.5.2.0.0, but its *library* requires base >=4 && < 4.20 and the snapshot contains base-4.20.0.0
         - filtrable < 0 # tried filtrable-0.1.6.0, but its *library* requires containers >=0.5.11 && < 0.7 and the snapshot contains containers-0.7
         - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.1.1
@@ -8092,6 +8091,9 @@ package-flags:
     # https://github.com/commercialhaskell/stackage/issues/7461
     hashable:
       arch-native: false
+
+    file-io:
+      os-string: true
 # end of package-flags
 
 # Special configure options for individual packages


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
