### PR TITLE
Update maintainer for crdt-event-fold.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4617,6 +4617,7 @@ packages:
         - json-spec-openapi
         - json-spec-elm-servant
         - generic-enumeration
+        - crdt-event-fold
 
     "ALeX Kazik <alex@kazik.de> @alexkazik":
         - exomizer
@@ -5272,7 +5273,6 @@ packages:
         - clash-shake
         - constrained-categories
         - consumers
-        - crdt-event-fold
         - data-prometheus
         - dataframe
         - delta-types


### PR DESCRIPTION
I am the maintainer of crdt-event-fold. I am happy to maintain it as part of stackage.

I didn't run this checklist, but it seems pretty safe to simply move an existing package from one maintainer to another.
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [ ] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
