### PR TITLE
Add regex-pcre2

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -180,6 +180,9 @@ packages:
         - system-fileio
         - system-filepath
 
+    "Pete Ryland <pdr@pdr.cx> @peteryland":
+        - regex-pcre2
+
     "Diogo Biazus <diogo@biazus.ca>":
         - hasql-notifications
 


### PR DESCRIPTION
New `Text.Regex`-compatible regex-pcre2 library which links against libpcre2 (already in `02-apt-get-install.sh`).

Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [X] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)