### PR TITLE
Re-enable cabal-add, it no longer depends on cabal-install-parsers

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6632,7 +6632,6 @@ packages:
         - buttplug-hs-core < 0 # tried buttplug-hs-core-0.1.0.1, but its *library* requires wuss >=1.1.18 && < 1.2 and the snapshot contains wuss-2.0.2.7
         - bytestring-progress < 0 # tried bytestring-progress-1.4, but its *library* requires text >=1.2.3.1 && < 1.3 and the snapshot contains text-2.1.4
         - bytezap < 0 # tried bytezap-1.6.0, but its *library* requires base >=4.18.0.0 && < 4.21 and the snapshot contains base-4.21.2.0
-        - cabal-add < 0 # tried cabal-add-0.2, but its *executable* requires the disabled package: cabal-install-parsers
         - cabal-install-parsers < 0 # tried cabal-install-parsers-0.6.3, but its *library* requires tar ^>=0.5.1.1 || ^>=0.6.0.0 and the snapshot contains tar-0.7.1.0
         - cardano-coin-selection < 0 # tried cardano-coin-selection-1.0.1, but its *library* requires the disabled package: cryptonite
         - caster < 0 # tried caster-0.0.3.0, but its *library* requires the disabled package: fast-builder


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
