### PR TITLE
add coerce-with-substitution

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4066,6 +4066,9 @@ packages:
         - tasty-lua
         - gridtables
 
+    "Ryan Hendrickson @rhendric":
+        - coerce-with-substitution
+
     "Judah Jacobson <judah.jacobson@gmail.com> @judah":
         - proto-lens-protobuf-types
         - proto-lens-protoc
@@ -9264,6 +9267,10 @@ expected-haddock-failures:
     - hw-rankselect
     - doctest-parallel # https://github.com/commercialhaskell/stackage/issues/5014
     - tztime # https://github.com/commercialhaskell/stackage/issues/5014
+
+    # Triggers https://gitlab.haskell.org/ghc/ghc/-/issues/25739
+    # GHC has fixed this for 9.14, not yet backported to earlier versions.
+    - coerce-with-substitution
 
 # end of expected-haddock-failures
 


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

---

`verify-package` fails during Haddock generation due to https://gitlab.haskell.org/ghc/ghc/-/issues/25739. This is a tool issue, not something I want to work around in the package, so I added the package to `expected-haddock-failures` (can be removed when the snapshot adopts GHC 9.14 or if the fix in GHC is backported). That's the best I can do, right?