### PR TITLE
Reinstate proto-lens-setup & proto-lens-protobuf-types

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4012,7 +4012,7 @@ packages:
         - proto-lens-protobuf-types
         - proto-lens-protoc
         - proto-lens-runtime
-        - proto-lens-setup < 0
+        - proto-lens-setup
         - proto-lens
         - proto-lens-arbitrary
         - proto-lens-optparse
@@ -7367,7 +7367,6 @@ packages:
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires prometheus ^>=2.2 and the snapshot contains prometheus-2.3.0
         - prometheus-wai-middleware < 0 # tried prometheus-wai-middleware-1.0.1.0, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.4
-        - proto-lens-protobuf-types < 0 # tried proto-lens-protobuf-types-0.7.2.2, but its *library* requires the disabled package: proto-lens-setup
         - protocol-buffers-descriptor < 0 # tried protocol-buffers-descriptor-2.4.17, but its *library* requires the disabled package: protocol-buffers
         - puresat < 0 # tried puresat-0.1, but its *executable* requires optparse-applicative ^>=0.18.1.0 and the snapshot contains optparse-applicative-0.19.0.0
         - puresat < 0 # tried puresat-0.1, but its *library* requires base >=4.18.2.1 && < 4.21 and the snapshot contains base-4.21.2.0


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
