### PR TITLE
Install WirePlumber 0.5 in build image

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4712,13 +4712,13 @@ packages:
         - gi-cairo-connector
         - gi-cairo-render
         - gi-gtk-layer-shell
-        - gi-wireplumber < 0 # needs wireplumber-0.5 (Ubuntu 24.04 has 0.4)
+        - gi-wireplumber
         - gtk-scaling-image
         - gtk-sni-tray
         - gtk-strut
         - rate-limit
         - status-notifier-item
-        - taffybar < 7.2
+        - taffybar
         - time-units
         - xml-helpers
         - xdg-desktop-entry

--- a/docker/02-apt-get-install.sh
+++ b/docker/02-apt-get-install.sh
@@ -32,6 +32,7 @@ apt-get install -y \
     gir1.2-soup-3.0 \
     git \
     gnupg \
+    gobject-introspection \
     gradle \
     hscolour \
     libadns1-dev \
@@ -86,6 +87,7 @@ apt-get install -y \
     liblmdb-dev \
     liblz4-tool \
     liblzma-dev \
+    liblua5.4-dev \
     libmagic-dev \
     libmagickcore-dev \
     libmagickwand-dev \
@@ -107,6 +109,7 @@ apt-get install -y \
     libpcap0.8-dev \
     libpcre2-dev \
     libpcre3-dev \
+    libpipewire-0.3-dev \
     libpq-dev \
     libprimecount-dev \
     libprotobuf-dev \
@@ -135,7 +138,6 @@ apt-get install -y \
     libusb-1.0-0-dev \
     libvte-2.91-dev \
     libwebkit2gtk-4.1-dev \
-    libwireplumber-0.4-dev \
     libxau-dev \
     libxml2-dev \
     libxrandr-dev \
@@ -149,6 +151,7 @@ apt-get install -y \
     llvm-15 \
     locales \
     m4 \
+    meson \
     minisat \
     mono-mcs \
     nettle-dev \
@@ -157,6 +160,7 @@ apt-get install -y \
     nodejs \
     nvidia-cuda-toolkit \
     openjdk-8-jdk \
+    pkg-config \
     python3-matplotlib \
     python3-numpy \
     python3-pip \

--- a/docker/03-custom-install.sh
+++ b/docker/03-custom-install.sh
@@ -14,6 +14,24 @@ locale-gen en_US.UTF-8
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.gold" 20
 update-alternatives --install "/usr/bin/ld" "ld" "/usr/bin/ld.bfd" 10
 
+# Install WirePlumber 0.5 for gi-wireplumber and taffybar.
+# Ubuntu 24.04 only packages WirePlumber 0.4.
+WIREPLUMBER_VER=0.5.14
+WIREPLUMBER_TARBALL=wireplumber-${WIREPLUMBER_VER}.tar.gz
+(
+  cd /tmp \
+    && curl -L -o ${WIREPLUMBER_TARBALL} https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/${WIREPLUMBER_VER}/${WIREPLUMBER_TARBALL} \
+    && echo "e91f04cd8cec75d72b8a2aaa7e90b1ba0a5e2094b7a882fc3a29a484a48a87e9  ${WIREPLUMBER_TARBALL}" | sha256sum -c - \
+    && tar -xzf ${WIREPLUMBER_TARBALL} \
+    && cd wireplumber-${WIREPLUMBER_VER} \
+    && meson setup build -Ddoc=disabled -Dsystem-lua=true \
+    && meson compile -C build \
+    && meson install -C build \
+    && ldconfig \
+    && cd /tmp \
+    && rm -rf wireplumber-${WIREPLUMBER_VER} ${WIREPLUMBER_TARBALL}
+)
+
 # # Add JDK to system paths.
 # echo "/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server" > /etc/ld.so.conf.d/openjdk.conf \
 #     && ldconfig


### PR DESCRIPTION
This installs WirePlumber 0.5.14 from source in the Stackage build image, because Ubuntu 24.04 only ships WirePlumber 0.4. That lets the nightly build environment provide `wireplumber-0.5.pc` for `gi-wireplumber`, and lets us remove the temporary constraints for `gi-wireplumber` and `taffybar >= 7.2`.

This is intended to address the follow-up from taffybar/taffybar#677 where `taffybar-7.2.2` builds with newer QuickCheck, but `gi-wireplumber` was still disabled by the Ubuntu 24.04 system package version.

Validation:
- `bash -n docker/02-apt-get-install.sh docker/03-custom-install.sh`
- `git diff --check`
- Tested the WirePlumber 0.5.14 tarball install block in a clean `ubuntu:24.04` container with the required apt deps; `pkg-config --modversion wireplumber-0.5` returned `0.5.14`.

I have not rebuilt the full Stackage Docker image locally.