### PR TITLE
Reenable filepath-bytestring

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6483,7 +6483,7 @@ packages:
         - amazonka-workspaces < 0 # tried amazonka-workspaces-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.21.0.0
         - amazonka-workspaces-web < 0 # tried amazonka-workspaces-web-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.21.0.0
         - amazonka-xray < 0 # tried amazonka-xray-2.0, but its *library* requires base >=4.12 && < 4.19 and the snapshot contains base-4.21.0.0
-        - amqp-utils < 0 # tried amqp-utils-0.6.6.0, but its *executable* requires the disabled package: filepath-bytestring
+        - amqp-utils < 0 # tried amqp-utils-0.6.7.2, but its *executable* requires time >= 1.12 && < 1.13 and the snapshot contains time-1.14
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.2.0
         - animalcase < 0 # tried animalcase-0.1.0.2, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.2
         - ansigraph < 0 # tried ansigraph-0.3.0.5, but its *library* requires base >=4.6 && < 4.21 and the snapshot contains base-4.21.0.0
@@ -6893,7 +6893,6 @@ packages:
         - fgl-arbitrary < 0 # tried fgl-arbitrary-0.2.0.6, but its *library* requires QuickCheck >=2.3 && < 2.15 and the snapshot contains QuickCheck-2.16.0.0
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
         - fields-and-cases < 0 # tried fields-and-cases-0.2.0.0, but its *library* requires base >=4.17.2.0 && < 4.20 and the snapshot contains base-4.21.0.0
-        - filepath-bytestring < 0 # tried filepath-bytestring-1.5.2.0.2, but its *library* requires base >=4 && < 4.21 and the snapshot contains base-4.21.0.0
         - fin < 0 # tried fin-0.3.2, but its *library* requires QuickCheck ^>=2.14.2 || ^>=2.15 and the snapshot contains QuickCheck-2.16.0.0
         - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.1.2
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.2
@@ -6942,7 +6941,6 @@ packages:
         - git < 0 # tried git-0.3.0, but its *library* requires bytestring >=0.9 && < 0.11 and the snapshot contains bytestring-0.12.2.0
         - git < 0 # tried git-0.3.0, but its *library* requires the disabled package: cryptonite
         - git-annex < 0 # tried git-annex-10.20250630, but its *executable* requires the disabled package: aws
-        - git-annex < 0 # tried git-annex-10.20250630, but its *executable* requires the disabled package: filepath-bytestring
         - git-annex < 0 # tried git-annex-10.20250630, but its *executable* requires the disabled package: yesod-static
         - github-release < 0 # tried github-release-2.0.0.14, but its *library* requires the disabled package: optparse-generic
         - github-webhooks < 0 # tried github-webhooks-0.18.0, but its *library* requires the disabled package: cryptonite
@@ -7792,7 +7790,6 @@ packages:
         - soap-tls < 0 # tried soap-tls-0.1.1.4, but its *library* requires tls >=1.3.8 && < 2.0 and the snapshot contains tls-2.1.10
         - socket-activation < 0 # tried socket-activation-0.1.0.2, but its *library* requires network >=2.3 && < 2.9 and the snapshot contains network-3.2.7.0
         - sound-collage < 0 # tried sound-collage-0.2.1, but its *executable* requires optparse-applicative >=0.11 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
-        - spacecookie < 0 # tried spacecookie-1.0.0.3, but its *library* requires the disabled package: filepath-bytestring
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires inline-java >=0.7.0 && < 0.9 and the snapshot contains inline-java-0.10.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires jvm >=0.4.0.1 && < 0.5 and the snapshot contains jvm-0.6.0
         - sparkle < 0 # tried sparkle-0.7.4, but its *library* requires the disabled package: jni
@@ -8503,7 +8500,7 @@ skipped-tests:
     - fclabels # tried fclabels-2.0.5.1, but its *test-suite* requires transformers < 0.6 and the snapshot contains transformers-0.6.1.2
     - feed # tried feed-1.3.2.1, but its *test-suite* requires markdown-unlit >=0.4 && < 0.6 and the snapshot contains markdown-unlit-0.6.0
     - feed # tried feed-1.3.2.1, but its *test-suite* requires xml-conduit < 1.10 and the snapshot contains xml-conduit-1.10.0.1
-    - filepath-bytestring # tried filepath-bytestring-1.5.2.0.2, but its *test-suite* requires QuickCheck >=2.7 && < 2.15 and the snapshot contains QuickCheck-2.16.0.0
+    - filepath-bytestring # tried filepath-bytestring-1.5.2.0.2, but its *test-suite* requires QuickCheck >=2.7 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
     - finite-typelits # tried finite-typelits-0.2.1.0, but its *test-suite* requires QuickCheck >=2.12 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
     - fixed-vector-hetero # tried fixed-vector-hetero-0.7.0.0, but its *test-suite* requires doctest >=0.15 && < 0.24 and the snapshot contains doctest-0.24.2
     - focuslist # tried focuslist-0.1.1.0, but its *test-suite* requires genvalidity < 1.0.0.0 and the snapshot contains genvalidity-1.1.1.0
@@ -9391,7 +9388,7 @@ skipped-benchmarks:
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires criterion < 1.6 and the snapshot contains criterion-1.6.4.0
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.2.0
     - fakedata # tried fakedata-1.0.5, but its *benchmarks* requires the disabled package: gauge
-    - filepath-bytestring # tried filepath-bytestring-1.5.2.0.2, but its *benchmarks* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.5.4.0
+    - filepath-bytestring # tried filepath-bytestring-1.5.2.0.3, but its *benchmarks* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.5.4.0
     - flatparse # tried flatparse-0.5.2.1, but its *benchmarks* requires the disabled package: gauge
     - freer-simple # tried freer-simple-1.2.1.2, but its *benchmarks* requires the disabled package: extensible-effects
     - fused-effects # tried fused-effects-1.1.2.5, but its *benchmarks* requires tasty-bench >=0.3 && < 0.4 and the snapshot contains tasty-bench-0.4.1


### PR DESCRIPTION
filepath 1.5.2.0.3 adds support for base and filepath of GHC 9.12. Unfortunately I've missed that QuickCheck 2.16 has been released, so I didn't submit a constraint relaxing patch for that, but I'll do that soon.

I haven't been able to use verify-package with these changes, but ./check agrees that the bounds are okay.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
