### PR TITLE
add aftovolio and its dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5155,6 +5155,19 @@ packages:
         - yi-frontend-pango
         - yi-frontend-vty
 
+    "Oleksandr Zhabenko <oleksandr.zhabenko2@gmail.com> @Oleksandr-Zhabenko":
+        - aftovolio
+        - cli-arguments
+        - intermediate-structures
+        - lists-flines
+        - minmax
+        - mmsyn2-array
+        - monoid-insertleft
+        - quantizer
+        - rev-scientific
+        - rhythmic-sequences
+        - uniqueness-periods-vector-stats  
+
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean


### PR DESCRIPTION
Added Oleksandr-Zhabenko as a new Stackage package maintainer.

Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
