### PR TITLE
Re-enable universum

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7864,7 +7864,6 @@ packages:
         - union-find < 0 # tried union-find-0.2, but its *library* requires base >=4.4 && < 4.17 and the snapshot contains base-4.21.0.0
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires attoparsec >=0.10 && < 0.14 and the snapshot contains attoparsec-0.14.4
         - uniprot-kb < 0 # tried uniprot-kb-0.1.2.0, but its *library* requires text >=0.2 && < 1.3 and the snapshot contains text-2.1.2
-        - universum < 0 # tried universum-1.8.2.2, but its *library* requires text >=1.0.0.0 && < =2.1.1 and the snapshot contains text-2.1.2
         - urbit-hob < 0 # tried urbit-hob-0.3.3, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.2
         - uri-templater < 0 # tried uri-templater-0.3.1.0, but its *library* requires trifecta >=1.6 && < 1.8 and the snapshot contains trifecta-2.1.4
         - userid < 0 # tried userid-0.1.3.8, but its *library* requires base >=4.6 && < 4.21 and the snapshot contains base-4.21.0.0


### PR DESCRIPTION
Version 1.8.3 supports text<2.2

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
