### PR TITLE
Add gi-gtk-layer-shell, re-enable taffybar ecosystem

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4689,10 +4689,10 @@ packages:
         - dbus-menu
         - gi-cairo-connector
         - gi-cairo-render
+        - gi-gtk-layer-shell
         - gtk-sni-tray
         - gtk-strut
         - rate-limit
-        - status-notifier-item
         - taffybar
         - time-units
         - xml-helpers
@@ -7570,7 +7570,6 @@ packages:
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires base ^>=4.18 || ^>=4.19 and the snapshot contains base-4.21.1.0
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires containers ^>=0.6.4 and the snapshot contains containers-0.7
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires network ^>=3.1.2 and the snapshot contains network-3.2.8.0
-        - taffybar < 0 # tried taffybar-4.1.1, but its *library* requires the disabled package: xdg-desktop-entry
         - tasty-bench-fit < 0 # tried tasty-bench-fit-0.1.1, but its *library* requires the disabled package: regression-simple
         - tasty-hunit-compat < 0 # tried tasty-hunit-compat-0.2.0.1, but its *library* requires tasty < 1.5 and the snapshot contains tasty-1.5.3
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.7
@@ -7734,7 +7733,6 @@ packages:
         - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires mtl < 2.3 and the snapshot contains mtl-2.3.1
         - writer-cps-mtl < 0 # tried writer-cps-mtl-0.1.1.6, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.1.2
         - wss-client < 0 # tried wss-client-0.3.0.0, but its *library* requires websockets >=0.12.6 && < 0.13 and the snapshot contains websockets-0.13.0.0
-        - xdg-desktop-entry < 0 # tried xdg-desktop-entry-0.1.1.2, but its *library* requires ini >=0.4.1 && < 0.4.3 and the snapshot contains ini-0.5.1
         - xmonad-extras < 0 # tried xmonad-extras-0.17.2, but its *library* requires bytestring >=0.9 && < 0.12 and the snapshot contains bytestring-0.12.2.0
         - xmonad-extras < 0 # tried xmonad-extras-0.17.2, but its *library* requires dbus >=1.2 && < 1.4 and the snapshot contains dbus-1.4.1
         - yeshql < 0 # tried yeshql-4.2.0.0, but its *library* requires the disabled package: yeshql-hdbc

--- a/docker/02-apt-get-install.sh
+++ b/docker/02-apt-get-install.sh
@@ -68,6 +68,7 @@ apt-get install -y \
     libgsl-dev \
     libgtk-3-dev \
     libgtk-4-dev \
+    libgtk-layer-shell-dev \
     libgtk2.0-dev \
     libgtksourceview-3.0-dev \
     libgtksourceview-5-dev \


### PR DESCRIPTION
## Summary

- Add `libgtk-layer-shell-dev` to the Docker build environment.
- Add `gi-gtk-layer-shell` to `build-constraints.yaml` under `@IvanMalison`.
- Re-enable the taffybar ecosystem on GHC 9.12 by removing now-unnecessary caps/disabled constraints and bumping the remaining blocker:
  - remove the `xdg-desktop-entry < 0` disabled constraint (compatible `xdg-desktop-entry-0.1.1.3` is on Hackage)
  - remove the `gtk-sni-tray` upper bound (compatible `gtk-sni-tray-0.1.14.2` is on Hackage)
  - remove the `taffybar` disabled constraint (compatible `dbus-menu-0.1.3.2` is on Hackage)
  - require `status-notifier-item >= 0.3.2.8` (relaxes `template-haskell`/`optparse-applicative` bounds for GHC 9.12)

Fixes #7948.

## Related Hackage Releases

- `xdg-desktop-entry-0.1.1.3`
- `dbus-menu-0.1.3.2`
- `gtk-sni-tray-0.1.14.2`
- `status-notifier-item-0.3.2.8`
- `taffybar-5.1.3`

Note: documentation for the GTK/GI packages was uploaded manually to Hackage (Hackage can't build those docs on its infrastructure).

## Testing

- GitHub Actions: `etc/check.sh` / curator `check-snapshot` passed for this PR (GHC 9.12.3, `nightly-2026-02-13`).
- Local: built + generated/uploaded Haddocks for the GTK/GI packages as part of the Hackage release process.
