### PR TITLE
remove no-revision list

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -9368,22 +9368,12 @@ hide:
 - zip # conflicts with Codec.Archive.Zip in zip-archive
 
 
-# Experimental: packages where Hackage cabal file revisions should be ignored.
+# Packages where Hackage cabal file revisions should be ignored.
 #
 # This always use the cabal file shipped with the sdist tarball instead of the latest revision.
 #
 # This only supports pinning to the initial release (revision 0), not to an arbitrary revision.
-no-revisions:
-- mime-mail
-- basement
-- cryptonite
-- foundation
-- gauge
-- http-download
-- rio-prettyprint
-- hi-file-parser
-- aura
-- hoogle # https://github.com/commercialhaskell/stackage/issues/7496
+no-revisions: []
 
 # Note, this no longer actually does anything with curator2 unfortunately:
 # Do not build these packages in parallel with others. Useful for high memory


### PR DESCRIPTION
This empties the `no-revisions:` list - I don't see any good reason we should carry these permanently.

Most of the 10 packages there date from the previous decade,
and 2 were added in more recent years: I think they were both intended to be temporary bounds workarounds.

I think this list should be up to Stackage not something that upstream maintainers can impose.