### PR TITLE
Upper bounds for tidal-link

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7813,6 +7813,7 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/7627
         - hosc < 0.21
+        - tidal-link < 1.1
 
         # https://github.com/commercialhaskell/stackage/issues/7635
         - singletons-base < 3.5


### PR DESCRIPTION
In anticipation of new release of tidal-link with breaking changes. Will remove upper bound once a compatible tidal-1.10 is released. 

Ref: https://github.com/commercialhaskell/stackage/issues/7627#issuecomment-2639204160