### PR TITLE
remove haskell-spacegoo

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1456,7 +1456,6 @@ packages:
         - rec-def
         - bytestring-progress # dependency of arbtt
         - circle-packing
-        - haskell-spacegoo
         - tasty-expected-failure
 
     "Aditya Bhargava <adit@adit.io> @egonSchiele":


### PR DESCRIPTION
removing old and irrelevant package

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
