### PR TITLE
Re-enable http-download

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5194,7 +5194,7 @@ packages:
         - crypton-pem
         - crypton-socks
         - hi-file-parser
-        - http-download < 0 # https://github.com/commercialhaskell/http-download/issues/6
+        - http-download
         - open-browser
         - pantry
         - rio-prettyprint


### PR DESCRIPTION
See:
* https://github.com/commercialhaskell/stackage/commit/92653cafdc3fc53eff56a4cf3e8426f7d06dcba7
* https://github.com/commercialhaskell/http-download/issues/6 (now closed)
* https://github.com/commercialhaskell/stackage/issues/8048#issuecomment-4866091698

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package) (Package CI builds against nightly-2026-06-30)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
