### PR TITLE
Remove constraint for hosc and tidal-link

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7845,11 +7845,7 @@ packages:
 
         # https://github.com/commercialhaskell/stackage/issues/7611
         - th-desugar < 1.18
-
-        # https://github.com/commercialhaskell/stackage/issues/7627
-        - hosc < 0.21
-        - tidal-link < 1.1
-
+        
         # https://github.com/commercialhaskell/stackage/issues/7635
         - singletons-base < 3.5
         - eliminators < 0.9.6


### PR DESCRIPTION
The new 1.10.0 release of tidal and tidal-core means we can finally remove these constraints. Fixes #7627

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
