### PR TITLE
Fixes for tonyday567 packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3813,7 +3813,6 @@ packages:
     "Tony Day <tonyday567@gmail.com> @tonyday567":
         - box
         - box-socket
-        - cabal-fix
         - chart-svg
         - dotparse
         - formatn
@@ -3822,7 +3821,6 @@ packages:
         - markup-parse
         - mealy
         - numhask
-        - numhask-array
         - numhask-space
         - perf
         - prettychart
@@ -5980,6 +5978,7 @@ packages:
         - 2captcha < 0 # 0.1.0.0 deprecated
         - Unique < 0 # 0.4.7.9 removed
         - box-csv < 0 # 0.2.0 deprecated
+        - cabal-fix < 0 # 0.1.0.0 deprecated
         - cli < 0 # 0.2.0 removed
         - fingertree-psqueue < 0 # 0.3 compile fail
         - hastache < 0 # 0.6.1 bounds
@@ -5988,6 +5987,7 @@ packages:
         - json-builder < 0 # 0.3 bounds
         - lens-labels < 0 # 0.3.0.1 bounds, deprecated #4358/closed
         - membrain < 0 # 0.0.0.2 bounds #5965/closed
+        - numhask-array <0 # 0.11.1.0 deprecated in favour of harpie
         - numhask-prelude < 0 # 0.5.0 deprecated
         - preprocessor-tools < 0 # 2.0.2
         - present < 0 # 4.1.0 compile fail #6271


### PR DESCRIPTION
Fixes for:

- box, box-socket (affected by #7743) 
- numhask-0.13 oob #7790
- moved numhask-prelude to deprecation section
- removed #7772 constraints (doctest-parallel oob for most of my packages)
- removed #7785 constraints (markup-parse)
- harpie test failure fixed in harpie-0.1.3

Apologies for doing this in one blob, and happy to unpick if that helps with the processing.
