### PR TITLE
Remove MissingH from expected-haddock-failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9039,8 +9039,6 @@ expected-haddock-failures:
     - doctest-parallel # https://github.com/commercialhaskell/stackage/issues/5014
     - tztime # https://github.com/commercialhaskell/stackage/issues/5014
 
-    # crashes with 9.4.3
-    - MissingH # https://github.com/haskell-hvr/missingh/issues/61
 # end of expected-haddock-failures
 
 # For packages with haddock issues


### PR DESCRIPTION
The upstream issue has been closed as no longer reproducible.
