### PR TITLE
Enable bench-show, add some streamly packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -817,10 +817,12 @@ packages:
 
     "Harendra Kumar <harendra.kumar@gmail.com> @harendra-kumar":
         - bench-show
-        - monad-recorder
         - packcheck
         - streamly
         - streamly-core
+        - streamly-filepath
+        - streamly-statistics
+        - streamly-text
         - unicode-transforms
         - xls
 
@@ -6526,7 +6528,6 @@ packages:
         - base64-lens < 0 # tried base64-lens-0.3.1, but its *library* requires text ^>=1.2 and the snapshot contains text-2.1.4
         - bcp47-orphans < 0 # tried bcp47-orphans-0.1.3.0, but its *library* requires the disabled package: openapi3
         - bench < 0 # tried bench-1.0.13, but its *executable* requires optparse-applicative >=0.14.0.0 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
-        - bench-show < 0 # tried bench-show-0.3.2, but its *executable* requires optparse-applicative >=0.14.2 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
         - bin < 0 # tried bin-0.1.4, but its *library* requires QuickCheck ^>=2.14.2 || ^>=2.15 and the snapshot contains QuickCheck-2.16.0.0
         - binary-tagged < 0 # tried binary-tagged-0.3.1, but its *library* requires base >=4.7.0.2 && < 4.20 and the snapshot contains base-4.21.2.0
         - binary-tagged < 0 # tried binary-tagged-0.3.1, but its *library* requires containers >=0.5.5.1 && < 0.7 and the snapshot contains containers-0.7


### PR DESCRIPTION
Remove monad-recorder

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
