### PR TITLE
Reenable testsuite of test-framework (dropped libxml dependency)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8428,7 +8428,6 @@ skipped-tests:
     - tasty-sugar # tried tasty-sugar-2.2.2.0, but its *test-suite* requires hedgehog >=1.1 && < 1.5 and the snapshot contains hedgehog-1.5
     - temporary-resourcet # tried temporary-resourcet-0.1.0.1, but its *test-suite* requires tasty >=1.0 && < 1.2 and the snapshot contains tasty-1.5.3
     - tensors # tried tensors-0.1.5, but its *test-suite* requires QuickCheck >=2.11.1 && < 2.15 and the snapshot contains QuickCheck-2.15.0.1
-    - test-framework # tried test-framework-0.8.2.1, but its *test-suite* requires the disabled package: libxml
     - true-name # tried true-name-0.2.0.0, but its *test-suite* requires containers ^>=0.5.6 || ^>=0.6.0 and the snapshot contains containers-0.7
     - type-errors # tried type-errors-0.2.0.2, but its *test-suite* requires doctest >=0.16.0.1 && < 0.22 and the snapshot contains doctest-0.24.0
     - tztime # tried tztime-0.1.1.0, but its *test-suite* requires the disabled package: tasty-hunit-compat


### PR DESCRIPTION
Closes #7697
