### PR TITLE
Re-enable redis-glob and packages that depend on it

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6974,10 +6974,6 @@ packages:
         - jvm-batching < 0 # tried jvm-batching-0.2.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
         - kanji < 0 # tried kanji-3.5.0, but its *library* requires aeson ^>=2.0 and the snapshot contains aeson-2.2.3.0
-        - keyed-vals < 0 # tried keyed-vals-0.2.3.1, but its *library* requires the disabled package: redis-glob
-        - keyed-vals-hspec-tests < 0 # tried keyed-vals-hspec-tests-0.2.3.1, but its *library* requires the disabled package: keyed-vals
-        - keyed-vals-mem < 0 # tried keyed-vals-mem-0.2.3.1, but its *library* requires the disabled package: keyed-vals
-        - keyed-vals-redis < 0 # tried keyed-vals-redis-0.2.3.1, but its *library* requires the disabled package: keyed-vals
         - kind-generics-th < 0 # tried kind-generics-th-0.2.3.3, but its *library* requires template-haskell >=2.14 && < 2.21 and the snapshot contains template-haskell-2.22.0.0
         - kind-generics-th < 0 # tried kind-generics-th-0.2.3.3, but its *library* requires th-abstraction >=0.4 && < 0.7 and the snapshot contains th-abstraction-0.7.1.0
         - kleene < 0 # tried kleene-0.1, but its *library* requires bytestring >=0.10.4.0 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -7361,7 +7357,6 @@ packages:
         - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.17, but its *library* requires ghc >=8.6 && < 9.9 and the snapshot contains ghc-9.10.1
         - records-sop < 0 # tried records-sop-0.1.1.1, but its *library* requires deepseq >=1.3 && < 1.5 and the snapshot contains deepseq-1.5.0.0
         - records-sop < 0 # tried records-sop-0.1.1.1, but its *library* requires ghc-prim >=0.5 && < 0.11 and the snapshot contains ghc-prim-0.11.0
-        - redis-glob < 0 # tried redis-glob-0.1.0.9, but its *library* requires the disabled package: ascii-char
         - redis-io < 0 # tried redis-io-1.1.0, but its *library* requires the disabled package: tinylog
         - reform < 0 # tried reform-0.2.7.5, but its *library* requires containers >=0.4 && < 0.7 and the snapshot contains containers-0.7
         - reform < 0 # tried reform-0.2.7.5, but its *library* requires mtl >=2.0 && < 2.3 and the snapshot contains mtl-2.3.1
@@ -8477,7 +8472,6 @@ skipped-tests:
     - queues # tried queues-1.0.0, but its *test-suite* requires hedgehog ^>=1.4 and the snapshot contains hedgehog-1.5
     - rank2classes # tried rank2classes-1.5.4, but its *test-suite* requires markdown-unlit >=0.5 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - records-sop # tried records-sop-0.1.1.1, but its *test-suite* requires hspec >=2.2 && < 2.11 and the snapshot contains hspec-2.11.10
-    - redis-glob # tried redis-glob-0.1.0.9, but its *test-suite* requires the disabled package: ascii-superset
     - rel8 # tried rel8-1.6.0.0, but its *test-suite* requires the disabled package: tmp-postgres
     - relude # tried relude-1.2.2.0, but its *test-suite* requires hedgehog >=1.0 && < 1.5 and the snapshot contains hedgehog-1.5
     - rest-rewrite # tried rest-rewrite-0.4.4, but its *test-suite* requires QuickCheck >=2.14.2 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
