### PR TITLE
Remove hakyll-diagrams from expected-test-failures

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8020,7 +8020,6 @@ expected-test-failures:
     - generic-lens # https://github.com/commercialhaskell/stackage/issues/6377
     - ghc-byteorder # 4.11.0.0.10 https://github.com/haskell-hvr/ghc-byteorder/issues/1
     - ghc-prof # Regression tests: /usr/bin/ld.gold: error: cannot find -lHStemporary-1.3-51ST9z47bmaL2YkhqqBGqn_p ...
-    - hakyll-diagrams # 0.1.0.2 https://github.com/renatoGarcia/hakyll-diagrams/issues/4
     - haskey-btree # https://github.com/commercialhaskell/stackage/issues/7393
     - hasql-migration # 0.3.1 https://github.com/tvh/hasql-migration/issues/11
     - heist # GHC 9.8.1


### PR DESCRIPTION
Related renatoGarcia/hakyll-diagrams#4

That issue was caused by a breaking change with Hakyll version 4.16.8.0 (now deprecated and released as Hakyll-4.17.0.0)
hakyll-diagrams 0.1.0.3 release add compatibility to hakyll 4.17

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
