### PR TITLE
Re-enable postgresql-simple

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -13,7 +13,7 @@ packages:
     "Daniel Brice <danielbrice@gmail.com> @friedbrice":
         - generic-lexicographic-order
         - text-convert
-        - text-encode < 0 # depends on disable postgresql-simple internally
+        - text-encode
 
     "Ernesto Hernandez-Novich <haskell@iamemhn.link> @iamemhn":
         - monad-logger-syslog
@@ -6788,7 +6788,6 @@ packages:
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires transformers >=0.3 && < 0.6 and the snapshot contains transformers-0.6.1.2
         - dawg-ord < 0 # tried dawg-ord-0.5.1.2, but its *library* requires vector >=0.10 && < 0.13 and the snapshot contains vector-0.13.2.0
-        - dbcleaner < 0 # tried dbcleaner-0.1.3, but its *library* requires the disabled package: postgresql-simple
         - dhall < 0 # tried dhall-1.42.2, but its *library* requires optparse-applicative >=0.14.0.0 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
         - dhall < 0 # tried dhall-1.42.2, but its *library* requires template-haskell >=2.13.0.0 && < 2.23 and the snapshot contains template-haskell-2.23.0.0
         - dhall-bash < 0 # tried dhall-bash-1.0.41, but its *library* requires bytestring < 0.12 and the snapshot contains bytestring-0.12.2.0
@@ -6835,7 +6834,6 @@ packages:
         - dotenv < 0 # tried dotenv-0.12.0.0, but its *library* requires data-default-class >=0.1.2 && < 0.2 and the snapshot contains data-default-class-0.2.0.0
         - dotparse < 0 # tried dotparse-0.1.2.3, but its *library* requires the disabled package: chart-svg
         - drawille < 0 # tried drawille-0.1.3.0, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
-        - drifter-postgresql < 0 # tried drifter-postgresql-0.2.1, but its *library* requires the disabled package: postgresql-simple
         - dvorak < 0 # tried dvorak-0.1.0.0, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
         - eap < 0 # tried eap-0.9.0.2, but its *library* requires the disabled package: cryptonite
         - easytest < 0 # tried easytest-0.3, but its *library* requires hedgehog >=0.6 && < =0.6.1 and the snapshot contains hedgehog-1.5
@@ -7493,7 +7491,6 @@ packages:
         - persistent-mysql < 0 # tried persistent-mysql-2.13.1.5, but its *library* requires the disabled package: mysql
         - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires mysql-haskell >=0.8.0.0 && < 1.0 and the snapshot contains mysql-haskell-1.1.6
         - persistent-mysql-haskell < 0 # tried persistent-mysql-haskell-0.6.0, but its *library* requires tls >=1.3.5 && < 1.5 and the snapshot contains tls-2.1.10
-        - persistent-postgresql < 0 # tried persistent-postgresql-2.13.7.0, but its *library* requires the disabled package: postgresql-simple
         - pfile < 0 # tried pfile-0.1.0.1, but its *library* requires filepath >=1.4.2 && < 1.5 and the snapshot contains filepath-1.5.4.0
         - pfile < 0 # tried pfile-0.1.0.1, but its *library* requires optparse-applicative >=0.17.1 && < =0.18.1.0 and the snapshot contains optparse-applicative-0.19.0.0
         - pfile < 0 # tried pfile-0.1.0.1, but its *library* requires transformers >=0.5.6 && < =0.6.1.0 and the snapshot contains transformers-0.6.1.2
@@ -7552,10 +7549,6 @@ packages:
         - pontarius-xmpp-extras < 0 # tried pontarius-xmpp-extras-0.1.0.12, but its *library* requires the disabled package: pontarius-xmpp
         - postgresql-migration < 0 # tried postgresql-migration-0.2.1.8, but its *library* requires time >=1.4 && < 1.14 and the snapshot contains time-1.14
         - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: inflections
-        - postgresql-query < 0 # tried postgresql-query-3.10.0, but its *library* requires the disabled package: postgresql-simple
-        - postgresql-schema < 0 # tried postgresql-schema-0.1.14, but its *library* requires the disabled package: postgresql-simple
-        - postgresql-simple < 0 # tried postgresql-simple-0.7.0.0, but its *library* requires base >=4.12.0.0 && < 4.21 and the snapshot contains base-4.21.0.0
-        - postgresql-simple < 0 # tried postgresql-simple-0.7.0.0, but its *library* requires template-haskell >=2.14.0.0 && < 2.23 and the snapshot contains template-haskell-2.23.0.0
         - postgresql-simple-url < 0 # tried postgresql-simple-url-0.2.1.0, but its *library* requires base >=4.6 && < 4.20 and the snapshot contains base-4.21.0.0
         - postgresql-typed < 0 # tried postgresql-typed-0.6.2.5, but its *library* requires the disabled package: HDBC
         - pred-trie < 0 # tried pred-trie-0.6.1, but its *library* requires the disabled package: tries
@@ -7591,7 +7584,6 @@ packages:
         - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.9, but its *library* requires Cabal >=2.0 && < 3.13 and the snapshot contains Cabal-3.14.1.0
         - proto-lens-setup < 0 # tried proto-lens-setup-0.4.0.9, but its *library* requires base >=4.10 && < 4.21 and the snapshot contains base-4.21.0.0
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
-        - psql-helpers < 0 # tried psql-helpers-0.1.0.0, but its *library* requires the disabled package: postgresql-simple
         - puresat < 0 # tried puresat-0.1, but its *executable* requires optparse-applicative ^>=0.18.1.0 and the snapshot contains optparse-applicative-0.19.0.0
         - purview < 0 # tried purview-0.2.0.2, but its *library* requires template-haskell >=2.15.0 && < 2.21 and the snapshot contains template-haskell-2.23.0.0
         - purview < 0 # tried purview-0.2.0.2, but its *library* requires warp >=3.3.0 && < 3.4 and the snapshot contains warp-3.4.8
@@ -7905,7 +7897,6 @@ packages:
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires the disabled package: x509-validation
         - tls-debug < 0 # tried tls-debug-0.4.8, but its *executable* requires tls >=1.3 && < 1.6 and the snapshot contains tls-2.1.10
         - tmp-postgres < 0 # tried tmp-postgres-1.34.1.0, but its *library* requires ansi-wl-pprint < 1 and the snapshot contains ansi-wl-pprint-1.0.2
-        - tmp-proc-postgres < 0 # tried tmp-proc-postgres-0.7.2.4, but its *library* requires the disabled package: postgresql-simple
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires Cabal < 3.12 and the snapshot contains Cabal-3.14.1.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires base >=4.14 && < 4.18 and the snapshot contains base-4.21.0.0
         - tonalude < 0 # tried tonalude-0.2.0.0, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.2.0
@@ -7995,7 +7986,6 @@ packages:
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.19.0.0
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route
-        - wai-session-postgresql < 0 # tried wai-session-postgresql-0.2.1.3, but its *library* requires the disabled package: postgresql-simple
         - wai-session-redis < 0 # tried wai-session-redis-0.1.0.5, but its *executable* requires warp < 3.4 and the snapshot contains warp-3.4.8
         - wai-session-redis < 0 # tried wai-session-redis-0.1.0.5, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.2.0
         - wai-session-redis < 0 # tried wai-session-redis-0.1.0.5, but its *library* requires data-default >=0.7 && < 0.8 and the snapshot contains data-default-0.8.0.1
@@ -8656,7 +8646,6 @@ skipped-tests:
     - pipes-category # tried pipes-category-0.3.0.0, but its *test-suite* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.2
     - pipes-fluid # tried pipes-fluid-0.6.0.1, but its *test-suite* requires the disabled package: pipes-misc
     - postgresql-libpq-notify # tried postgresql-libpq-notify-0.2.0.0, but its *test-suite* requires the disabled package: tmp-postgres
-    - postgresql-simple # tried postgresql-simple-0.7.0.0, but its *test-suite* requires inspection-testing >=0.4.1.1 && < 0.6 and the snapshot contains inspection-testing-0.6.2
     - pqueue # tried pqueue-1.5.0.0, but its *test-suite* requires base >=4.8 && < 4.21 and the snapshot contains base-4.21.0.0
     - pretty-diff # tried pretty-diff-0.4.0.3, but its *test-suite* requires tasty >=1.1 && < 1.5 and the snapshot contains tasty-1.5.3
     - pretty-sop # tried pretty-sop-0.2.0.3, but its *test-suite* requires markdown-unlit >=0.5.0 && < 0.6 and the snapshot contains markdown-unlit-0.6.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [X] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

I haven't been able to run `verify-package` on all the packages enabled here,
since it seems they try to use the existing nightly snapshot, that doesn't have
postgresql-simple.
