### PR TITLE
Re-enable webgear-openapi

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4569,7 +4569,7 @@ packages:
 
     "Raghu Kaippully <rkaippully@gmail.com> @rkaippully":
         - webgear-core
-        - webgear-openapi < 0 # 1.5.0 fails to compile
+        - webgear-openapi
         - webgear-server
         - webgear-swagger
         - webgear-swagger-ui


### PR DESCRIPTION
`webgear-openapi-1.5.0` was disabled due to build errors. I have uploaded `1.5.1` that fixes these errors.

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [ ] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (recommended) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)
- [ ] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)