### PR TITLE
Reintroduce "deriving-trans" and "wai-control"

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -54,7 +54,7 @@ packages:
         - inf-backprop >= 0.1.1.0
 
     "Felix Springer <felixspringer149@gmail.com> @jumper149":
-        - deriving-trans < 0 # 0.9.1.0 https://github.com/jumper149/deriving-trans/issues/8
+        - deriving-trans
         - monad-control-identity
         - wai-control
 
@@ -7669,7 +7669,6 @@ packages:
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires the disabled package: protocol-buffers
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires transformers ^>=0.5 and the snapshot contains transformers-0.6.3.0
         - vectortiles < 0 # tried vectortiles-1.5.1, but its *library* requires vector >=0.11 && < 0.13 and the snapshot contains vector-0.13.2.0
-        - wai-control < 0 # tried wai-control-0.2.0.0, but its *library* requires websockets >=0.12.5.3 && < 0.13 and the snapshot contains websockets-0.13.0.0
         - wai-middleware-crowd < 0 # tried wai-middleware-crowd-0.1.4.2, but its *executable* requires optparse-applicative >=0.11 && < 0.15 and the snapshot contains optparse-applicative-0.19.0.0
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-predicates
         - wai-routing < 0 # tried wai-routing-0.13.0, but its *library* requires the disabled package: wai-route


### PR DESCRIPTION
After bumping versions they should build again.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks

Should I have added lower version bounds to the `build-constraints.yml`?