### PR TITLE
Unconstrain mysql-haskell (without benchmarks or ram)

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7835,7 +7835,6 @@ packages:
         - tls-session-manager < 0.1.0
         - smtp-mail < 0.5.0.1
         - pusher-http-haskell < 2.1.0.22
-        - mysql-haskell < 1.2.1
         - wreq < 0.5.4.5
 
         # https://github.com/commercialhaskell/stackage/issues/7930
@@ -8007,6 +8006,10 @@ package-flags:
 
     path:
       os-string: true
+
+    # https://github.com/commercialhaskell/stackage/issues/7929
+    mysql-haskell:
+      crypton-1-1: false
 # end of package-flags
 
 # Special configure options for individual packages
@@ -9033,6 +9036,7 @@ expected-benchmark-failures:
     - lr-acts # 0.1
     - lz4 # https://github.com/fpco/stackage/issues/3510
     - memcache # 0.3.0.2
+    - mysql-haskell # https://github.com/winterland1989/mysql-haskell/issues/82
     - product-profunctors # 0.11.1.1
     - stateWriter # 0.4.0 https://github.com/bartavelle/stateWriter/issues/5
     - ua-parser # 0.7.7.0 compile fail against aeson 2


### PR DESCRIPTION
Somehow `./verify-package mysql-haskell` doesn't pick up on the disabled
benchmark, so it tries to build it anyway, but fails. I am submitting this anyway as I think it might just be an issue
with `verify-package`.

See

* https://github.com/winterland1989/mysql-haskell/issues/82
