### PR TITLE
Reenable skeletest tests

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8116,7 +8116,6 @@ expected-test-failures:
     - rocksdb-haskell-jprupp # 2.1.7 https://github.com/jprupp/rocksdb-haskell/issues/10
     - sandwich-webdriver # 0.3.0.1 needs Nix binary and store.
     - servant-auth-client # 0.4.2.0 https://github.com/haskell-servant/servant/issues/1864
-    - skeletest # 0.4.0 https://github.com/brandonchinn178/skeletest/issues/116
     - subcategories # 0.2.1.2
     - sydtest # 0.20.0.0
     - sydtest-autodocodec # https://github.com/commercialhaskell/stackage/issues/7465


### PR DESCRIPTION
Issue was fixed in 0.4.1

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
