### PR TITLE
New maintainer for open-browser

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3123,8 +3123,7 @@ packages:
         - giphy-api
         - optparse-text
 
-    "rightfold <rightfold@gmail.com> @rightfold":
-        - open-browser
+    "rightfold <rightfold@gmail.com> @rightfold": []
 
     "Denis Redozubov <denis.redozubov@gmail.com> @dredozubov":
         - hreader-lens
@@ -5091,9 +5090,10 @@ packages:
         - ansi-terminal
         - ansi-terminal-types
         - companion
+        - open-browser
+        - pantry
         - stack < 9
         - static-bytes
-        - pantry
 
     "Torsten Schmits <stackage@schmits.me> @tek":
         - exon


### PR DESCRIPTION
See https://hackage.haskell.org/package/open-browser-0.2.1.1

Also re-orders other Mike Pilgrem packages alphabetically.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
      No change to package.
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
      Not applicable.
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
      No change to package.
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
      No change to package