### PR TITLE
elynx: build errors should be fixed in 0.9.0.0

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4918,7 +4918,7 @@ packages:
         - covariance
         - dirichlet
         - elynx
-        - elynx-markov < 0 # https://github.com/dschrempf/elynx/issues/6
+        - elynx-markov
         - elynx-nexus
         - elynx-seq
         - elynx-tools
@@ -6833,7 +6833,6 @@ packages:
         - egison-pattern-src-th-mode < 0 # tried egison-pattern-src-th-mode-0.2.1.2, but its *library* requires text >=0.1.0 && < 1.3 and the snapshot contains text-2.1.2
         - elliptic-curve < 0 # tried elliptic-curve-0.3.0, but its *library* requires protolude >=0.2 && < 0.3 and the snapshot contains protolude-0.3.5
         - elm-street < 0 # tried elm-street-0.2.2.1, but its *library* requires base >=4.11.1.0 && < 4.20 and the snapshot contains base-4.21.0.0
-        - elynx < 0 # tried elynx-0.8.0.0, but its *executable* requires the disabled package: slynx
         - errata < 0 # tried errata-0.4.0.3, but its *library* requires base >=4.12 && < 4.21 and the snapshot contains base-4.21.0.0
         - essence-of-live-coding < 0 # tried essence-of-live-coding-0.2.8, but its *library* requires base >=4.13 && < 4.21 and the snapshot contains base-4.21.0.0
         - essence-of-live-coding-gloss < 0 # tried essence-of-live-coding-gloss-0.2.8, but its *library* requires base >=4.13 && < 4.21 and the snapshot contains base-4.21.0.0
@@ -7712,7 +7711,6 @@ packages:
         - simplest-sqlite < 0 # tried simplest-sqlite-0.1.0.2, but its *library* requires text >=1.1 && < 1.3 and the snapshot contains text-2.1.2
         - siphash < 0 # tried siphash-1.0.3, but its *library* requires bytestring < 0.11 and the snapshot contains bytestring-0.12.2.0
         - skeletons < 0 # tried skeletons-0.4.0, but its *executable* requires the disabled package: tinytemplate
-        - slynx < 0 # tried slynx-0.8.0.0, but its *library* requires the disabled package: elynx-markov
         - smash < 0 # tried smash-0.1.3, but its *library* requires base >=4.12 && < 4.17 and the snapshot contains base-4.21.0.0
         - smash < 0 # tried smash-0.1.3, but its *library* requires bifunctors ^>=5.5 and the snapshot contains bifunctors-5.6.2
         - smash < 0 # tried smash-0.1.3, but its *library* requires deepseq ^>=1.4 and the snapshot contains deepseq-1.5.1.0


### PR DESCRIPTION
related: https://github.com/dschrempf/elynx/issues/6

adpated to random 1.3

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
