### PR TITLE
Add mempack and impspec

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8489,7 +8489,6 @@ skipped-tests:
     - safe-coloured-text-layout-gen # tried safe-coloured-text-layout-gen-0.0.0.1, but its *test-suite* requires the disabled package: sydtest-discover
     - salak-toml # tried salak-toml-0.3.5.3, but its *test-suite* requires QuickCheck < 2.14 and the snapshot contains QuickCheck-2.15.0.1
     - scalendar # tried scalendar-1.2.0, but its *test-suite* requires the disabled package: SCalendar
-    - scheduler # tried scheduler-2.0.0.1, but its *test-suite* requires QuickCheck < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - selective # tried selective-0.7.0.1, but its *test-suite* requires QuickCheck >=2.8 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
     - serialise # tried serialise-0.2.6.1, but its *test-suite* requires base >=4.11 && < 4.20 and the snapshot contains base-4.20.0.0
     - serialise # tried serialise-0.2.6.1, but its *test-suite* requires tasty-quickcheck >=0.8 && < 0.11 and the snapshot contains tasty-quickcheck-0.11.1
@@ -8630,7 +8629,6 @@ expected-test-failures:
     - parameterized # 0.5.0.0 https://github.com/commercialhaskell/stackage/issues/5746
     - protobuf # 0.2.1.4
     - record-wrangler # 0.1.1.0
-    - scheduler # 2.0.0.1 https://github.com/lehins/scheduler/issues/11
     - secp256k1-haskell # #5948/closed
     - servant-static-th # 1.0.0.1 https://github.com/cdepillabout/servant-static-th/issues/21
     - snappy # Could not find module ‘Functions’

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8201,7 +8201,6 @@ skipped-tests:
     - nothunks
     - optparse-applicative # via QuickCheck
     - primitive
-    - random
     - scientific
     - split
     - splitmix

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3761,6 +3761,8 @@ packages:
         - conduit-aeson
         - vector-stream
         - FailT
+        - mempack
+        - ImpSpec
 
     "Hans-Peter Deifel <hpd@hpdeifel.de> @hpdeifel":
         - hledger-iadd


### PR DESCRIPTION
This PR adds two packages [`mempack`](https://hackage.haskell.org/package/mempack) and [`ImpSpec`](https://hackage.haskell.org/package/ImpSpec)

Also it re-enables the test suite for `scheduler`, since the issue has been fixed and the
newly released version of [`scheduler-2.0.1.0`](https://hackage.haskell.org/package/scheduler-2.0.1.0) is now compatible with `QuickCheck-2.15.x`

I am not sure what the reason why `random`'s test suite was disabled, but I am pretty sure it should be fine now.

CI failure seems totally unrelated to this PR

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
