### PR TITLE
Add reflex FRP packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5192,14 +5192,12 @@ packages:
         - manifolds-core
         - nerd-font-icons
         - nix-narinfo
-        - patch
         - pinecone
         - probability-polynomial
         - pseudo-boolean
         - refined-containers
         - smith
         - streaming-binary
-        - which
 
     "Alexander Esgen <amesgen@amesgen.de> @amesgen":
         - ghc-hs-meta
@@ -5278,6 +5276,24 @@ packages:
         - rev-scientific
         - rhythmic-sequences
         - uniqueness-periods-vector-stats
+
+    "Alexandre Esteves <alexfmpe@proton.me> @alexfmpe":
+        - aeson-gadt-th
+        - bytestring-aeson-orphans
+        - commutative-semigroups
+        - constraints-extras
+        - dependent-monoidal-map
+        - dependent-sum-aeson-orphans
+        - haveibeenpwned
+        - monad-logger-extras
+        - monoid-map
+        - patch
+        - reflex-dom-core
+        - reflex-fsnotify
+        - reflex-gadt-api
+        - reflex
+        - vessel
+        - which
 
     "Grandfathered dependencies":
         - BiobaseNewick
@@ -5370,12 +5386,10 @@ packages:
         - cmark-gfm
         - colour
         - colourista
-        - commutative-semigroups
         - concurrent-extra
         - conduit
         - config-ini
         - configurator
-        - constraints-extras
         - contravariant-extras
         - control-monad-free
         - control-monad-omega
@@ -8100,6 +8114,10 @@ skipped-tests:
 
     # @andreasabel
     - system-fileio # tests malfunction
+
+    # @alexfmpe
+    - reflex # hlint test suite needs fixes
+    - reflex-dom-core # https://github.com/reflex-frp/reflex-dom/issues/392
 
     # Uses Cabal's "library internal" stanza feature
     - s3-signer


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
