### PR TITLE
Ormolu will henceforth be maintained by Tweag

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3102,7 +3102,6 @@ packages:
         - mmark-cli
         - mmark-ext
         - modern-uri
-        - ormolu
         - pagination
         - parser-combinators
         - parser-combinators-tests
@@ -4311,6 +4310,7 @@ packages:
         - stm-conduit
         - co-log-concurrent
         - HaskellNet
+        - ormolu
 
     "Tung Dao <me@tungdao.com> @tungd":
         - time-locale-vietnamese


### PR DESCRIPTION
Represented by Alexander Vershilov (cc @qnikst).
