### PR TITLE
Remove temporary status-notifier-item exclusion

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4690,7 +4690,7 @@ packages:
         - gtk-sni-tray
         - gtk-strut
         - rate-limit
-        - status-notifier-item < 0.3.2.9 || > 0.3.2.9 # https://github.com/taffybar/status-notifier-item/issues/12
+        - status-notifier-item
         - taffybar
         - time-units
         - xml-helpers


### PR DESCRIPTION
status-notifier-item issue taffybar/status-notifier-item#12 is fixed in 0.3.2.10 (released on 2026-02-17), including relaxed bounds for optparse-applicative and template-haskell.\n\nThis removes the temporary constraint that excluded only 0.3.2.9 so Stackage can move forward without this exception.