### PR TITLE
Re-enable json-spec-openapi

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7031,7 +7031,6 @@ packages:
         - ixset-typed-hashable-instance < 0 # tried ixset-typed-hashable-instance-0.1.0.2, but its *library* requires the disabled package: ixset-typed
         - javascript-extras < 0 # tried javascript-extras-0.5.0.0, but its *library* requires the disabled package: ghcjs-base-stub
         - journalctl-stream < 0 # tried journalctl-stream-0.6.0.8, but its *library* requires base < 4.21 and the snapshot contains base-4.21.2.0
-        - json-spec-openapi < 0 # tried json-spec-openapi-1.2.0.2, but its *library* requires insert-ordered-containers >=0.2.5.3 && < 0.3 and the snapshot contains insert-ordered-containers-0.3.0
         - jvm < 0 # tried jvm-0.6.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jni
         - jvm-streaming < 0 # tried jvm-streaming-0.4.0, but its *library* requires the disabled package: jvm-batching


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
