### PR TITLE
hi-file-parser, rio-prettyprint and http-download: Shift Stackage responsibility

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -975,9 +975,6 @@ packages:
         - githash
 
         - time-manager
-        - http-download < 0 # https://github.com/commercialhaskell/http-download/issues/6
-        - hi-file-parser
-        - rio-prettyprint
         - packdeps
 
     "Brandon Barker <brandon.barnnker@gmail.com> @bbarker":
@@ -5196,8 +5193,11 @@ packages:
         - crypton-asn1-types
         - crypton-pem
         - crypton-socks
+        - hi-file-parser
+        - http-download < 0 # https://github.com/commercialhaskell/http-download/issues/6
         - open-browser
         - pantry
+        - rio-prettyprint
         - stack < 9
         - static-bytes
         - time-hourglass


### PR DESCRIPTION
I am a Hackage maintainer of `hi-file-parser`, `rio-prettyprint` and (now) `http-download` and, I think, probably better placed than @snoyberg to bear the administrative burden of the related Stackage responsibility.

See:
* https://github.com/commercialhaskell/http-download/pull/7