### PR TITLE
Pick up more packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2380,11 +2380,27 @@ packages:
         - maximal-cliques
 
     "Alexander Bondarenko <aenor.realm@gmail.com> @dpwiz":
+        - apecs
+        - apecs-gloss
+        - apecs-physics
+        - apecs-stm
+        - geomancy
+        - geomancy-layout
+        - gl-block
+        - gltf-codec
         - hedn
+        - hedn-functor
+        - ktx-codec
+        - rio-app
         - sdl2
         - soap
-        - soap-tls
         - soap-openssl
+        - soap-tls
+        - spirv-enum
+        - spirv-headers
+        - spirv-reflect-ffi
+        - spirv-reflect-types
+        - spirv-reflect-yaml
 
     "Andres Löh <andres@well-typed.com> @kosmikus":
         - generics-sop
@@ -2945,9 +2961,6 @@ packages:
         - GPipe
 
     "Jonas Carpay <jonascarpay@gmail.com> @jonascarpay":
-        - apecs
-        - apecs-gloss
-        - apecs-physics
         - aeson-commit
         - js-chart
         - safe-gen

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1197,6 +1197,7 @@ packages:
         - numeric-extras
         - parsers
         - pointed
+        - ptrdiff
         - profunctors
         - promises
         - rcu

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7851,9 +7851,6 @@ packages:
         # https://github.com/commercialhaskell/stackage/issues/8037
         - magic < 1.2
 
-        # https://github.com/commercialhaskell/stackage/issues/8049
-        - apecs < 0.10
-
         # https://github.com/commercialhaskell/stackage/issues/8058
         - hackage-revdeps < 0.4
 


### PR DESCRIPTION
Added some of the stable/low-deps/core-ish packages.
Adopted `apecs-*` from Jonas.
Added [ptrdiff](https://hackage.haskell.org/package/ptrdiff) to EKmett's list, needed to enable gl-block and geomancy.