### PR TITLE
Take over cpphs, pass on microaeson

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -148,7 +148,6 @@ packages:
         - xor
         - http-io-streams
         - github
-        - microaeson
         - ini
         - cryptohash-md5
         - cryptohash-sha1
@@ -1736,6 +1735,7 @@ packages:
     "Tom Ellis <tom-stackage@jaguarpaw.co.uk> @tomjaguarpaw":
         - bluefin
         - bluefin-internal
+        - microaeson
         - opaleye
         - product-profunctors
         - strict-wrapper


### PR DESCRIPTION
CI fails for unrelated reasons:

unicode-data-0.7.0 ([changelog](http://hackage.haskell.org/package/unicode-data-0.7.0/changelog)) (Adithya Kumar <adi.obilisetty@gmail.com> @adithyaov) is out of bounds for:
- [ ] pandoc-3.8 (>=0.6 && < 0.7). John MacFarlane <jgm@berkeley.edu> @jgm. Used by: library
- [ ] streamly-0.10.1 (>=0.1 && < 0.7). Harendra Kumar <harendra.kumar@gmail.com> @harendra-kumar, Stackage upper bounds. Used by: library
- [ ] unicode-transforms-0.4.0.1 (>=0.2 && < 0.7). Harendra Kumar <harendra.kumar@gmail.com> @harendra-kumar. Used by: library