### PR TITLE
reenable typecheck-plugin-nat-simple and ranged-list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3411,7 +3411,7 @@ packages:
         - simplest-sqlite
         - warp-tls-uid < 0 # 0.2.0.6 https://github.com/YoshikuniJujo/warp-tls-uid/issues/1
         - nowdoc
-        - typecheck-plugin-nat-simple < 0 # https://github.com/YoshikuniJujo/typecheck-plugin-nat-simple/issues/3
+        - typecheck-plugin-nat-simple
         - ranged-list
         - c-enum
         - c-struct
@@ -7623,7 +7623,6 @@ packages:
         - random-fu < 0 # tried random-fu-0.3.0.1, but its *library* requires random >=1.2 && < 1.3 and the snapshot contains random-1.3.1
         - random-fu < 0 # tried random-fu-0.3.0.1, but its *library* requires the disabled package: rvar
         - range-set-list < 0 # tried range-set-list-0.1.4, but its *library* requires base >=4.12.0.0 && < 4.21 and the snapshot contains base-4.21.0.0
-        - ranged-list < 0 # tried ranged-list-0.1.2.3, but its *library* requires the disabled package: typecheck-plugin-nat-simple
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires base >=4.12 && < =4.17 and the snapshot contains base-4.21.0.0
         - rec-smallarray < 0 # tried rec-smallarray-0.1.0.0, but its *library* requires primitive >=0.6.4 && < 0.8 and the snapshot contains primitive-0.9.1.0
         - record-dot-preprocessor < 0 # tried record-dot-preprocessor-0.2.17, but its *library* requires ghc >=8.6 && < 9.9 and the snapshot contains ghc-9.12.2


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
