### PR TITLE
Re-enable lazyppl

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7059,8 +7059,6 @@ packages:
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires transformers >=0.4 && < 0.6 and the snapshot contains transformers-0.6.3.0
         - language-puppet < 0 # tried language-puppet-1.5.1, but its *library* requires unix >=2.7 && < 2.8 and the snapshot contains unix-2.8.8.0
         - language-thrift < 0 # tried language-thrift-0.13.0.0, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
-        - lazyppl < 0 # tried lazyppl-1.0, but its *library* requires containers >=0.6.5.1 && < 0.7 and the snapshot contains containers-0.7
-        - lazyppl < 0 # tried lazyppl-1.0, but its *library* requires random >=1.2.0 && < 1.3 and the snapshot contains random-1.3.1
         - lens-datetime < 0 # tried lens-datetime-0.3, but its *library* requires lens >=3 && < 5 and the snapshot contains lens-5.3.6
         - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires filepath >=1.0 && < 1.5 and the snapshot contains filepath-1.5.5.0
         - lens-process < 0 # tried lens-process-0.4.0.0, but its *library* requires lens >=4.0 && < 5.1 and the snapshot contains lens-5.3.6


### PR DESCRIPTION
- [x] Meaningful commit message
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] Verified package builds against latest nightly via `verify-package`

`lazyppl-1.0.1` drops upper bounds on `containers` and `random`, so the two skip lines are no longer needed.