### PR TITLE
Re-enable `queue-sheet`

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7403,7 +7403,6 @@ packages:
         - quaalude < 0 # tried quaalude-0.0.0.1, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 || ^>=4.19 and the snapshot contains base-4.20.1.0
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires ansi-terminal >=0.6 && < 0.7 and the snapshot contains ansi-terminal-1.1.2
         - questioner < 0 # tried questioner-0.1.1.0, but its *library* requires the disabled package: readline
-        - queue-sheet < 0 # tried queue-sheet-0.8.0.1, but its *library* requires the disabled package: ginger
         - quickcheck-arbitrary-template < 0 # tried quickcheck-arbitrary-template-0.2.1.1, but its *library* requires template-haskell >=2.11 && < 2.17 and the snapshot contains template-haskell-2.22.0.0
         - quickcheck-combinators < 0 # tried quickcheck-combinators-0.0.6, but its *library* requires the disabled package: unfoldable-restricted
         - rank2classes < 0 # tried rank2classes-1.5.4, but its *library* requires the disabled package: data-functor-logistic


### PR DESCRIPTION
Dependency `ginger` is re-enabled from `nightly-2025-05-07` (`ghc-9.10.2`).

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
