### PR TITLE
CI: install libgmp-dev for stack setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,10 @@ jobs:
     name: Stackage check
     steps:
       - uses: actions/checkout@v6
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgmp-dev
       - uses: actions/cache@v5
         with:
           path: |


### PR DESCRIPTION
The `check` GitHub Actions job was failing on `ubuntu-latest` during `stack setup` with a linker error (`ld.gold: cannot find -lgmp`).

Install `libgmp-dev` before running `etc/check.sh` so the downloaded GHC can link executables during Stack's sanity check.
