### PR TITLE
Re-enable mustache, on the release of mustache-2.4.3.1

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3220,7 +3220,7 @@ packages:
         - extensible-effects < 0 # 5.0.0.1 https://github.com/suhailshergill/extensible-effects/issues/135
 
     "Justus Adam <dev@justus.science> @JustusAdam":
-        - mustache < 0 # https://github.com/commercialhaskell/stackage/issues/7747
+        - mustache
         - exit-codes
 
     "Jean-Philippe Bernardy <jean-philippe.bernardy@tweag.io> @jyp":


### PR DESCRIPTION
The new Hackage release should address the problem with the `test-suite unit-tests` stanza of `mustache-2.4.3` on Hackage.

- [x] (recommended) Package has been verified to work with the latest nightly snapshot:

      stack unpack mustache # No stack.yaml included with package
      cd mustache-2.4.3.1
      stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks