### PR TITLE
re-enable liquidhaskell

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5009,10 +5009,16 @@ packages:
     "Brooklyn Zelenka <hello@brooklynzelenka.com> @expede":
         - rescue
 
-    "Artem Pelenitsyn <artem.pelenitsyn@gmail.com> @ulysses4ever":
+    "Artem Pelenitsyn <a@pelenitsyn.top> @ulysses4ever":
+        - BNFC-meta
         - alex-meta
         - happy-meta
-        - BNFC-meta
+        - liquidhaskell == 0.9.12.2
+        - liquidhaskell-boot
+        - liquid-fixpoint == 0.9.6.3.3
+        - smtlib-backends
+        - smtlib-backends-process
+        - smtlib-backends-tests
         - vector-hashtables
 
     "Tomasz Maciosowski <t4ccer@gmail.com> @t4ccer":
@@ -5654,8 +5660,6 @@ packages:
         - libyaml
         - libyaml-clib
         - lifted-base
-        - liquidhaskell == 0.9.10.1
-        - liquidhaskell-boot == 0.9.10.1
         - loch-th
         - lockfree-queue
         - log-base
@@ -7207,12 +7211,6 @@ packages:
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires lens-family-core >=1.2 && < 1.3 and the snapshot contains lens-family-core-2.1.3
         - lens-simple < 0 # tried lens-simple-0.1.0.9, but its *library* requires mtl >=2.1 && < 2.3 and the snapshot contains mtl-2.3.1
         - libgraph < 0 # tried libgraph-1.14, but its *library* requires the disabled package: union-find
-        - liquidhaskell < 0 # tried liquidhaskell-0.9.10.1, but its *library* requires bytestring ==0.12.1.0 and the snapshot contains bytestring-0.12.2.0
-        - liquidhaskell-boot < 0 # tried liquidhaskell-boot-0.9.10.1, but its *library* requires Diff >=0.3 && < 0.6 and the snapshot contains Diff-1.0.2
-        - liquidhaskell-boot < 0 # tried liquidhaskell-boot-0.9.10.1, but its *library* requires ghc ^>=9.10 and the snapshot contains ghc-9.12.2
-        - liquidhaskell-boot < 0 # tried liquidhaskell-boot-0.9.10.1, but its *library* requires hashable >=1.3 && < 1.5 and the snapshot contains hashable-1.5.0.0
-        - liquidhaskell-boot < 0 # tried liquidhaskell-boot-0.9.10.1, but its *library* requires optparse-applicative < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
-        - liquidhaskell-boot < 0 # tried liquidhaskell-boot-0.9.10.1, but its *library* requires the disabled package: liquid-fixpoint
         - loc < 0 # tried loc-0.2.0.0, but its *library* requires base ^>=4.16 || ^>=4.17 || ^>=4.18 and the snapshot contains base-4.21.0.0
         - loc < 0 # tried loc-0.2.0.0, but its *library* requires containers ^>=0.6.4 and the snapshot contains containers-0.7
         - loopbreaker < 0 # tried loopbreaker-0.1.1.1, but its *library* requires containers >=0.6 && < 0.7 and the snapshot contains containers-0.7

--- a/docker/02-apt-get-install.sh
+++ b/docker/02-apt-get-install.sh
@@ -169,6 +169,7 @@ apt-get install -y \
     unzip \
     wget \
     xclip \
+    z3 \
     zip \
     zlib1g-dev \
     zsh


### PR DESCRIPTION
### Checklist

- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
  - Since I'm adding a little tree (DAG) of packages (rooted at liquidhaskell), I was only able to run this with a success on the single leaf of this DAG: `smtlib-backends`. All rest (transitively) depends on it, so since it's not on Stackage yet, `verify-package` doesn't seem helpful.
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)