### PR TITLE
Re-enable fastmemo: 0.1.2 fixes the out-of-date bounds

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -6875,9 +6875,6 @@ packages:
         - fakedata-quickcheck < 0 # tried fakedata-quickcheck-0.2.0, but its *library* requires QuickCheck >=2.6 && < 2.15 and the snapshot contains QuickCheck-2.16.0.0
         - fast-builder < 0 # tried fast-builder-0.1.5.0, but its *library* requires base >=4.8 && < 4.21 and the snapshot contains base-4.21.2.0
         - fasta < 0 # tried fasta-0.10.4.2, but its *library* requires the disabled package: pipes-text
-        - fastmemo < 0 # tried fastmemo-0.1.1, but its *library* requires base >=4.7 && < 4.18 and the snapshot contains base-4.21.2.0
-        - fastmemo < 0 # tried fastmemo-0.1.1, but its *library* requires bytestring >=0.10 && < 0.12 and the snapshot contains bytestring-0.12.2.0
-        - fastmemo < 0 # tried fastmemo-0.1.1, but its *library* requires containers >=0.6 && < 0.7 and the snapshot contains containers-0.7
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires base >=4.5 && < 4.19 and the snapshot contains base-4.21.2.0
         - fclabels < 0 # tried fclabels-2.0.5.1, but its *library* requires template-haskell >=2.2 && < 2.21 and the snapshot contains template-haskell-2.23.0.0
         - fgl-arbitrary < 0 # tried fgl-arbitrary-0.2.0.6, but its *library* requires QuickCheck >=2.3 && < 2.15 and the snapshot contains QuickCheck-2.16.0.0


### PR DESCRIPTION
fastmemo was disabled because 0.1.1's bounds predate GHC 9.6+ (`base < 4.18`, `bytestring < 0.12`, `containers < 0.7`).

I've uploaded [fastmemo-0.1.2](https://hackage.haskell.org/package/fastmemo-0.1.2) with relaxed bounds (`base < 4.22`, `bytestring < 0.13`, `containers < 0.9`), which builds and passes its test suite on GHC 9.10.3 (lts-24.54). This PR removes the three stale `< 0` constraints.

I'm the maintainer (@davidspies, already listed in the maintainer section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7WExoJRXb3gjYr8BTnpab