### PR TITLE
Re-enable `heftia` and its dependencies

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6626,9 +6626,6 @@ packages:
         - data-default-instances-text < 0 # tried data-default-instances-text-0.0.1, but its *library* requires text >=0.2 && < 2 and the snapshot contains text-2.1.1
         - data-default-instances-unordered-containers < 0 # tried data-default-instances-unordered-containers-0.0.1, but its *library* requires data-default-class >=0.0 && < 0.1 || >=0.1 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
         - data-default-instances-vector < 0 # tried data-default-instances-vector-0.0.1, but its *library* requires data-default-class >=0.0 && < 0.1 || >=0.1 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
-        - data-effects < 0 # tried data-effects-0.3.0.1, but its *library* requires the disabled package: data-effects-th
-        - data-effects-core < 0 # tried data-effects-core-0.2.0.0, but its *library* requires the disabled package: compdata
-        - data-effects-th < 0 # tried data-effects-th-0.2.0.0, but its *library* requires extra ^>=1.7.14 and the snapshot contains extra-1.8
         - data-forest < 0 # tried data-forest-0.1.0.13, but its *library* requires base ^>=4.18 || ^>=4.19 and the snapshot contains base-4.20.0.0
         - data-functor-logistic < 0 # tried data-functor-logistic-0.0, but its *library* requires base >=4.9 && < 4.20 and the snapshot contains base-4.20.0.0
         - data-tree-print < 0 # tried data-tree-print-0.1.0.2, but its *library* requires base >=4.8 && < 4.17 and the snapshot contains base-4.20.0.0
@@ -6855,8 +6852,6 @@ packages:
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: amazonka
         - haxl-amazonka < 0 # tried haxl-amazonka-0.1.1, but its *library* requires the disabled package: amazonka-core
         - hedgehog-optics < 0 # tried hedgehog-optics-1.0.0.4, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 || ^>=4.19 and the snapshot contains base-4.20.0.0
-        - heftia < 0 # tried heftia-0.5.0.0, but its *library* requires the disabled package: data-effects
-        - heftia-effects < 0 # tried heftia-effects-0.5.0.0, but its *library* requires the disabled package: data-effects
         - hegg < 0 # tried hegg-0.5.0.0, but its *library* requires containers >=0.4 && < 0.7 and the snapshot contains containers-0.7
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires ansi-terminal >=0.7.0 && < =0.8.1 and the snapshot contains ansi-terminal-1.1.2
         - herms < 0 # tried herms-1.9.0.4, but its *executable* requires brick >=0.19 && < =0.39 and the snapshot contains brick-2.8.3


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

In the latest release, I’ve removed the `compdata` dependency, so these should now be compatible.