### PR TITLE
Enable http-client-tls and benchmark for Dhall

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7931,10 +7931,6 @@ package-flags:
     curl:
         new-base: true
 
-    # https://github.com/dhall-lang/dhall-haskell/issues/2748
-    dhall:
-        use-http-client-tls: false
-
     hpio:
         test-hlint: false
 
@@ -9193,7 +9189,6 @@ skipped-benchmarks:
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires criterion < 1.6 and the snapshot contains criterion-1.6.5.0
     - csg # tried csg-0.1.0.6, but its *benchmarks* requires vector < 0.13 and the snapshot contains vector-0.13.2.0
     - data-findcycle # tried data-findcycle-0.1.2.0, but its *benchmarks* requires tasty-bench >=0.4 && < 0.5 and the snapshot contains tasty-bench-0.5.1
-    - dhall # tried dhall-1.42.3, but its *benchmarks* requires tasty-bench >=0.4 && < 0.5 and the snapshot contains tasty-bench-0.5.1
     - fakedata # tried fakedata-1.0.5, but its *benchmarks* requires the disabled package: gauge
     - filepath-bytestring # tried filepath-bytestring-1.5.2.0.5, but its *benchmarks* requires filepath >=1.4.2 && < =1.4.2.1 and the snapshot contains filepath-1.5.5.0
     - freer-simple # tried freer-simple-1.2.1.2, but its *benchmarks* requires the disabled package: extensible-effects


### PR DESCRIPTION
Checklist:
- [ ] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [X] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [ ] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)

Revisions were made for Dhall which should allow us to use the TLS flag again:

https://hackage.haskell.org/package/dhall-1.42.3/revisions/
