### PR TITLE
Assign xml-hamlet to @ysangkok

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -72,6 +72,7 @@ packages:
     "Janus Troelsen <ysangkok@gmail.com> @ysangkok":
         - ListZipper
         - timezone-olson-th
+        - xml-hamlet
 
     "Paul Burns <paul@flipstone.com> @onslaughtq":
         - rollbar
@@ -5813,7 +5814,6 @@ packages:
         - word8
         - xml
         - xml-conduit
-        - xml-hamlet
         - xml-types
         - xss-sanitize
         - yeshql-core


### PR DESCRIPTION
I saw in #7870 that xml-hamlet might get removed unless someone receives
notifications for it. We use xml-hamlet for Electronic Data Interchange (EDI)
at Flipstone so I'd like to get those notifications.
