### PR TITLE
Return map-syntax, heist, snap to grandfathered dependencies.

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -190,9 +190,6 @@ packages:
         - hasktags
         - text-icu
         - vector-binary-instances
-        - map-syntax
-        - heist
-        - snap
 
     "Michael Chavinda <mschavinda@gmail.com> @mchav":
         - cassava < 0.5.5.0 || > 0.5.5.0 # https://github.com/haskell-hvr/cassava/issues/248
@@ -5616,6 +5613,7 @@ packages:
         - hasql-dynamic-statements
         - hasql-implicits
         - heap
+        - heist
         - here
         - hex
         - hie-compat
@@ -5693,6 +5691,7 @@ packages:
         - lzma
         - lzma-clib
         - managed
+        - map-syntax
         - markov-chain-usage-model
         - math-functions
         - membership
@@ -5815,6 +5814,7 @@ packages:
         - singleton-bool
         - size-based
         - skein
+        - snap
         - snap-core
         - snappy
         - some


### PR DESCRIPTION
I don't have commit rights for these projects and communication is too laggy.
