### PR TITLE
Add `webcolor-labels` package

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3078,6 +3078,9 @@ packages:
         - hsexif
         - slack-web
 
+    "Andrei Borzenkov <me@sandwitch.dev> @s-and-witch":
+        - webcolor-labels
+
     "Nikolai Kudasov <nickolay.kudasov@gmail.com> @fizruk":
         - http-api-data
         - swagger2


### PR DESCRIPTION
Hello, I was asked to upload this package to stackage. It has no dependencies other than base and it builds with pretty much every decently modern GHC. 

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
