### PR TITLE
hledger-web: drop < 0 constraint

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -7006,7 +7006,6 @@ packages:
         - highjson-swagger < 0 # tried highjson-swagger-0.5.0.0, but its *library* requires the disabled package: highjson
         - highjson-th < 0 # tried highjson-th-0.5.0.0, but its *library* requires the disabled package: highjson
         - hit < 0 # tried hit-0.7.0, but its *executable* requires the disabled package: git
-        - hledger-web < 0 # tried hledger-web-1.52.1, but its *library* requires the disabled package: yesod-static
         - hmatrix-repa < 0 # tried hmatrix-repa-0.1.2.2, but its *library* requires the disabled package: repa
         - hnock < 0 # tried hnock-0.4.0, but its *library* requires text >=1.2.3.0 && < 1.3 and the snapshot contains text-2.1.4
         - hocon < 0 # tried hocon-0.1.0.4, but its *library* requires MissingH < =1.4.3.0 and the snapshot contains MissingH-1.6.0.3


### PR DESCRIPTION
hledger-web was disabled because it required yesod-static, which is disabled (doesn't build with crypton 1.1+).
hledger-web-1.52.4 no longer depends on yesod-static (or hjsmin), so this constraint can be removed.