### PR TITLE
reenable moffy-samples-gtk4

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7120,7 +7120,6 @@ packages:
         - model < 0 # tried model-0.5, but its *library* requires transformers >=0.4.2.0 && < 0.6 and the snapshot contains transformers-0.6.1.2
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *executable* requires the disabled package: pipes-text
         - modify-fasta < 0 # tried modify-fasta-0.8.3.0, but its *library* requires the disabled package: regex-tdfa-text
-        - moffy-samples-gtk4 < 0 # tried moffy-samples-gtk4-0.1.0.1, but its *executable* requires the disabled package: moffy-samples-gtk4-run
         - monad-bayes < 0 # tried monad-bayes-1.3.0.5, but its *executable* requires QuickCheck >=2.14 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
         - monad-bayes < 0 # tried monad-bayes-1.3.0.5, but its *executable* requires optparse-applicative >=0.17 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
         - monad-bayes < 0 # tried monad-bayes-1.3.0.5, but its *executable* requires time >=1.9 && < 1.13 and the snapshot contains time-1.14


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
