### PR TITLE
Re-enable regression-simple and tasty-bench-fit

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7415,7 +7415,6 @@ packages:
         - regex-pcre-text < 0 # tried regex-pcre-text-0.94.0.1, but its *library* requires text >=1.2 && < 1.3 and the snapshot contains text-2.1.4
         - regex-tdfa-text < 0 # tried regex-tdfa-text-1.0.0.3, but its *library* requires regex-base < 0.94 and the snapshot contains regex-base-0.94.0.3
         - registry-options < 0 # tried registry-options-0.2.1.1, but its *library* requires text >=1 && < 2 and the snapshot contains text-2.1.4
-        - regression-simple < 0 # tried regression-simple-0.2.1, but its *library* requires base >=4.3 && < 4.20 and the snapshot contains base-4.21.2.0
         - rel8 < 0 # tried rel8-1.7.0.0, but its *library* requires hasql >=1.8 && < 1.10 and the snapshot contains hasql-1.10.3.5
         - repa < 0 # tried repa-3.4.2.0, but its *library* requires QuickCheck >=2.8 && < 2.16 and the snapshot contains QuickCheck-2.16.0.0
         - repa-algorithms < 0 # tried repa-algorithms-3.4.2.0, but its *library* requires base >=4.8 && < 4.21 and the snapshot contains base-4.21.2.0
@@ -7563,7 +7562,6 @@ packages:
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires base ^>=4.18 || ^>=4.19 and the snapshot contains base-4.21.2.0
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires containers ^>=0.6.4 and the snapshot contains containers-0.7
         - systemd-socket-activation < 0 # tried systemd-socket-activation-1.1.0.2, but its *library* requires network ^>=3.1.2 and the snapshot contains network-3.2.8.0
-        - tasty-bench-fit < 0 # tried tasty-bench-fit-0.1.1, but its *library* requires the disabled package: regression-simple
         - tasty-hunit-compat < 0 # tried tasty-hunit-compat-0.2.0.1, but its *library* requires tasty < 1.5 and the snapshot contains tasty-1.5.4
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires containers >=0.4 && < 0.6 and the snapshot contains containers-0.7
         - tasty-stats < 0 # tried tasty-stats-0.2.0.4, but its *library* requires tasty >=0.11.2 && < 1.2 and the snapshot contains tasty-1.5.4


### PR DESCRIPTION
Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
