### PR TITLE
add effable, hspec-tidy-formatter

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5339,6 +5339,10 @@ packages:
     "Joosep Jääger <joosep.jaager@gmail.com> @Soupstraw":
         - antigen
 
+    "Carl Wernhoff <carl@wernhoff.com> @carlwr":
+        - effable
+        - hspec-tidy-formatter
+
     "Grandfathered dependencies":
         - BiobaseNewick
         - Boolean


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] `*1` (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] `*1` (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

`*1`: with GHC 9.12.2 instead of the snapshot-specified 9.12.3 (not available through `ghcup`; #7936)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
