### PR TITLE
Re-enable firebase-hs

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -5261,6 +5261,9 @@ packages:
         - config-value
         - toml-parser
 
+    "Devon Tomlin <devon.tomlin@novavero.ai> @aoinoikaz":
+        - firebase-hs
+
     "Andreas Ländle @alaendle":
         - co-log
         - co-log-core
@@ -5284,7 +5287,6 @@ packages:
         - effectful-poolboy
         - exact-real
         - fgl-visualize
-        - firebase-hs
         - fx
         - gb-vector
         - generic-case
@@ -6853,7 +6855,6 @@ packages:
         - fib < 0 # tried fib-0.1.0.1, but its *library* requires the disabled package: base-noprelude
         - fields-and-cases < 0 # tried fields-and-cases-0.2.0.0, but its *library* requires base >=4.17.2.0 && < 4.20 and the snapshot contains base-4.21.2.0
         - fin < 0 # tried fin-0.3.2, but its *library* requires QuickCheck ^>=2.14.2 || ^>=2.15 || ^>=2.18.0.0 and the snapshot contains QuickCheck-2.16.0.0
-        - firebase-hs < 0 # tried firebase-hs-0.2.0.0, but its *library* requires http-client-tls >=0.3 && < 0.4 and the snapshot contains http-client-tls-0.4.0
         - first-class-patterns < 0 # tried first-class-patterns-0.3.2.5, but its *library* requires transformers >=0.1.0 && < 0.6 and the snapshot contains transformers-0.6.3.0
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires text >=1.2 && < 2 and the snapshot contains text-2.1.4
         - flat-mcmc < 0 # tried flat-mcmc-1.5.2, but its *library* requires transformers >=0.2 && < 0.6 and the snapshot contains transformers-0.6.3.0


### PR DESCRIPTION
firebase-hs-0.3.0.0 allows http-client-tls < 0.5 (#7966). Also moving it out of @alaendle's up-for-grabs list to my own entry since I maintain it upstream.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh) (none required)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package) (package CI builds and tests with GHC 9.12 against http-client-tls-0.4.0)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
