### PR TITLE
Add tidal-core to build-constraints.yaml

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3228,6 +3228,7 @@ packages:
 
     "Alex McLean <alex@slab.org> @yaxu":
         - tidal
+        - tidal-core
         - tidal-link
         - hosc
 


### PR DESCRIPTION
This will soon become a dependency of the next release of tidal, so just preparing the ground for that.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
