### PR TITLE
re-enable tests of leancheck-instances

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8541,7 +8541,6 @@ expected-test-failures:
     - heist # GHC 9.8.1
     - hweblib # 0.6.3 https://github.com/aycanirican/hweblib/issues/3
     - inline-r # 1.0.1 https://github.com/tweag/HaskellR/issues/371
-    - leancheck-instances # 0.0.5 https://github.com/rudymatela/leancheck-instances/issues/3
     - leveldb-haskell
     - lifted-base # 0.2.3.12 compile fail
     - mfsolve # https://github.com/commercialhaskell/stackage/issues/6379


### PR DESCRIPTION
... as the build has been fixed in version 0.0.8

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
