### PR TITLE
Re-enable stakhanov

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7506,9 +7506,6 @@ packages:
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
         - srt-dhall < 0 # tried srt-dhall-0.1.0.0, but its *library* requires text >=1.0 && < 1.3 and the snapshot contains text-2.1.4
         - srt-formatting < 0 # tried srt-formatting-0.1.0.0, but its *library* requires formatting >=7.0.0 && < 7.2 and the snapshot contains formatting-7.2.0
-        - stakhanov < 0 # tried stakhanov-0.1.0.0, but its *library* requires hasql >=1.9 && < 1.10 and the snapshot contains hasql-1.10.3
-        - stakhanov < 0 # tried stakhanov-0.1.0.0, but its *library* requires hasql-dynamic-statements >=0.3 && < 0.4 and the snapshot contains hasql-dynamic-statements-0.5.1
-        - stakhanov < 0 # tried stakhanov-0.1.0.0, but its *library* requires hasql-th >=0.4 && < 0.5 and the snapshot contains hasql-th-0.5
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires base >=4.5 && < 4.19 and the snapshot contains base-4.21.2.0
         - static-canvas < 0 # tried static-canvas-0.2.0.3, but its *library* requires text >=0.11 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.4
         - stb-image-redux < 0 # tried stb-image-redux-0.2.1.2, but its *library* requires vector >=0.10.12.3 && < 0.13 and the snapshot contains vector-0.13.2.0


### PR DESCRIPTION
Checklist:
- [X] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [X] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
