### PR TITLE
Add `monoidmap-aeson`.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3714,6 +3714,7 @@ packages:
         - bech32-th
         - cardano-coin-selection
         - monoidmap
+        - monoidmap-aeson
         - quickcheck-groups
         - quickcheck-monoid-subclasses
         - quickcheck-quid


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
