### PR TITLE
Update z3 for `grisette` test suite (lsrcz/grisette#287)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8579,7 +8579,6 @@ expected-test-failures:
     - foldl-statistics # https://github.com/data61/foldl-statistics/issues/2
     - friday # https://github.com/RaphaelJ/friday/issues/37
     - fsnotify # Often runs out of inotify handles
-    - grisette # 0.11.0.0 https://github.com/lsrcz/grisette/issues/287
     - hastache
     - hedn
     - ihaskell # https://github.com/gibiansky/IHaskell/issues/551

--- a/docker/03-custom-install.sh
+++ b/docker/03-custom-install.sh
@@ -76,7 +76,7 @@ add-apt-repository "deb https://packages.confluent.io/deb/5.2 stable main"
 apt-get update && apt install -y librdkafka-dev
 
 # Install z3, for grisette test suite
-Z3_VER=4.12.4
+Z3_VER=4.13.4
 (
   cd /usr/local \
     && wget https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VER}/z3-${Z3_VER}-x64-glibc-2.35.zip \


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

This pull request updates the z3 for `grisette` test suite.

The floating point operations in `grisette`'s test suite only work with the latest z3 thus causing test failure (lsrcz/grisette#287), updating z3 to 4.13.4 resolves this.

I built the docker image locally and tested the package with verify-package script, and there was no test failure. Thanks to @alaendle for reporting this.


