### PR TITLE
Re-enable tmp-proc-rabbitmq and testing for tmp-proc

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7686,7 +7686,6 @@ packages:
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires the disabled package: x509-validation
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.1.6
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires ansi-wl-pprint < 1 and the snapshot contains ansi-wl-pprint-1.0.2
-        - tmp-proc-rabbitmq < 0 # tried tmp-proc-rabbitmq-0.7.2.0, but its *library* requires amqp >=0.22.1 && < 0.24 and the snapshot contains amqp-0.24.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires Cabal < 3.12 and the snapshot contains Cabal-3.12.0.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.20.0.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.1.0
@@ -8635,7 +8634,6 @@ expected-test-failures:
     - servant-static-th # 1.0.0.1 https://github.com/cdepillabout/servant-static-th/issues/21
     - snappy # Could not find module ‘Functions’
     - thread-supervisor # 0.2.0.0
-    - tmp-proc # 0.7.1.0 https://github.com/adetokunbo/tmp-proc/issues/112
     - twitter-types # 0.11.0 compile fail against aeson 2
     - type-of-html-static # 0.1.0.2 https://github.com/commercialhaskell/stackage/issues/5728
     - tztime # 0.1.1.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
