### PR TITLE
Trying to fix showing documentation of `password` library

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8031,6 +8031,11 @@ package-flags:
     # See https://github.com/commercialhaskell/stackage/issues/7474
     password:
       crypton: true
+      # See https://github.com/commercialhaskell/stackage/issues/7265
+      argon2: true
+      bcrypt: true
+      pbkdf2: true
+      scrypt: true
 
     # https://github.com/commercialhaskell/stackage/issues/7461
     hashable:


### PR DESCRIPTION
As advised in #7265, I've added some flags for the `password` package to hopefully have the documentation of the modules that are behind those flags to show up on `stackage.org`

- password flags set to true to hopefully build/show the haddocks on stackage.org

---

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)