### PR TITLE
Re-enable Clash

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6588,10 +6588,6 @@ packages:
         - chell-quickcheck < 0 # tried chell-quickcheck-0.2.5.4, but its *library* requires QuickCheck ^>=2.14.2 and the snapshot contains QuickCheck-2.16.0.0
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires hashable >=1.2.6.0 && < 1.4 and the snapshot contains hashable-1.5.1.0
         - chiphunk < 0 # tried chiphunk-0.1.4.0, but its *library* requires vector-space >=0.13 && < 0.17 and the snapshot contains vector-space-0.19
-        - clash-ghc < 0 # tried clash-ghc-1.10.0, but its *library* requires the disabled package: clash-prelude
-        - clash-lib < 0 # tried clash-lib-1.10.0, but its *library* requires the disabled package: clash-prelude
-        - clash-prelude < 0 # tried clash-prelude-1.10.0, but its *library* requires QuickCheck >=2.7 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
-        - clash-prelude-hedgehog < 0 # tried clash-prelude-hedgehog-1.10.0, but its *library* requires hedgehog >=1.0.3 && < 1.6 and the snapshot contains hedgehog-1.7
         - clash-shake < 0 # tried clash-shake-0.4.0, but its *library* requires the disabled package: clash-prelude
         - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires base >=4.12 && < 4.20 and the snapshot contains base-4.21.2.0
         - cleff < 0 # tried cleff-0.3.3.0, but its *library* requires containers >=0.5 && < 0.7 and the snapshot contains containers-0.7
@@ -8689,7 +8685,6 @@ skipped-tests:
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires QuickCheck >=2.12 && < 2.13 and the snapshot contains QuickCheck-2.16.0.0
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires bytestring >=0.11 && < 0.12 and the snapshot contains bytestring-0.12.2.0
     - cassava-conduit # tried cassava-conduit-0.6.6, but its *test-suite* requires text >=1.2 && < 1.3 || >=2.0 && < 2.1 and the snapshot contains text-2.1.4
-    - clash-prelude # tried clash-prelude-1.10.0, but its *test-suite* requires hedgehog >=1.0.3 && < 1.6 and the snapshot contains hedgehog-1.7
     - co-log # tried co-log-0.7.0.0, but its *test-suite* requires hedgehog >=1.0 && < 1.6 and the snapshot contains hedgehog-1.7
     - colour # tried colour-2.3.7, but its *test-suite* requires QuickCheck >=2.5 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
     - colour # tried colour-2.3.7, but its *test-suite* requires random >=1.0 && < 1.3 and the snapshot contains random-1.3.1


### PR DESCRIPTION
Our [new release 1.10.0](https://clash-lang.org/blog/2026-04-28-clash110/) supports GHC 9.12.4, so we can get in again. It does require the Hackage revision with loosened bounds released today.

I noticed `clash-shake` could also be re-enabled; in Stackage, it is maintained by Andreas Ländle but they added a note saying

> Packages that I personally like to be on Stackage - but I do not maintain them!
> Feel free to snatch them from me! Just remove them if they are causing trouble!

Shall I also open a PR re-enabling `clash-shake`?

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
