### PR TITLE
Transfer maintenance of ini to jhrcek

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4669,10 +4669,10 @@ packages:
         - gtk-strut
         - rate-limit
         - status-notifier-item
-        - taffybar
+        - taffybar < 0 # not compatible with ini 0.5.1
         - time-units
         - xml-helpers
-        - xdg-desktop-entry < 0 # not compatible with init 0.5.1, see https://github.com/taffybar/xdg-desktop-entry/pull/4
+        - xdg-desktop-entry < 0 # not compatible with ini 0.5.1, see https://github.com/taffybar/xdg-desktop-entry/pull/4
 
     "ARATA Mizuki <minorinoki@gmail.com> @minoki":
         - unboxing-vector


### PR DESCRIPTION
I took over maintenance of this package from @andreasabel - see https://github.com/jhrcek/ini/issues/11
Also pushed a new version of ini (0.5.1) to hackage.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
