### PR TITLE
Re-enable pantry

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7270,7 +7270,6 @@ packages:
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.1.3, but its *library* requires optparse-applicative >=0.18 && < 0.19 and the snapshot contains optparse-applicative-0.19.0.0
         - pandoc-symreg < 0 # tried pandoc-symreg-0.2.1.3, but its *library* requires srtree >=1.0.0.4 && < 1.1 and the snapshot contains srtree-2.0.1.8
         - pango < 0 # tried pango-0.13.12.0, but its *library* requires the disabled package: glib
-        - pantry < 0 # tried pantry-0.11.2, but its *library* requires the disabled package: http-download
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires bytestring >=0.10 && < 0.11 and the snapshot contains bytestring-0.12.2.0
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires monads-tf >=0.1 && < 0.2 and the snapshot contains monads-tf-0.3.0.1
         - papillon < 0 # tried papillon-0.1.1.1, but its *library* requires template-haskell >=2.15 && < 2.16 and the snapshot contains template-haskell-2.23.0.0


### PR DESCRIPTION
See:
* #8068
* https://hackage.haskell.org/package/pantry-0.11.4

- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package) `pantry-0.11.4` builds against `nightly-2026-07-11`.
